### PR TITLE
Add support for reading bounding boxes of features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 -   Auto-discovery of `GDAL_VERSION` on Windows, if `gdalinfo.exe` is discoverable
     on the `PATH`.
+-   Addition of `read_bounds` function to read the bounds of each feature.
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,28 @@ extension of the filename:
 `.gpkg`: `GPKG`
 `.json`: `GeoJSON`
 
+### Reading feature bounds
+
+You can read the bounds of all or a subset of features in the dataset in order
+to create a spatial index of features without reading all underlying geometries.
+This is typically 2-3x faster than reading full feature data, but the main
+benefit is to avoid reading all feature data into memory for very large datasets.
+
+```python
+>>> from pyogrio import read_bounds
+>>> fids, bounds = read_bounds('ne_10m_admin_0_countries.shp')
+```
+
+`fids` provide the global feature id of each feature.
+`bounds` provide an ndarray of shape (4,n) with values for `xmin`, `ymin`, `xmax`, `ymax`.
+
+This function supports options to subset features from the dataset:
+
+-   `skip_features`
+-   `max_features`
+-   `where`
+-   `bbox`
+
 ### Configuration options
 
 It is possible to set [GDAL configuration options](https://trac.osgeo.org/gdal/wiki/ConfigOptions) for an entire session:
@@ -460,11 +482,11 @@ for working with OGR vector data sources. It is **awesome**, has highly-dedicate
 maintainers and contributors, and exposes more functionality than `pyogrio` ever will.
 This project would not be possible without `Fiona` having come first.
 
-`pyogrio` is an experimental approach that uses a vectorized (array-oriented)
-approach for reading and writing spatial vector file formats, which enables faster
-I/O operations. It borrows from the internal mechanics and lessons learned of
-`Fiona`. It uses a stateless approach to reading or writing data; all data
-are read or written in a single pass.
+`pyogrio` uses a vectorized (array-oriented) approach for reading and writing
+spatial vector file formats, which enables faster I/O operations. It borrows
+from the internal mechanics and lessons learned of `Fiona`. It uses a stateless
+approach to reading or writing data; all data are read or written in a single
+pass.
 
 `Fiona` is a general purpose spatial format I/O library that is used within many
 projects in the Python ecosystem. In contrast, `pyogrio` specifically targets

--- a/benchmarks/test_core_benchmarks.py
+++ b/benchmarks/test_core_benchmarks.py
@@ -3,7 +3,7 @@ import os
 import fiona
 import pytest
 
-from pyogrio import list_layers, read_info
+from pyogrio import list_layers, read_bounds, read_info
 
 
 def fiona_read_info(path, layer=None):
@@ -44,6 +44,21 @@ def test_list_layers_multi(nhd_hr, benchmark):
 @pytest.mark.benchmark(group="list-layers-nhd-hr")
 def test_list_layers_fiona_multi(nhd_hr, benchmark):
     benchmark(fiona.listlayers, nhd_hr)
+
+
+@pytest.mark.benchmark(group="read-bounds-lowres")
+def test_read_bounds_lowres(naturalearth_lowres, benchmark):
+    benchmark(read_bounds, naturalearth_lowres)
+
+
+@pytest.mark.benchmark(group="read-bounds-modres")
+def test_read_bounds_modres(naturalearth_modres, benchmark):
+    benchmark(read_bounds, naturalearth_modres)
+
+
+@pytest.mark.benchmark(group="read-bounds-nhd-hr")
+def test_read_bounds_nhd_hr(nhd_hr, benchmark):
+    benchmark(read_bounds, nhd_hr, layer="NHDFlowline")
 
 
 @pytest.mark.benchmark(group="read-info-lowres")

--- a/pyogrio/__init__.py
+++ b/pyogrio/__init__.py
@@ -1,6 +1,7 @@
 from pyogrio.core import (
     list_drivers,
     list_layers,
+    read_bounds,
     read_info,
     set_gdal_config_options,
     get_gdal_config_option,

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -142,13 +142,18 @@ cdef extern from "ogr_core.h":
         OFSTFloat32
 
     ctypedef void* OGRDataSourceH
-    ctypedef void* OGREnvelope
     ctypedef void* OGRFeatureDefnH
     ctypedef void* OGRFieldDefnH
     ctypedef void* OGRFeatureH
     ctypedef void* OGRGeometryH
     ctypedef void* OGRLayerH
     ctypedef void* OGRSFDriverH
+
+    ctypedef struct OGREnvelope:
+        double MinX
+        double MaxX
+        double MinY
+        double MaxY
 
 
 cdef extern from "ogr_srs_api.h":
@@ -174,7 +179,7 @@ cdef extern from "ogr_api.h":
     OGRFeatureH     OGR_F_Create(OGRFeatureDefnH featuredefn)
     void            OGR_F_Destroy(OGRFeatureH feature)
 
-    long            OGR_F_GetFID(OGRFeatureH feature)
+    int            OGR_F_GetFID(OGRFeatureH feature)
     OGRGeometryH    OGR_F_GetGeometryRef(OGRFeatureH feature)
     GByte*          OGR_F_GetFieldAsBinary(OGRFeatureH feature, int n, int *s)
     int             OGR_F_GetFieldAsDateTime(OGRFeatureH feature, int n, int *y, int *m, int *d, int *h, int *m, int *s, int *z)
@@ -242,7 +247,6 @@ cdef extern from "ogr_api.h":
     int             OGRGetNonLinearGeometriesEnabledFlag()
 
     int             OGRReleaseDataSource(OGRDataSourceH ds)
-
 
 
 cdef extern from "gdal.h":

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -1,4 +1,5 @@
 # Contains declarations against GDAL / OGR API
+from libc.stdint cimport int64_t
 
 
 cdef extern from "cpl_conv.h":
@@ -179,7 +180,7 @@ cdef extern from "ogr_api.h":
     OGRFeatureH     OGR_F_Create(OGRFeatureDefnH featuredefn)
     void            OGR_F_Destroy(OGRFeatureH feature)
 
-    int            OGR_F_GetFID(OGRFeatureH feature)
+    int64_t         OGR_F_GetFID(OGRFeatureH feature)
     OGRGeometryH    OGR_F_GetGeometryRef(OGRFeatureH feature)
     GByte*          OGR_F_GetFieldAsBinary(OGRFeatureH feature, int n, int *s)
     int             OGR_F_GetFieldAsDateTime(OGRFeatureH feature, int n, int *y, int *m, int *d, int *h, int *m, int *s, int *z)

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -142,6 +142,7 @@ cdef extern from "ogr_core.h":
         OFSTFloat32
 
     ctypedef void* OGRDataSourceH
+    ctypedef void* OGREnvelope
     ctypedef void* OGRFeatureDefnH
     ctypedef void* OGRFieldDefnH
     ctypedef void* OGRFeatureH
@@ -212,12 +213,13 @@ cdef extern from "ogr_api.h":
     OGRGeometryH    OGR_G_CreateGeometry(int wkbtypecode)
     void            OGR_G_DestroyGeometry(OGRGeometryH geometry)
     void            OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, unsigned char *buffer)
+    void            OGR_G_GetEnvelope(OGRGeometryH geometry, OGREnvelope* envelope)
     OGRErr          OGR_G_ImportFromWkb(OGRGeometryH geometry, const void *bytes, int nbytes)
-    int             OGR_G_WkbSize(OGRGeometryH geometry)
     int             OGR_G_IsMeasured(OGRGeometryH geometry)
     void            OGR_G_SetMeasured(OGRGeometryH geometry, int isMeasured)
     int             OGR_G_Is3D(OGRGeometryH geometry)
     void            OGR_G_Set3D(OGRGeometryH geometry, int is3D)
+    int             OGR_G_WkbSize(OGRGeometryH geometry)
 
     int                 OGR_GT_HasM(OGRwkbGeometryType eType)
     int                 OGR_GT_HasZ(OGRwkbGeometryType eType)

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -8,7 +8,7 @@ with GDALEnv():
         set_gdal_config_options as _set_gdal_config_options,
         get_gdal_config_option as _get_gdal_config_option,
     )
-    from pyogrio._io import ogr_list_layers, ogr_read_info
+    from pyogrio._io import ogr_list_layers, ogr_read_bounds, ogr_read_info
 
     __gdal_version__ = get_gdal_version()
     __gdal_version_string__ = get_gdal_version_string()
@@ -59,6 +59,51 @@ def list_layers(path):
     """
 
     return ogr_list_layers(str(path))
+
+
+def read_bounds(
+    path, layer=None, skip_features=0, max_features=None, where=None, bbox=None
+):
+    """Read bounds of each feature.
+
+    Parameters
+    ----------
+    path : pathlib.Path or str
+        data source path
+    layer : int or str, optional (default: first layer)
+        If an integer is provided, it corresponds to the index of the layer
+        with the data source.  If a string is provided, it must match the name
+        of the layer in the data source.  Defaults to first layer in data source.
+    skip_features : int, optional (default: 0)
+        Number of features to skip from the beginning of the file before returning
+        features.  Must be less than the total number of features in the file.
+    max_features : int, optional (default: None)
+        Number of features to read from the file.  Must be less than the total
+        number of features in the file minus skip_features (if used).
+    where : str, optional (default: None)
+        Where clause to filter features in layer by attribute values.  Uses a
+        restricted form of SQL WHERE clause, defined here:
+        http://ogdi.sourceforge.net/prop/6.2.CapabilitiesMetadata.html
+        Examples: "ISO_A3 = 'CAN'", "POP_EST > 10000000 AND POP_EST < 100000000"
+    bbox : tuple of (xmin, ymin, xmax, ymax), optional (default: None)
+        If present, will be used to filter records whose geometry intersects this
+        box.  This must be in the same CRS as the dataset.
+
+    Returns
+    -------
+    tuple of (fids, bounds)
+        fids are global IDs read from the FID field of the dataset
+        bounds are ndarray of shape(4, n) containig xmin, ymin, xmax, ymax
+    """
+
+    return ogr_read_bounds(
+        str(path),
+        layer=layer,
+        skip_features=skip_features,
+        max_features=max_features or 0,
+        where=where,
+        bbox=bbox,
+    )
 
 
 def read_info(path, layer=None, encoding=None):

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -66,6 +66,10 @@ def read_bounds(
 ):
     """Read bounds of each feature.
 
+    This can be used to assist with spatial indexing and partitioning, in
+    order to avoid reading all features into memory.  It is roughly 2-3x faster
+    than reading the full geometry and attributes of a dataset.
+
     Parameters
     ----------
     path : pathlib.Path or str


### PR DESCRIPTION
Resolves #12 

This is about 2-3x faster than reading full feature data (had hoped for faster), likely because the underlying geometry data still need to be read from disk in order to calculate the extent.

The main benefit of this is likely using these bounds to create a spatial index, and then selectively read features by FID (not yet implemented; later PR).

This also includes a bit of reorganization within the I/O related functions in Cython, to better re-use them between different top-level functions.