### PR TITLE
ENH: read features based on array of FIDs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 -   Auto-discovery of `GDAL_VERSION` on Windows, if `gdalinfo.exe` is discoverable
     on the `PATH`.
 -   Addition of `read_bounds` function to read the bounds of each feature.
+-   Addition of a `fids` keyword to `read` and `read_dataframe` to selectively
+    read features based on a list of the FIDs.
 
 ## 0.2.0
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -606,7 +606,7 @@ cdef get_features_by_fid(
         ogr_feature = OGR_L_GetFeature(ogr_layer, fid)
 
         if ogr_feature == NULL:
-            raise ValueError("Failed to read feature {}".format(i))
+            raise ValueError("Failed to read FID {}".format(fid))
 
         if read_geometry:
             process_geometry(ogr_feature, i, geom_view, force_2d)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 ### Constants
 cdef const char * STRINGSASUTF8 = "StringsAsUTF8"
 cdef const char * OLCRandomRead = "RandomRead"
+cdef const char * OLCFastSetNextByIndex = "FastSetNextByIndex"
 
 
 # Mapping of OGR integer field types to Python field type names
@@ -624,6 +625,66 @@ cdef get_features_by_fid(
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
+cdef get_features_by_index(
+    OGRLayerH ogr_layer,
+    int[:] indices,
+    object[:,:] fields,
+    encoding,
+    uint8_t read_geometry,
+    uint8_t force_2d):
+
+    cdef OGRFeatureH ogr_feature = NULL
+    cdef int n_fields
+    cdef int i
+    cdef int idx
+    cdef int field_index
+    cdef int count
+
+    # make sure layer is read from beginning
+    OGR_L_ResetReading(ogr_layer)
+
+    count = len(indices)
+
+    if read_geometry:
+        geometries = np.empty(shape=(count, ), dtype='object')
+        geom_view = geometries[:]
+
+    else:
+        geometries = None
+
+    n_fields = fields.shape[0]
+    field_indexes = fields[:,0]
+    field_ogr_types = fields[:,1]
+
+    field_data = [
+        np.empty(shape=(count, ),
+        dtype=fields[field_index,3]) for field_index in range(n_fields)
+    ]
+
+    field_data_view = [field_data[field_index][:] for field_index in range(n_fields)]
+
+    for i in range(count):
+        idx = indices[i]
+
+        OGR_L_SetNextByIndex(ogr_layer, idx)
+        ogr_feature = OGR_L_GetNextFeature(ogr_layer)
+
+        if ogr_feature == NULL:
+            raise ValueError("Failed to read feature {}".format(i))
+
+        if read_geometry:
+            process_geometry(ogr_feature, i, geom_view, force_2d)
+
+        process_fields(
+            ogr_feature, i, n_fields, field_data, field_data_view, field_indexes, field_ogr_types, encoding
+        )
+
+    return (geometries, field_data)
+
+
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
 cdef get_bounds(
     OGRLayerH ogr_layer,
     int skip_features,
@@ -691,6 +752,7 @@ def ogr_read(
     object where=None,
     tuple bbox=None,
     object fids=None,
+    object indices=None,
     **kwargs):
 
     cdef int err = 0
@@ -717,6 +779,12 @@ def ogr_read(
                 "cannot set both 'fids' and one of 'where', 'bbox', "
                 "'skip_features' or 'max_features'")
         fids = np.asarray(fids, dtype=np.intc)
+    elif indices is not None:
+        if where is not None or bbox is not None or skip_features or max_features:
+            raise ValueError(
+                "cannot set both 'indices' and one of 'where', 'bbox', "
+                "'skip_features' or 'max_features'")
+        indices = np.asarray(indices, dtype=np.intc)
     else:
         # Apply the attribute filter
         if where is not None and where != "":
@@ -757,6 +825,16 @@ def ogr_read(
             read_geometry=read_geometry and geometry_type is not None,
             force_2d=force_2d,
         )
+    elif indices is not None:
+        geometries, field_data = get_features_by_index(
+            ogr_layer,
+            indices,
+            fields,
+            encoding,
+            read_geometry=read_geometry and geometry_type is not None,
+            force_2d=force_2d,
+        )
+        get_features_by_index
 
     else:
         geometries, field_data = get_features(
@@ -860,7 +938,11 @@ def ogr_read_info(str path, object layer=None, object encoding=None, **kwargs):
         'fields': get_fields(ogr_layer, encoding)[:,2], # return only names
         'geometry_type': get_geometry_type(ogr_layer),
         'features': OGR_L_GetFeatureCount(ogr_layer, 1),
-        'random_read': OGR_L_TestCapability(ogr_layer, OLCRandomRead),
+        "capabilities": {
+            "random_read": OGR_L_TestCapability(ogr_layer, OLCRandomRead),
+            # "fast_spatial_filter": OGR_L_TestCapability(ogr_layer, OLCFastSpatialFilter),
+            "fast_set_next_by_index": OGR_L_TestCapability(ogr_layer, OLCFastSetNextByIndex),
+        }
     }
 
     if ogr_dataset != NULL:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -35,7 +35,7 @@ log = logging.getLogger(__name__)
 
 ### Constants
 cdef const char * STRINGSASUTF8 = "StringsAsUTF8"
-
+cdef const char * OLCRandomRead = "RandomRead"
 
 
 # Mapping of OGR integer field types to Python field type names
@@ -390,6 +390,116 @@ cdef validate_feature_range(OGRLayerH ogr_layer, int skip_features=0, int max_fe
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
+cdef process_geometry(OGRFeatureH ogr_feature, int i, geom_view, uint8_t force_2d):
+
+    cdef OGRGeometryH ogr_geometry = NULL
+    cdef unsigned char *wkb = NULL
+    cdef int ret_length
+
+    ogr_geometry = OGR_F_GetGeometryRef(ogr_feature)
+
+    if ogr_geometry == NULL:
+        geom_view[i] = None
+    else:
+        try:
+            # if geometry has M values, these need to be removed first
+            if (OGR_G_IsMeasured(ogr_geometry)):
+                OGR_G_SetMeasured(ogr_geometry, 0)
+
+            if force_2d and OGR_G_Is3D(ogr_geometry):
+                OGR_G_Set3D(ogr_geometry, 0)
+
+            ret_length = OGR_G_WkbSize(ogr_geometry)
+            wkb = <unsigned char*>malloc(sizeof(unsigned char)*ret_length)
+            OGR_G_ExportToWkb(ogr_geometry, 1, wkb)
+            geom_view[i] = wkb[:ret_length]
+
+        finally:
+            free(wkb)
+
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+cdef process_fields(
+    OGRFeatureH ogr_feature,
+    int i,
+    int n_fields,
+    object field_data,
+    object field_data_view, 
+    object field_indexes,
+    object field_ogr_types,
+    encoding
+):
+    cdef int j
+    cdef int success
+    cdef int field_index
+    cdef GByte *bin_value
+    cdef int ret_length
+    cdef int year = 0
+    cdef int month = 0
+    cdef int day = 0
+    cdef int hour = 0
+    cdef int minute = 0
+    cdef int second = 0
+    cdef int timezone = 0
+
+    for j in range(n_fields):
+        field_index = field_indexes[j]
+        field_type = field_ogr_types[j]
+        data = field_data_view[j]
+
+        isnull = OGR_F_IsFieldSetAndNotNull(ogr_feature, field_index) == 0
+        if isnull:
+            if field_type in (OFTInteger, OFTInteger64, OFTReal):
+                if data.dtype in (np.int32, np.int64):
+                    # have to cast to float to hold NaN values
+                    field_data[j] = field_data[j].astype(np.float64)
+                    field_data_view[j] = field_data[j][:]
+                    field_data_view[j][i] = np.nan
+                else:
+                    data[i] = np.nan
+
+            elif field_type in ( OFTDate, OFTDateTime):
+                data[i] = np.datetime64('NaT')
+
+            else:
+                data[i] = None
+
+            continue
+
+        if field_type == OFTInteger:
+            data[i] = OGR_F_GetFieldAsInteger(ogr_feature, field_index)
+
+        elif field_type == OFTInteger64:
+            data[i] = OGR_F_GetFieldAsInteger64(ogr_feature, field_index)
+
+        elif field_type == OFTReal:
+            data[i] = OGR_F_GetFieldAsDouble(ogr_feature, field_index)
+
+        elif field_type == OFTString:
+            value = get_string(OGR_F_GetFieldAsString(ogr_feature, field_index), encoding=encoding)
+            data[i] = value
+
+        elif field_type == OFTBinary:
+            bin_value = OGR_F_GetFieldAsBinary(ogr_feature, field_index, &ret_length)
+            data[i] = bin_value[:ret_length]
+
+        elif field_type == OFTDateTime or field_type == OFTDate:
+            success = OGR_F_GetFieldAsDateTime(
+                ogr_feature, field_index, &year, &month, &day, &hour, &minute, &second, &timezone)
+
+            if not success:
+                data[i] = np.datetime64('NaT')
+
+            elif field_type == OFTDate:
+                data[i] = datetime.date(year, month, day).isoformat()
+
+            elif field_type == OFTDateTime:
+                data[i] = datetime.datetime(year, month, day, hour, minute, second).isoformat()
+
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
 cdef get_features(
     OGRLayerH ogr_layer,
     object[:,:] fields,
@@ -400,23 +510,10 @@ cdef get_features(
     int max_features):
 
     cdef OGRFeatureH ogr_feature = NULL
-    cdef OGRGeometryH ogr_geometry = NULL
-    cdef unsigned char *wkb = NULL
+    cdef int n_fields
     cdef int i
-    cdef int j
-    cdef int success
     cdef int field_index
     cdef int count
-    cdef int ret_length
-    cdef GByte *bin_value
-    cdef int year = 0
-    cdef int month = 0
-    cdef int day = 0
-    cdef int hour = 0
-    cdef int minute = 0
-    cdef int second = 0
-    cdef int timezone = 0
-
 
     # make sure layer is read from beginning
     OGR_L_ResetReading(ogr_layer)
@@ -440,17 +537,16 @@ cdef get_features(
     else:
         geometries = None
 
-
-    field_iter = range(fields.shape[0])
+    n_fields = fields.shape[0]
     field_indexes = fields[:,0]
     field_ogr_types = fields[:,1]
 
     field_data = [
         np.empty(shape=(count, ),
-        dtype=fields[field_index,3]) for field_index in field_iter
+        dtype=fields[field_index,3]) for field_index in range(n_fields)
     ]
 
-    field_data_view = [field_data[field_index][:] for field_index in field_iter]
+    field_data_view = [field_data[field_index][:] for field_index in range(n_fields)]
 
     for i in range(count):
         ogr_feature = OGR_L_GetNextFeature(ogr_layer)
@@ -459,81 +555,11 @@ cdef get_features(
             raise ValueError("Failed to read feature {}".format(i))
 
         if read_geometry:
-            ogr_geometry = OGR_F_GetGeometryRef(ogr_feature)
+            process_geometry(ogr_feature, i, geom_view, force_2d)
 
-            if ogr_geometry == NULL:
-                geom_view[i] = None
-
-            else:
-                try:
-                    # if geometry has M values, these need to be removed first
-                    if (OGR_G_IsMeasured(ogr_geometry)):
-                        OGR_G_SetMeasured(ogr_geometry, 0)
-
-                    if force_2d and OGR_G_Is3D(ogr_geometry):
-                        OGR_G_Set3D(ogr_geometry, 0)
-
-                    ret_length = OGR_G_WkbSize(ogr_geometry)
-                    wkb = <unsigned char*>malloc(sizeof(unsigned char)*ret_length)
-                    OGR_G_ExportToWkb(ogr_geometry, 1, wkb)
-                    geom_view[i] = wkb[:ret_length]
-
-                finally:
-                    free(wkb)
-
-        for j in field_iter:
-            field_index = field_indexes[j]
-            field_type = field_ogr_types[j]
-            data = field_data_view[j]
-
-            isnull = OGR_F_IsFieldSetAndNotNull(ogr_feature, field_index) == 0
-            if isnull:
-                if field_type in (OFTInteger, OFTInteger64, OFTReal):
-                    if data.dtype in (np.int32, np.int64):
-                        # have to cast to float to hold NaN values
-                        field_data[j] = field_data[j].astype(np.float64)
-                        field_data_view[j] = field_data[j][:]
-                        field_data_view[j][i] = np.nan
-                    else:
-                        data[i] = np.nan
-
-                elif field_type in ( OFTDate, OFTDateTime):
-                    data[i] = np.datetime64('NaT')
-
-                else:
-                    data[i] = None
-
-                continue
-
-            if field_type == OFTInteger:
-                data[i] = OGR_F_GetFieldAsInteger(ogr_feature, field_index)
-
-            elif field_type == OFTInteger64:
-                data[i] = OGR_F_GetFieldAsInteger64(ogr_feature, field_index)
-
-            elif field_type == OFTReal:
-                data[i] = OGR_F_GetFieldAsDouble(ogr_feature, field_index)
-
-            elif field_type == OFTString:
-                value = get_string(OGR_F_GetFieldAsString(ogr_feature, field_index), encoding=encoding)
-                data[i] = value
-
-            elif field_type == OFTBinary:
-                bin_value = OGR_F_GetFieldAsBinary(ogr_feature, field_index, &ret_length)
-                data[i] = bin_value[:ret_length]
-
-            elif field_type == OFTDateTime or field_type == OFTDate:
-                success = OGR_F_GetFieldAsDateTime(
-                    ogr_feature, field_index, &year, &month, &day, &hour, &minute, &second, &timezone)
-
-                if not success:
-                    data[i] = np.datetime64('NaT')
-
-                elif field_type == OFTDate:
-                    data[i] = datetime.date(year, month, day).isoformat()
-
-                elif field_type == OFTDateTime:
-                    data[i] = datetime.datetime(year, month, day, hour, minute, second).isoformat()
+        process_fields(
+            ogr_feature, i, n_fields, field_data, field_data_view, field_indexes, field_ogr_types, encoding
+        )
 
     return (geometries, field_data)
 
@@ -629,7 +655,6 @@ def ogr_read(
     # Apply the attribute filter
     if where is not None and where != "":
         apply_where_filter(ogr_layer, where)
-
 
     # Apply the spatial filter
     if bbox is not None:
@@ -757,7 +782,8 @@ def ogr_read_info(str path, object layer=None, object encoding=None, **kwargs):
         'encoding': encoding,
         'fields': get_fields(ogr_layer, encoding)[:,2], # return only names
         'geometry_type': get_geometry_type(ogr_layer),
-        'features': OGR_L_GetFeatureCount(ogr_layer, 1)
+        'features': OGR_L_GetFeatureCount(ogr_layer, 1),
+        'random_read': OGR_L_TestCapability(ogr_layer, OLCRandomRead),
     }
 
     if ogr_dataset != NULL:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -708,27 +708,16 @@ def ogr_read(
     if layer is None:
         layer = 0
 
-    ogr_dataset = ogr_open(path_c, 0, kwargs)
-    ogr_layer = get_ogr_layer(ogr_dataset, layer)
-
     if fids is not None:
         if where is not None or bbox is not None or skip_features or max_features:
             raise ValueError(
-                "cannot set both 'fids' and one of 'where', 'bbox', "
+                "cannot set both 'fids' and any of 'where', 'bbox', "
                 "'skip_features' or 'max_features'"
             )
         fids = np.asarray(fids, dtype=np.intc)
-    else:
-        # Apply the attribute filter
-        if where is not None and where != "":
-            apply_where_filter(ogr_layer, where)
 
-        # Apply the spatial filter
-        if bbox is not None:
-            apply_spatial_filter(ogr_layer, bbox)
-
-        # Limit feature range to available range
-        skip_features, max_features = validate_feature_range(ogr_layer, skip_features, max_features)
+    ogr_dataset = ogr_open(path_c, 0, kwargs)
+    ogr_layer = get_ogr_layer(ogr_dataset, layer)
 
     crs = get_crs(ogr_layer)
 
@@ -759,6 +748,19 @@ def ogr_read(
             force_2d=force_2d,
         )
     else:
+        # Apply the attribute filter
+        if where is not None and where != "":
+            apply_where_filter(ogr_layer, where)
+
+        # Apply the spatial filter
+        if bbox is not None:
+            apply_spatial_filter(ogr_layer, bbox)
+
+        # Limit feature range to available range
+        skip_features, max_features = validate_feature_range(
+            ogr_layer, skip_features, max_features
+        )
+
         geometries, field_data = get_features(
             ogr_layer,
             fields,

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -429,8 +429,8 @@ cdef process_fields(
     cdef int j
     cdef int success
     cdef int field_index
-    cdef GByte *bin_value
     cdef int ret_length
+    cdef GByte *bin_value
     cdef int year = 0
     cdef int month = 0
     cdef int day = 0
@@ -503,7 +503,8 @@ cdef get_features(
     uint8_t read_geometry,
     uint8_t force_2d,
     int skip_features,
-    int max_features):
+    int max_features
+):
 
     cdef OGRFeatureH ogr_feature = NULL
     cdef int n_fields
@@ -554,7 +555,8 @@ cdef get_features(
             process_geometry(ogr_feature, i, geom_view, force_2d)
 
         process_fields(
-            ogr_feature, i, n_fields, field_data, field_data_view, field_indexes, field_ogr_types, encoding
+            ogr_feature, i, n_fields, field_data, field_data_view,
+            field_indexes, field_ogr_types, encoding
         )
 
     return (geometries, field_data)
@@ -568,7 +570,8 @@ cdef get_features_by_fid(
     object[:,:] fields,
     encoding,
     uint8_t read_geometry,
-    uint8_t force_2d):
+    uint8_t force_2d
+):
 
     cdef OGRFeatureH ogr_feature = NULL
     cdef int n_fields
@@ -612,7 +615,8 @@ cdef get_features_by_fid(
             process_geometry(ogr_feature, i, geom_view, force_2d)
 
         process_fields(
-            ogr_feature, i, n_fields, field_data, field_data_view, field_indexes, field_ogr_types, encoding
+            ogr_feature, i, n_fields, field_data, field_data_view,
+            field_indexes, field_ogr_types, encoding
         )
 
     return (geometries, field_data)

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -250,6 +250,11 @@ cdef extern from "ogr_api.h":
 
     int             OGRReleaseDataSource(OGRDataSourceH ds)
 
+    const char*     OLCStringsAsUTF8
+    const char*     OLCRandomRead
+    const char*     OLCFastSetNextByIndex
+    const char*     OLCFastSpatialFilter
+
 
 cdef extern from "gdal.h":
     ctypedef enum GDALDataType:

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -238,6 +238,7 @@ cdef extern from "ogr_api.h":
     int                     OGR_L_TestCapability(OGRLayerH layer, const char *name)
     OGRFeatureDefnH         OGR_L_GetLayerDefn(OGRLayerH layer)
     OGRFeatureH             OGR_L_GetNextFeature(OGRLayerH layer)
+    OGRFeatureH             OGR_L_GetFeature(OGRLayerH layer, int nFeatureId)
     void                    OGR_L_ResetReading(OGRLayerH layer)
     OGRErr                  OGR_L_SetAttributeFilter(OGRLayerH hLayer, const char* pszQuery)
     OGRErr                  OGR_L_SetNextByIndex(OGRLayerH layer, int nIndex)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -16,6 +16,7 @@ def read_dataframe(
     where=None,
     bbox=None,
     fids=None,
+    indices=None,
 ):
     """Read from an OGR data source to a GeoPandas GeoDataFrame or Pandas DataFrame.
     If the data source does not have a geometry column or `read_geometry` is False,
@@ -92,6 +93,7 @@ def read_dataframe(
         where=where,
         bbox=bbox,
         fids=fids,
+        indices=indices,
     )
 
     columns = meta["fields"].tolist()

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -15,6 +15,7 @@ def read_dataframe(
     max_features=None,
     where=None,
     bbox=None,
+    fids=None,
 ):
     """Read from an OGR data source to a GeoPandas GeoDataFrame or Pandas DataFrame.
     If the data source does not have a geometry column or `read_geometry` is False,
@@ -90,6 +91,7 @@ def read_dataframe(
         max_features=max_features,
         where=where,
         bbox=bbox,
+        fids=fids,
     )
 
     columns = meta["fields"].tolist()

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -16,7 +16,6 @@ def read_dataframe(
     where=None,
     bbox=None,
     fids=None,
-    indices=None,
 ):
     """Read from an OGR data source to a GeoPandas GeoDataFrame or Pandas DataFrame.
     If the data source does not have a geometry column or `read_geometry` is False,
@@ -93,7 +92,6 @@ def read_dataframe(
         where=where,
         bbox=bbox,
         fids=fids,
-        indices=indices,
     )
 
     columns = meta["fields"].tolist()

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -63,7 +63,10 @@ def read_dataframe(
     fids : array-like, optional (default: None)
         Array of integer feature id (FID) values to select. Cannot be combined
         with other keywords to select a subset (`skip_features`, `max_features`,
-        `where` or `bbox`).
+        `where` or `bbox`). Note that the starting index is driver and file
+        specific (e.g. typically 0 for Shapefile and 1 for GeoPackage, but can
+        still depend on the specific file). The performance of reading a large
+        number of features usings FIDs is also driver specific.
 
     Returns
     -------

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -60,6 +60,10 @@ def read_dataframe(
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this
         box.  This must be in the same CRS as the dataset.
+    fids : array-like, optional (default: None)
+        Array of integer feature id (FID) values to select. Cannot be combined
+        with other keywords to select a subset (`skip_features`, `max_features`,
+        `where` or `bbox`).
 
     Returns
     -------

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -69,6 +69,10 @@ def read(
     bbox : tuple of (xmin, ymin, xmax, ymax), optional (default: None)
         If present, will be used to filter records whose geometry intersects this
         box.  This must be in the same CRS as the dataset.
+    fids : array-like, optional (default: None)
+        Array of integer feature id (FID) values to select. Cannot be combined
+        with other keywords to select a subset (`skip_features`, `max_features`,
+        `where` or `bbox`).
 
     Returns
     -------

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -72,7 +72,10 @@ def read(
     fids : array-like, optional (default: None)
         Array of integer feature id (FID) values to select. Cannot be combined
         with other keywords to select a subset (`skip_features`, `max_features`,
-        `where` or `bbox`).
+        `where` or `bbox`). Note that the starting index is driver and file
+        specific (e.g. typically 0 for Shapefile and 1 for GeoPackage, but can
+        still depend on the specific file). The performance of reading a large
+        number of features usings FIDs is also driver specific.
 
     Returns
     -------

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -27,6 +27,7 @@ def read(
     where=None,
     bbox=None,
     fids=None,
+    indices=None,
 ):
     """Read OGR data source.
 
@@ -98,6 +99,7 @@ def read(
         where=where,
         bbox=bbox,
         fids=fids,
+        indices=indices,
     )
 
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -26,6 +26,7 @@ def read(
     max_features=None,
     where=None,
     bbox=None,
+    fids=None,
 ):
     """Read OGR data source.
 
@@ -96,6 +97,7 @@ def read(
         max_features=max_features or 0,
         where=where,
         bbox=bbox,
+        fids=fids,
     )
 
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -27,7 +27,6 @@ def read(
     where=None,
     bbox=None,
     fids=None,
-    indices=None,
 ):
     """Read OGR data source.
 
@@ -99,7 +98,6 @@ def read(
         where=where,
         bbox=bbox,
         fids=fids,
-        indices=indices,
     )
 
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -145,6 +145,27 @@ def test_read_bbox(naturalearth_lowres):
     assert np.array_equal(df.iso_a3, ["USA", "MEX"])
 
 
+def test_read_fids(naturalearth_lowres):
+    # ensure keyword is properly passed through
+    df = read_dataframe(naturalearth_lowres, fids=[0, 10, 5])
+    assert len(df) == 3
+
+
+def test_read_fids_force_2d(test_fgdb_vsi):
+    with pytest.warns(
+        UserWarning, match=r"Measured \(M\) geometry types are not supported"
+    ):
+        df = read_dataframe(test_fgdb_vsi, layer="test_lines", fids=[22])
+        assert len(df) == 1
+        assert df.iloc[0].geometry.has_z
+
+        df = read_dataframe(
+            test_fgdb_vsi, layer="test_lines", force_2d=True, fids=[22]
+        )
+        assert len(df) == 1
+        assert not df.iloc[0].geometry.has_z
+
+
 @pytest.mark.parametrize(
     "driver,ext",
     [

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -166,6 +166,20 @@ def test_read_fids_out_of_bounds(naturalearth_lowres):
         read(naturalearth_lowres, fids=[200])
 
 
+def test_read_fids_unsupported_keywords(naturalearth_lowres):
+    with pytest.raises(ValueError, match="cannot set both 'fids' and any of"):
+        read(naturalearth_lowres, fids=[1], where="iso_a3 = 'CAN'")
+
+    with pytest.raises(ValueError, match="cannot set both 'fids' and any of"):
+        read(naturalearth_lowres, fids=[1], bbox=(-140, 20, -100, 40))
+
+    with pytest.raises(ValueError, match="cannot set both 'fids' and any of"):
+        read(naturalearth_lowres, fids=[1], skip_features=5)
+
+    with pytest.raises(ValueError, match="cannot set both 'fids' and any of"):
+        read(naturalearth_lowres, fids=[1], max_features=5)
+
+
 def test_write(tmpdir, naturalearth_lowres):
     meta, geometry, field_data = read(naturalearth_lowres)
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -144,6 +144,28 @@ def test_read_bbox(naturalearth_lowres):
     assert np.array_equal(fields[3], ["USA", "MEX"])
 
 
+def test_read_fids(naturalearth_lowres):
+    expected_geometry, expected_fields = read(naturalearth_lowres)[1:]
+    subset = [0, 10, 5]
+    
+    for fids in [subset, np.array(subset)]:
+        geometry, fields = read(naturalearth_lowres, fids=subset)[1:]
+
+        assert len(geometry) == 3
+        assert len(fields[0]) == 3
+
+        assert np.array_equal(geometry, expected_geometry[subset])
+        assert np.array_equal(fields[-1], expected_fields[-1][subset])
+
+
+def test_read_fids_out_of_bounds(naturalearth_lowres):
+    with pytest.raises(ValueError, match="Failed to read FID -1"):
+        read(naturalearth_lowres, fids=[-1])
+
+    with pytest.raises(ValueError, match="Failed to read FID 200"):
+        read(naturalearth_lowres, fids=[200])
+
+
 def test_write(tmpdir, naturalearth_lowres):
     meta, geometry, field_data = read(naturalearth_lowres)
 


### PR DESCRIPTION
This is experimenting with reading a subset based on an array of FIDs. Very much a draft (eg still needs tests, docs, etc), but good enough for running some benchmarks (will post them after a re-run).

The diff is not super clear: I splitted `get_features` to separate the processing of the geometry and fields (so this can be reused in `get_features_by_fid`). If you look at only the first commit, this is clearer. In the end, I am not sure if this was the best approach, as in theory it could also be combined in `get_features` and have a if/else switch at the moment to get the OGRFeature (switching between `OGR_L_GetNextFeature` and ``OGR_L_GetFeature``), since the rest of `get_features` and `get_features_by_fid` have a lot of overlap.

