### PR TITLE
ENH: pass through vsi schemas like S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 *.dll
 
 */__pycache__/*
-build/*
-*.egg-info/*
 .benchmarks/*
 .coverage
 .pytest_cache/*
@@ -19,3 +17,21 @@ benchmarks/fixtures/*
 .libs
 
 docs/build
+
+# Distribution / packaging
+.Python
+env/
+venv*/
+build/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -84,7 +84,7 @@ def read_dataframe(
     path = str(path)
 
     if not "://" in path:
-        if not "/vsizip" in path.lower() and not os.path.exists(path):
+        if not "/vsi" in path.lower() and not os.path.exists(path):
             raise ValueError(f"'{path}' does not exist")
 
     meta, geometry, field_data = read(


### PR DESCRIPTION
GDAL natively supports [more](https://gdal.org/user/virtual_file_systems.html) vsi schemes than `vsizip`. If we don't necessarily check for that one, you can already use storages like S3 out of the box.

```py
pyogrio.read_dataframe("/vsis3/{bucket}/{filename}")
pyogrio.write_dataframe(df, "/vsis3/{bucket}/{filename}", driver="GeoJSON")
```

I think that it would also be nice to support the `s3://{bucket}/{filename}` format as well, as we do in GeoPandas (Fiona) (ref #21). 

I just don't know how to test this. I tried the `moto` way of mocking S3 but it seems that GDAL somehow ignores that. I'd rather avoid setting up a bucket as[ Fiona did](https://github.com/Toblerity/Fiona/blob/885dbd11c5dcb2c61862faefc28bfbbff99954de/tests/test_vfs.py#L182-L187).