### PR TITLE
ENH: Add dtypes to read_info

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -75,6 +75,7 @@ first layer.
   'crs': 'EPSG:4326',
   'encoding': 'UTF-8',
   'fields': array(['featurecla', 'scalerank', 'LABELRANK', ...], dtype=object),
+  'dtypes': array(['int64', 'object', 'object', 'object', 'float64'], dtype=object),
   'geometry_type': 'Polygon',
   'features': 255
 }

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -421,7 +421,7 @@ cdef process_fields(
     int i,
     int n_fields,
     object field_data,
-    object field_data_view, 
+    object field_data_view,
     object field_indexes,
     object field_ogr_types,
     encoding
@@ -856,10 +856,13 @@ def ogr_read_info(str path, object layer=None, object encoding=None, **kwargs):
         or locale.getpreferredencoding()
     )
 
+    fields = get_fields(ogr_layer, encoding)
+
     meta = {
         'crs': get_crs(ogr_layer),
         'encoding': encoding,
-        'fields': get_fields(ogr_layer, encoding)[:,2], # return only names
+        'fields': fields[:,2], # return only names
+        'dtypes': fields[:,3],
         'geometry_type': get_geometry_type(ogr_layer),
         'features': OGR_L_GetFeatureCount(ogr_layer, 1),
         "capabilities": {
@@ -948,8 +951,6 @@ cdef void * create_crs(str crs) except NULL:
         err = OSRSetFromUserInput(ogr_crs, crs_c)
         if err:
             raise CRSError("Could not set CRS: {}".format(crs_c.decode('UTF-8')))
-
-        # TODO: on GDAL < 3, use OSRFixup()?
 
     except CPLE_BaseError as exc:
         OSRRelease(ogr_crs)

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -134,6 +134,7 @@ def read_info(path, layer=None, encoding=None):
             {
                 "crs": "<crs>",
                 "fields": <ndarray of field names>,
+                "dtypes": <ndarray of field dtypes>,
                 "encoding": "<encoding>",
                 "geometry": "<geometry type>",
                 "features": <feature count>

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -1,5 +1,4 @@
 from numpy import array_equal, allclose
-from numpy.core.records import array
 import pytest
 
 from pyogrio import (
@@ -135,6 +134,7 @@ def test_read_info(naturalearth_lowres):
     assert meta["geometry_type"] == "Polygon"
     assert meta["encoding"] == "UTF-8"
     assert meta["fields"].shape == (5,)
+    assert meta["dtypes"].tolist() == ["int64", "object", "object", "object", "float64"]
     assert meta["features"] == 177
 
 


### PR DESCRIPTION
Resolves #23

This adds an array of numpy dtype names to the output of `read_info`.  This intentionally does not refactor the `fields` entry, because that is also used as input when writing files and easiest to use as a simple list-like.