### PR TITLE
BUG: properly raise error if layer could not be opened

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -144,7 +144,7 @@ cdef void* ogr_open(const char* path_c, int mode, options) except NULL:
         CSLDestroy(open_opts)
 
 
-cdef OGRLayerH get_ogr_layer(GDALDatasetH ogr_dataset, layer):
+cdef OGRLayerH get_ogr_layer(GDALDatasetH ogr_dataset, layer) except NULL:
     """Open OGR layer by index or name.
 
     Parameters

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -81,6 +81,11 @@ def test_read_layer(test_fgdb_vsi):
     assert "RIVER_MILE" in df.columns
 
 
+def test_read_layer_invalid(naturalearth_lowres):
+    with pytest.raises(ValueError, match="Layer 'wrong' could not be opened"):
+        read_dataframe(naturalearth_lowres, layer="wrong")
+
+
 @pytest.mark.filterwarnings("ignore: Measured")
 def test_read_datetime(test_fgdb_vsi):
     df = read_dataframe(test_fgdb_vsi, layer="test_lines", max_features=1)


### PR DESCRIPTION
Encountered this while adding `layer` support in dask-geopandas