### PR TITLE
ENH: Use FID to set GeoDataFrame index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,14 @@
 
 ### Major enhancements
 
--   index of GeoDataFrame created by `read_dataframe` is now set to the FID of the
-    features that are read, as `int64` dtype. Note that some drivers start FID
-    numbering at 0 whereas others start numbering at 1.
+-   index of GeoDataFrame created by `read_dataframe` can now optionally be set
+    to the FID of the features that are read, as `int64` dtype. Note that some
+    drivers start FID numbering at 0 whereas others start numbering at 1.
 
 ### Breaking changes
 
--   `read` now also returns FIDs ndarray in addition to meta, geometries, and fields
+-   `read` now also returns an optional FIDs ndarray in addition to meta,
+    geometries, and fields; this is the 2nd item in the returned tuple.
 
 ## 0.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 0.4.0
+
+### Major enhancements
+
+-   index of GeoDataFrame created by `read_dataframe` is now set to the FID of the
+    features that are read, as `int64` dtype. Note that some drivers start FID
+    numbering at 0 whereas others start numbering at 1.
+
+### Breaking changes
+
+-   `read` now also returns FIDs ndarray in addition to meta, geometries, and fields
+
 ## 0.3.0
 
 ### Major enhancements

--- a/benchmarks/test_raw_io_benchmarks.py
+++ b/benchmarks/test_raw_io_benchmarks.py
@@ -109,14 +109,14 @@ def test_write_lowres_gpkg(tmpdir, naturalearth_lowres, benchmark):
 
 @pytest.mark.benchmark(group="write-lowres")
 def test_write_lowres_geojson(tmpdir, naturalearth_lowres, benchmark):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, _, geometry, field_data = read(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.json")
     benchmark(write, filename, geometry, field_data, driver="GeoJSON", **meta)
 
 
 @pytest.mark.benchmark(group="write-lowres")
 def test_write_lowres_geojsonseq(tmpdir, naturalearth_lowres, benchmark):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, _, geometry, field_data = read(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.json")
     benchmark(write, filename, geometry, field_data, driver="GeoJSONSeq", **meta)
 
@@ -158,7 +158,7 @@ def test_write_fiona_lowres_shp(tmpdir, naturalearth_lowres, benchmark):
 
 @pytest.mark.benchmark(group="write-modres")
 def test_write_modres_shp(tmpdir, naturalearth_modres, benchmark):
-    meta, geometry, field_data = read(naturalearth_modres)
+    meta, _, geometry, field_data = read(naturalearth_modres)
     filename = os.path.join(str(tmpdir), "test.shp")
     benchmark(write, filename, geometry, field_data, **meta)
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -16,6 +16,7 @@ def read_dataframe(
     where=None,
     bbox=None,
     fids=None,
+    set_fid_index=False,
 ):
     """Read from an OGR data source to a GeoPandas GeoDataFrame or Pandas DataFrame.
     If the data source does not have a geometry column or ``read_geometry`` is False,
@@ -67,6 +68,9 @@ def read_dataframe(
         specific (e.g. typically 0 for Shapefile and 1 for GeoPackage, but can
         still depend on the specific file). The performance of reading a large
         number of features usings FIDs is also driver specific.
+    set_fid_index : bool, optional (default: False)
+        If True, will return use the FIDs of the features that were read as the
+        index of the GeoDataFrame.  May start at 0 or 1 depending on the driver.
 
     Returns
     -------
@@ -99,11 +103,17 @@ def read_dataframe(
         where=where,
         bbox=bbox,
         fids=fids,
+        return_fids=set_fid_index,
     )
 
     columns = meta["fields"].tolist()
     data = {columns[i]: field_data[i] for i in range(len(columns))}
-    df = pd.DataFrame(data, columns=columns, index=pd.Series(index, name='fid'))
+    if set_fid_index:
+        index = index = pd.Series(index, name="fid")
+    else:
+        index = None
+
+    df = pd.DataFrame(data, columns=columns, index=index)
 
     if geometry is None or not read_geometry:
         return df

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -87,7 +87,7 @@ def read_dataframe(
         if not "/vsi" in path.lower() and not os.path.exists(path):
             raise ValueError(f"'{path}' does not exist")
 
-    meta, geometry, field_data = read(
+    meta, index, geometry, field_data = read(
         path,
         layer=layer,
         encoding=encoding,
@@ -103,7 +103,7 @@ def read_dataframe(
 
     columns = meta["fields"].tolist()
     data = {columns[i]: field_data[i] for i in range(len(columns))}
-    df = pd.DataFrame(data, columns=columns)
+    df = pd.DataFrame(data, columns=columns, index=pd.Series(index, name='fid'))
 
     if geometry is None or not read_geometry:
         return df

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -109,7 +109,7 @@ def read_dataframe(
     columns = meta["fields"].tolist()
     data = {columns[i]: field_data[i] for i in range(len(columns))}
     if fid_as_index:
-        index = pd.Int64Index(index, name="fid")
+        index = pd.Index(index, name="fid")
     else:
         index = None
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -16,7 +16,7 @@ def read_dataframe(
     where=None,
     bbox=None,
     fids=None,
-    set_fid_index=False,
+    fid_as_index=False,
 ):
     """Read from an OGR data source to a GeoPandas GeoDataFrame or Pandas DataFrame.
     If the data source does not have a geometry column or ``read_geometry`` is False,
@@ -68,8 +68,8 @@ def read_dataframe(
         specific (e.g. typically 0 for Shapefile and 1 for GeoPackage, but can
         still depend on the specific file). The performance of reading a large
         number of features usings FIDs is also driver specific.
-    set_fid_index : bool, optional (default: False)
-        If True, will return use the FIDs of the features that were read as the
+    fid_as_index : bool, optional (default: False)
+        If True, will use the FIDs of the features that were read as the
         index of the GeoDataFrame.  May start at 0 or 1 depending on the driver.
 
     Returns
@@ -103,13 +103,13 @@ def read_dataframe(
         where=where,
         bbox=bbox,
         fids=fids,
-        return_fids=set_fid_index,
+        return_fids=fid_as_index,
     )
 
     columns = meta["fields"].tolist()
     data = {columns[i]: field_data[i] for i in range(len(columns))}
-    if set_fid_index:
-        index = index = pd.Series(index, name="fid")
+    if fid_as_index:
+        index = pd.Int64Index(index, name="fid")
     else:
         index = None
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -79,8 +79,9 @@ def read(
 
     Returns
     -------
-    (dict, geometry, data fields)
+    (dict, fids, geometry, data fields)
         Returns a tuple of meta information about the data source in a dict,
+        an ndarray of FIDs corresponding to the features that were read,
         an ndarray of geometry objects or None (if data source does not include
         geometry or read_geometry is False), a tuple of ndarrays for each field
         in the data layer.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -27,6 +27,7 @@ def read(
     where=None,
     bbox=None,
     fids=None,
+    return_fids=False,
 ):
     """Read OGR data source.
 
@@ -76,12 +77,15 @@ def read(
         specific (e.g. typically 0 for Shapefile and 1 for GeoPackage, but can
         still depend on the specific file). The performance of reading a large
         number of features usings FIDs is also driver specific.
+    return_fids : bool, optional (default: False)
+        If True, will return the FIDs of the feature that were read.
 
     Returns
     -------
     (dict, fids, geometry, data fields)
         Returns a tuple of meta information about the data source in a dict,
-        an ndarray of FIDs corresponding to the features that were read,
+        an ndarray of FIDs corresponding to the features that were read or None
+        (if return_fids is False),
         an ndarray of geometry objects or None (if data source does not include
         geometry or read_geometry is False), a tuple of ndarrays for each field
         in the data layer.
@@ -106,6 +110,7 @@ def read(
         where=where,
         bbox=bbox,
         fids=fids,
+        return_fids=return_fids,
     )
 
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -111,7 +111,7 @@ def test_read_fid_as_index(naturalearth_lowres):
     assert_index_equal(df.index, pd.RangeIndex(0, 2))
 
     df = read_dataframe(naturalearth_lowres, fid_as_index=True, **kwargs)
-    assert_index_equal(df.index, pd.Int64Index([2, 3], name="fid"))
+    assert_index_equal(df.index, pd.Index([2, 3], name="fid"))
 
 
 @pytest.mark.filterwarnings("ignore: Layer")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_index_equal
 import pytest
 
 from pyogrio import list_layers
@@ -100,19 +100,18 @@ def test_read_null_values(test_fgdb_vsi):
     assert df.loc[df.SEGMENT_NAME.isnull()].SEGMENT_NAME.iloc[0] == None
 
 
-def test_read_set_fid_index(naturalearth_lowres):
+def test_read_fid_as_index(naturalearth_lowres):
     kwargs = {"skip_features": 2, "max_features": 2}
 
     # default is to not set FIDs as index
     df = read_dataframe(naturalearth_lowres, **kwargs)
-    assert np.array_equal(df.index.values, pd.RangeIndex(0, 2).values)
+    assert_index_equal(df.index, pd.RangeIndex(0, 2))
 
-    df = read_dataframe(naturalearth_lowres, set_fid_index=False, **kwargs)
-    assert np.array_equal(df.index.values, pd.RangeIndex(0, 2).values)
+    df = read_dataframe(naturalearth_lowres, fid_as_index=False, **kwargs)
+    assert_index_equal(df.index, pd.RangeIndex(0, 2))
 
-    df = read_dataframe(naturalearth_lowres, set_fid_index=True, **kwargs)
-    assert df.index.name == "fid"
-    assert np.array_equal(df.index.values, np.array([2, 3], dtype=np.int64))
+    df = read_dataframe(naturalearth_lowres, fid_as_index=True, **kwargs)
+    assert_index_equal(df.index, pd.Int64Index([2, 3], name="fid"))
 
 
 @pytest.mark.filterwarnings("ignore: Layer")
@@ -168,7 +167,7 @@ def test_read_bbox(naturalearth_lowres):
 def test_read_fids(naturalearth_lowres):
     # ensure keyword is properly passed through
     fids = np.array([0, 10, 5], dtype=np.int64)
-    df = read_dataframe(naturalearth_lowres, fids=fids, set_fid_index=True)
+    df = read_dataframe(naturalearth_lowres, fids=fids, fid_as_index=True)
     assert len(df) == 3
     assert np.array_equal(fids, df.index.values)
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -11,7 +11,7 @@ from pyogrio.errors import DriverError
 
 
 def test_read(naturalearth_lowres):
-    meta, geometry, fields = read(naturalearth_lowres)
+    meta, index, geometry, fields = read(naturalearth_lowres)
 
     assert meta["crs"] == "EPSG:4326"
     assert meta["geometry_type"] == "Polygon"
@@ -27,7 +27,9 @@ def test_read(naturalearth_lowres):
     ]
 
     assert len(fields) == 5
+    assert len(index) == len(fields[0])
     assert len(geometry) == len(fields[0])
+    assert index.dtype == np.int64
 
     # quick test that WKB is a Polygon type
     assert geometry[0][:6] == b"\x01\x06\x00\x00\x00\x03"
@@ -38,53 +40,58 @@ def test_vsi_read_layers(naturalearth_lowres_vsi):
         list_layers(naturalearth_lowres_vsi), [["naturalearth_lowres", "Polygon"]]
     )
 
-    meta, geometry, fields = read(naturalearth_lowres_vsi)
+    geometry = read(naturalearth_lowres_vsi)[2]
     assert geometry.shape == (177,)
 
 
 def test_read_no_geometry(naturalearth_lowres):
-    meta, geometry, fields = read(naturalearth_lowres, read_geometry=False)
+    geometry = read(naturalearth_lowres, read_geometry=False)[2]
 
     assert geometry is None
 
 
 def test_read_columns(naturalearth_lowres):
     # read no columns or geometry
-    meta, geometry, fields = read(naturalearth_lowres, columns=[], read_geometry=False)
+    meta, _, geometry, fields = read(
+        naturalearth_lowres, columns=[], read_geometry=False
+    )
     assert geometry is None
     assert len(fields) == 0
     array_equal(meta["fields"], np.empty(shape=(0, 4), dtype="object"))
 
     columns = ["NAME", "NAME_LONG"]
-    meta, geometry, fields = read(
+    meta, _, geometry, fields = read(
         naturalearth_lowres, columns=columns, read_geometry=False
     )
     array_equal(meta["fields"], columns)
 
     # Repeats should be dropped
     columns = ["NAME", "NAME_LONG", "NAME"]
-    meta, geometry, fields = read(
+    meta, _, geometry, fields = read(
         naturalearth_lowres, columns=columns, read_geometry=False
     )
     array_equal(meta["fields"], columns[:2])
 
 
 def test_read_skip_features(naturalearth_lowres):
-    expected_geometry, expected_fields = read(naturalearth_lowres)[1:]
-    geometry, fields = read(naturalearth_lowres, skip_features=10)[1:]
+    expected_geometry, expected_fields = read(naturalearth_lowres)[2:]
+    index, geometry, fields = read(naturalearth_lowres, skip_features=10)[1:]
 
+    assert len(index) == len(geometry)
     assert len(geometry) == len(expected_geometry) - 10
     assert len(fields[0]) == len(expected_fields[0]) - 10
 
+    assert index[0] == 10
     assert np.array_equal(geometry, expected_geometry[10:])
     # Last field has more variable data
     assert np.array_equal(fields[-1], expected_fields[-1][10:])
 
 
 def test_read_max_features(naturalearth_lowres):
-    expected_geometry, expected_fields = read(naturalearth_lowres)[1:]
-    geometry, fields = read(naturalearth_lowres, max_features=2)[1:]
+    expected_geometry, expected_fields = read(naturalearth_lowres)[2:]
+    index, geometry, fields = read(naturalearth_lowres, max_features=2)[1:]
 
+    assert len(index) == 2
     assert len(geometry) == 2
     assert len(fields[0]) == 2
 
@@ -94,13 +101,13 @@ def test_read_max_features(naturalearth_lowres):
 
 def test_read_where(naturalearth_lowres):
     # empty filter should return full set of records
-    geometry, fields = read(naturalearth_lowres, where="")[1:]
+    geometry, fields = read(naturalearth_lowres, where="")[2:]
     assert len(geometry) == 177
     assert len(fields) == 5
     assert len(fields[0]) == 177
 
     # should return singular item
-    geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'CAN'")[1:]
+    geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'CAN'")[2:]
     assert len(geometry) == 1
     assert len(fields) == 5
     assert len(fields[0]) == 1
@@ -109,14 +116,14 @@ def test_read_where(naturalearth_lowres):
     # should return items within range
     geometry, fields = read(
         naturalearth_lowres, where="POP_EST >= 10000000 AND POP_EST < 100000000"
-    )[1:]
+    )[2:]
     assert len(geometry) == 75
     assert min(fields[0]) >= 10000000
     assert max(fields[0]) < 100000000
 
     # should match no items
     with pytest.warns(UserWarning, match="does not have any features to read"):
-        geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'INVALID'")[1:]
+        geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'INVALID'")[2:]
         assert len(geometry) == 0
 
 
@@ -134,26 +141,28 @@ def test_read_bbox_invalid(naturalearth_lowres, bbox):
 def test_read_bbox(naturalearth_lowres):
     # should return no features
     with pytest.warns(UserWarning, match="does not have any features to read"):
-        geometry, fields = read(naturalearth_lowres, bbox=(0, 0, 0.00001, 0.00001))[1:]
+        geometry, fields = read(naturalearth_lowres, bbox=(0, 0, 0.00001, 0.00001))[2:]
 
     assert len(geometry) == 0
 
-    geometry, fields = read(naturalearth_lowres, bbox=(-140, 20, -100, 40))[1:]
+    geometry, fields = read(naturalearth_lowres, bbox=(-140, 20, -100, 40))[2:]
 
     assert len(geometry) == 2
     assert np.array_equal(fields[3], ["USA", "MEX"])
 
 
 def test_read_fids(naturalearth_lowres):
-    expected_geometry, expected_fields = read(naturalearth_lowres)[1:]
+    expected_fids, expected_geometry, expected_fields = read(naturalearth_lowres)[1:]
     subset = [0, 10, 5]
-    
-    for fids in [subset, np.array(subset)]:
-        geometry, fields = read(naturalearth_lowres, fids=subset)[1:]
 
+    for fids in [subset, np.array(subset)]:
+        index, geometry, fields = read(naturalearth_lowres, fids=subset)[1:]
+
+        assert len(fids) == 3
         assert len(geometry) == 3
         assert len(fields[0]) == 3
 
+        assert np.array_equal(fids, expected_fids[subset])
         assert np.array_equal(geometry, expected_geometry[subset])
         assert np.array_equal(fields[-1], expected_fields[-1][subset])
 
@@ -181,7 +190,7 @@ def test_read_fids_unsupported_keywords(naturalearth_lowres):
 
 
 def test_write(tmpdir, naturalearth_lowres):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, index, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.shp")
     write(filename, geometry, field_data, **meta)
@@ -192,7 +201,7 @@ def test_write(tmpdir, naturalearth_lowres):
 
 
 def test_write_gpkg(tmpdir, naturalearth_lowres):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, index, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.gpkg")
     write(filename, geometry, field_data, driver="GPKG", **meta)
@@ -201,7 +210,7 @@ def test_write_gpkg(tmpdir, naturalearth_lowres):
 
 
 def test_write_geojson(tmpdir, naturalearth_lowres):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, index, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.json")
     write(filename, geometry, field_data, driver="GeoJSON", **meta)
@@ -229,7 +238,7 @@ def test_write_geojson(tmpdir, naturalearth_lowres):
 )
 def test_write_supported(tmpdir, naturalearth_lowres, driver):
     """Test drivers not specifically tested above"""
-    meta, geometry, field_data = read(naturalearth_lowres, columns=["iso_a3"])
+    meta, index, geometry, field_data = read(naturalearth_lowres, columns=["iso_a3"])
 
     # note: naturalearth_lowres contains mixed polygons / multipolygons, which
     # are not supported in mixed form for all drivers.  To get around this here
@@ -242,14 +251,14 @@ def test_write_supported(tmpdir, naturalearth_lowres, driver):
         geometry[:1],
         field_data=[f[:1] for f in field_data],
         driver=driver,
-        **meta
+        **meta,
     )
 
     assert filename.exists()
 
 
 def test_write_unsupported(tmpdir, naturalearth_lowres):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, index, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.fgdb")
 


### PR DESCRIPTION
Resolves #14

This expands the Cython layer to read in FID while reading features, unless `fids` are provided as input, in which case those are copied and returned.

Questions:
* do we want to make this the default behavior or opt-in?
* if opt-in, do we want this to be based solely on a keyword parameter to enable it, or do we also want to opt-in when `fids` are passed in?