### PR TITLE
Allow gdal config via GDAL_INCLUDE/LIBRARY_PATH env variables (Simplify building on Windows with environment variables)

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -59,8 +59,10 @@ exactly the same GDAL library.
 
 Clone this repository to a local folder.
 
-Install an appropriate distribution of GDAL for your system. `gdal-config` must
-be on your system path.
+Install an appropriate distribution of GDAL for your system. Either
+`gdal-config` must be on your system path (to automatically determine the
+GDAL paths), or either the `GDAL_INCLUDE_PATH` and `GDAL_LIBRARY_PATH`
+environment variables need to be set.
 
 Building Pyogrio requires requires `Cython`, `numpy`, and `pandas`.
 
@@ -77,18 +79,24 @@ pytest pyogrio/tests
 Install GDAL from an appropriate provider of Windows binaries. We've heard that
 the [OSGeo4W](https://trac.osgeo.org/osgeo4w/) works.
 
-To build on Windows, you need to provide additional command-line parameters
-because the location of the GDAL binaries and headers cannot be automatically
-determined.
+To build on Windows, you need to provide additional environment variables or
+command-line parameters because the location of the GDAL binaries and headers
+cannot be automatically determined.
 
-Assuming GDAL is installed to `c:\GDAL`, you can build as follows:
+Assuming GDAL is installed to `c:\GDAL`, you can set the `GDAL_INCLUDE_PATH`
+and `GDAL_LIBRARY_PATH` environment variables and build as follows:
+
+```bash
+set GDAL_INCLUDE_PATH=C:\GDAL\include
+set GDAL_LIBRARY_PATH=C:\GDAL\lib
+python -m pip install --no-deps --force-reinstall --no-use-pep517 -e . -v
+```
+
+Alternatively, you can pass those options also as command-line parameters:
 
 ```bash
 python -m pip install --install-option=build_ext --install-option="-IC:\GDAL\include" --install-option="-lgdal_i" --install-option="-LC:\GDAL\lib" --no-deps --force-reinstall --no-use-pep517 -e . -v
 ```
-
-`GDAL_VERSION` environment variable must be if the version cannot be autodetected
-using `gdalinfo.exe` (must be on your system `PATH` in order for this to work).
 
 The location of the GDAL DLLs must be on your system `PATH`.
 

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ def get_gdal_paths():
         gdal_config = os.environ.get("GDAL_CONFIG", "gdal-config")
         config = {flag: read_response([gdal_config, f"--{flag}"]) for flag in flags}
 
-        GDAL_VERSION = tuple(int(i) for i in config["version"].split("."))
-        if not GDAL_VERSION > MIN_GDAL_VERSION:
+        gdal_version = tuple(int(i) for i in config["version"].split("."))
+        if not gdal_version >= MIN_GDAL_VERSION:
             sys.exit("GDAL must be >= 2.4.x")
 
         include_dirs = [
@@ -98,38 +98,6 @@ def get_gdal_paths():
         if platform.system() == "Windows":
             # Note: additional command-line parameters required to point to GDAL;
             # see the README.
-
-            gdal_version_str = os.environ.get("GDAL_VERSION", "")
-            if not gdal_version_str:
-                # attempt to execute gdalinfo to find GDAL version
-                # Note: gdalinfo must be on the PATH
-                try:
-                    gdalinfo_path = None
-                    for path in os.getenv("PATH", "").split(os.pathsep):
-                        matches = list(Path(path).glob("**/gdalinfo.exe"))
-                        if matches:
-                            gdalinfo_path = matches[0]
-                            break
-
-                    if gdalinfo_path:
-                        raw_version = read_response([gdalinfo_path, "--version"]) or ""
-                        m = re.search("\d+\.\d+\.\d+", raw_version)
-                        if m:
-                            gdal_version_str = m.group()
-
-                except:
-                    log.warn(
-                        "Could not obtain version by executing 'gdalinfo --version'"
-                    )
-
-            if not gdal_version_str:
-                print("GDAL_VERSION must be provided as an environment variable")
-                sys.exit(1)
-
-            GDAL_VERSION = tuple(int(i) for i in gdal_version_str.split("."))
-            if not GDAL_VERSION > MIN_GDAL_VERSION:
-                sys.exit("GDAL must be >= 2.4.x")
-
             log.info(
                 "Building on Windows requires extra options to setup.py to locate GDAL files.  See the README."
             )

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ def read_response(cmd):
 def get_gdal_paths():
     """Obtain the paths for compiling and linking with the GDAL C-API
 
-    First the presence of the GDAL_INCLUDE_PATH and GDAL_LIBRARY_PATH environment
-    variables is checked. If they are both present, these are taken.
+    GDAL_INCLUDE_PATH and GDAL_LIBRARY_PATH environment variables are used
+    if both are present.
 
-    If one of the two paths was not present, gdal-config is called (it should be on the
-    PATH variable). gdal-config provides all the paths.
+    If those variables are not present, gdal-config is called (it should be
+    on the PATH variable). gdal-config provides all the paths.
 
     If no environment variables were specified or gdal-config was not found,
     no additional paths are provided to the extension. It is still possible

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ else:
                 try:
                     gdalinfo_path = None
                     for path in os.getenv("PATH", "").split(os.pathsep):
-                        matches = list(Path(path).glob("**/gdalinfo*"))
+                        matches = list(Path(path).glob("**/gdalinfo.exe"))
                         if matches:
                             gdalinfo_path = matches[0]
                             break
@@ -111,9 +111,17 @@ else:
 
             GDAL_VERSION = tuple(int(i) for i in gdal_version_str.split("."))
 
-            log.info(
-                "Building on Windows requires extra options to setup.py to locate GDAL files.  See the README."
-            )
+            include_dir = os.environ.get("GDAL_INCLUDE_PATH")
+            library_dir = os.environ.get("GDAL_LIBRARY_PATH")
+
+            if include_dir and library_dir:
+                ext_options["include_dirs"].append(include_dir)
+                ext_options["library_dirs"].append(library_dir)
+                ext_options["libraries"].append("gdal_i")
+            else:
+                log.info(
+                    "Building on Windows requires extra options to setup.py to locate GDAL files.  See the README."
+                )
 
         else:
             raise e


### PR DESCRIPTION
Related to https://github.com/geopandas/pyogrio/issues/8

Currently, for installing on source on Windows, we indicate that you need to pass additional flags (to the include and library dirs): https://pyogrio.readthedocs.io/en/latest/install.html#windows. Passing those additional flags gets complicated if not using ``python setup.py build_ext``, but eg pip, as noted in https://github.com/geopandas/pyogrio/issues/8

So this PR adds an alternative way to do this, by specifying environment variables. 
This is similar to how pygeos/shapely do it (eg https://github.com/pygeos/pygeos/blob/0835379a5bc534be63037696b1b70cf4337e3841/setup.py#L66-L72)

As a result, I can build locally on Windows with

```
set GDAL_INCLUDE_PATH=%CONDA_PREFIX%\Library\include
set GDAL_LIBRARY_PATH=%CONDA_PREFIX%\Library\lib

python setup.py build_ext -i
```

instead of 

```
python setup.py build_ext -i -I"%CONDA_PREFIX%\Library\include" -lgdal_i -L"%CONDA_PREFIX%\Library\lib"
```

(and with pip it's even more a simplification, because of not needing the `--install-option`)

Still need to update the docs if we want this.