### PR TITLE
Add test for custom CRS read / write

### DIFF
--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -236,3 +236,26 @@ def test_write_empty_dataframe(tmpdir, driver, ext):
     df = read_dataframe(filename)
 
     assert_geodataframe_equal(df, expected)
+
+
+@pytest.mark.filterwarnings(
+    "ignore: You will likely lose important projection information"
+)
+def test_custom_crs_io(tmpdir, naturalearth_lowres):
+    df = read_dataframe(naturalearth_lowres)
+    # project Belgium to a custom Albers Equal Area projection
+    expected = df.loc[df.name == "Belgium"].to_crs(
+        "+proj=aea +lat_1=49.5 +lat_2=51.5 +lon_0=4.3"
+    )
+    filename = os.path.join(str(tmpdir), "test.shp")
+    write_dataframe(expected, filename)
+
+    assert os.path.exists(filename)
+
+    df = read_dataframe(filename)
+
+    crs = df.crs.to_dict()
+    assert crs["lat_1"] == 49.5
+    assert crs["lat_2"] == 51.5
+    assert crs["lon_0"] == 4.3
+

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -258,4 +258,5 @@ def test_custom_crs_io(tmpdir, naturalearth_lowres):
     assert crs["lat_1"] == 49.5
     assert crs["lat_2"] == 51.5
     assert crs["lon_0"] == 4.3
+    assert df.crs.equals(expected.crs)
 


### PR DESCRIPTION
This uses a custom (completely made up) CRS centered over Belgium to verify that a custom CRS can be round-tripped.

This should also ensure that GDAL data files / PROJ data files are used when reading / writing the file.