### PR TITLE
Search for GDAL and PROJ data folders during startup

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -107,3 +107,16 @@ Also see `.github/test-windows.yml` for additional ideas if you run into problem
 
 Windows is minimally tested; we are currently unable to get automated tests
 working on our Windows CI.
+
+## GDAL and PROJ data files
+
+GDAL requires certain files to be present within a GDAL data folder, as well
+as a PROJ data folder. These folders are normally detected automatically.
+
+If you have an unusual installation of GDAL and PROJ, you may need to set
+additional environment variables at **runtime** in order for these to be
+correctly detected by GDAL:
+
+-   set `GDAL_DATA` to the folder containing the GDAL data files (e.g., contains `header.dxf`)
+    within the installation of GDAL that is used by Pyogrio.
+-   set `PROJ_LIB` to the folder containing the PROJ data files (e.g., contains `proj.db`)

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -1,3 +1,4 @@
 cdef object exc_check()
 cdef int exc_wrap_int(int retval) except -1
+cdef int exc_wrap_ogrerr(int retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -1,7 +1,9 @@
 # ported from fiona::_err.pyx
 from enum import IntEnum
 
-from pyogrio._ogr cimport *
+from pyogrio._ogr cimport (
+    CE_None, CE_Debug, CE_Warning, CE_Failure, CE_Fatal, CPLErrorReset,
+    CPLGetLastErrorType, CPLGetLastErrorNo, CPLGetLastErrorMsg, OGRErr)
 
 
 # CPL Error types as an enum.
@@ -182,6 +184,8 @@ cdef void *exc_wrap_pointer(void *ptr) except NULL:
 cdef int exc_wrap_int(int err) except -1:
     """Wrap a GDAL/OGR function that returns CPLErr or OGRErr (int)
     Raises an exception if a non-fatal error has be set.
+
+    Copied from Fiona (_err.pyx).
     """
     if err:
         exc = exc_check()
@@ -190,4 +194,16 @@ cdef int exc_wrap_int(int err) except -1:
         else:
             # no error message from GDAL
             raise CPLE_BaseError(-1, -1, "Unspecified OGR / GDAL error")
+    return err
+
+
+cdef int exc_wrap_ogrerr(int err) except -1:
+    """Wrap a function that returns OGRErr (int) but does not use the
+    CPL error stack.
+
+    Adapted from Fiona (_err.pyx).
+    """
+    if err != 0:
+        raise CPLE_BaseError(3, err, f"OGR Error code {err}")
+
     return err

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -161,11 +161,13 @@ cdef extern from "ogr_srs_api.h":
     ctypedef void* OGRSpatialReferenceH
 
     int                     OSRAutoIdentifyEPSG(OGRSpatialReferenceH srs)
+    OGRErr                  OSRExportToWkt(OGRSpatialReferenceH srs, char **params)
     const char*             OSRGetAuthorityName(OGRSpatialReferenceH srs, const char *key)
     const char*             OSRGetAuthorityCode(OGRSpatialReferenceH srs, const char *key)
-    OGRErr                  OSRExportToWkt(OGRSpatialReferenceH srs, char **params)
+    OGRErr                  OSRImportFromEPSG(OGRSpatialReferenceH srs, int code)
 
     int                     OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *pszDef)
+    void                    OSRSetPROJSearchPaths(const char *const *paths)
     OGRSpatialReferenceH    OSRNewSpatialReference(const char *wkt)
     void                    OSRRelease(OGRSpatialReferenceH srs)
 

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -8,6 +8,7 @@ cdef extern from "cpl_conv.h":
     void*   CPLMalloc(size_t)
     void    CPLFree(void *ptr)
 
+    const char* CPLFindFile(const char *pszClass, const char *filename)
     const char* CPLGetConfigOption(const char* key, const char* value)
     void        CPLSetConfigOption(const char* key, const char* value)
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -185,7 +185,7 @@ def init_gdal_data():
             raise ValueError("Could not correctly detect GDAL data files installed by pyogrio wheel")
         return
 
-    # GDAL correctly found data files from compiled-in paths
+    # GDAL correctly found data files from GDAL_DATA or compiled-in paths
     if has_gdal_data():
         return
 
@@ -201,7 +201,6 @@ def init_gdal_data():
 
 def init_proj_data():
     """Set Proj search directories in the following precedence:
-    - PROJ_LIB env var
     - wheel copy of proj_data
     - default detection by GDAL, including PROJ_LIB (detected automatically by GDAL)
     - search other well-known paths under sys.prefix
@@ -218,7 +217,7 @@ def init_proj_data():
             raise ValueError("Could not correctly detect PROJ data files installed by pyogrio wheel")
         return
 
-    # GDAL correctly found PROJ based on compiled-in paths
+    # GDAL correctly found data files from PROJ_LIB or compiled-in paths
     if has_proj_data():
         return
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -168,7 +168,6 @@ cdef char has_proj_data():
             OSRRelease(srs)
 
 
-
 def init_gdal_data():
     """Set GDAL data search directories in the following precedence:
     - GDAL_DATA env var
@@ -185,7 +184,7 @@ def init_gdal_data():
             raise ValueError("GDAL_DATA does not resolve to a directory that contains GDAL data files")
         return
 
-    # wheels are packaged to include PROJ data files at pyogrio/gdal_data
+    # wheels are packaged to include GDAL data files at pyogrio/gdal_data
     wheel_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "gdal_data"))
     if os.path.exists(wheel_path):
         set_gdal_config_options({"GDAL_DATA": wheel_path})
@@ -205,8 +204,6 @@ def init_gdal_data():
         return
 
     warnings.warn("Could not detect GDAL data files.  Set GDAL_DATA environment variable to the correct path.", RuntimeWarning)
-
-
 
 
 def init_proj_data():

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -170,19 +170,12 @@ cdef char has_proj_data():
 
 def init_gdal_data():
     """Set GDAL data search directories in the following precedence:
-    - GDAL_DATA env var
     - wheel copy of gdal_data
-    - default install of GDAL data files
+    - default detection by GDAL, including GDAL_DATA (detected automatically by GDAL)
     - other well-known paths under sys.prefix
 
     Adapted from Fiona (env.py, _env.pyx).
     """
-
-    if "GDAL_DATA" in os.environ:
-        set_gdal_config_options({"GDAL_DATA": os.environ["GDAL_DATA"]})
-        if not has_gdal_data():
-            raise ValueError("GDAL_DATA does not resolve to a directory that contains GDAL data files")
-        return
 
     # wheels are packaged to include GDAL data files at pyogrio/gdal_data
     wheel_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "gdal_data"))
@@ -210,18 +203,11 @@ def init_proj_data():
     """Set Proj search directories in the following precedence:
     - PROJ_LIB env var
     - wheel copy of proj_data
-    - default install of proj found by GDAL
+    - default detection by GDAL, including PROJ_LIB (detected automatically by GDAL)
     - search other well-known paths under sys.prefix
 
     Adapted from Fiona (env.py, _env.pyx).
     """
-
-    if "PROJ_LIB" in os.environ:
-        set_proj_search_path(os.environ["PROJ_LIB"])
-        # verify that this now resolves
-        if not has_proj_data():
-            raise ValueError("PROJ_LIB did not resolve to a path containing PROJ data files")
-        return
 
     # wheels are packaged to include PROJ data files at pyogrio/proj_data
     wheel_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "proj_data"))

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -173,6 +173,7 @@ def init_gdal_data():
     """Set GDAL data search directories in the following precedence:
     - GDAL_DATA env var
     - wheel copy of gdal_data
+    - default install of GDAL data files
     - other well-known paths under sys.prefix
 
     Adapted from Fiona (env.py, _env.pyx).

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -145,7 +145,7 @@ cdef char has_gdal_data():
 
 
 cdef char has_proj_data():
-    """Verify that PROJ library data files are loaded by GDAL.
+    """Verify that PROJ library data files are correctly found.
 
     Returns
     -------
@@ -202,7 +202,7 @@ def init_gdal_data():
 def init_proj_data():
     """Set Proj search directories in the following precedence:
     - wheel copy of proj_data
-    - default detection by GDAL, including PROJ_LIB (detected automatically by GDAL)
+    - default detection by PROJ, including PROJ_LIB (detected automatically by PROJ)
     - search other well-known paths under sys.prefix
 
     Adapted from Fiona (env.py, _env.pyx).
@@ -217,7 +217,7 @@ def init_proj_data():
             raise ValueError("Could not correctly detect PROJ data files installed by pyogrio wheel")
         return
 
-    # GDAL correctly found data files from PROJ_LIB or compiled-in paths
+    # PROJ correctly found data files from PROJ_LIB or compiled-in paths
     if has_proj_data():
         return
 

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -9,10 +9,12 @@ with GDALEnv():
         ogr_list_drivers,
         set_gdal_config_options as _set_gdal_config_options,
         get_gdal_config_option as _get_gdal_config_option,
+        init_gdal_data as _init_gdal_data,
         init_proj_data as _init_proj_data,
     )
     from pyogrio._io import ogr_list_layers, ogr_read_bounds, ogr_read_info
 
+    _init_gdal_data()
     _init_proj_data()
 
     __gdal_version__ = get_gdal_version()

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -9,8 +9,11 @@ with GDALEnv():
         ogr_list_drivers,
         set_gdal_config_options as _set_gdal_config_options,
         get_gdal_config_option as _get_gdal_config_option,
+        init_proj_data as _init_proj_data,
     )
     from pyogrio._io import ogr_list_layers, ogr_read_bounds, ogr_read_info
+
+    _init_proj_data()
 
     __gdal_version__ = get_gdal_version()
     __gdal_version_string__ = get_gdal_version_string()


### PR DESCRIPTION
This follows the same approach as used by Fiona for searching for GDAL and PROJ data folders.

GDAL data folders are searched in the following precedence:
- wheel copy of gdal_data
- auto detection by GDAL (including `GDAL_DATA` env var)
- other well-known paths under `sys.prefix`


PROJ data folders are searched in the following precedence:
- wheel copy of proj
- default detection by GDAL (including `PROJ_LIB` env var)
- other well-known paths under `sys.prefix`