### PR TITLE
Add direct tests for GDAL and PROJ data discovery

### DIFF
--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -132,7 +132,7 @@ cdef void set_proj_search_path(str path):
     OSRSetPROJSearchPaths(<const char *const *>paths)
 
 
-cdef char has_gdal_data():
+def has_gdal_data():
     """Verify that GDAL library data files are correctly found.
 
     Adapted from Fiona (_env.pyx).
@@ -144,7 +144,7 @@ cdef char has_gdal_data():
     return False
 
 
-cdef char has_proj_data():
+def has_proj_data():
     """Verify that PROJ library data files are correctly found.
 
     Returns
@@ -160,9 +160,9 @@ cdef char has_proj_data():
     try:
         exc_wrap_ogrerr(exc_wrap_int(OSRImportFromEPSG(srs, 4326)))
     except CPLE_BaseError:
-        return 0
+        return False
     else:
-        return 1
+        return True
     finally:
         if srs != NULL:
             OSRRelease(srs)

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -10,6 +10,23 @@ from pyogrio import (
     get_gdal_config_option,
 )
 
+from pyogrio._env import GDALEnv
+
+with GDALEnv():
+    # NOTE: this must be AFTER above imports, which init the GDAL and PROJ data
+    # search paths
+    from pyogrio._ogr import has_gdal_data, has_proj_data
+
+
+def test_gdal_data():
+    # test will fail if GDAL data files cannot be found, indicating an installation error
+    assert has_gdal_data()
+
+
+def test_proj_data():
+    # test will fail if PROJ data files cannot be found, indicating an installation error
+    assert has_proj_data()
+
 
 def test_list_drivers():
     all_drivers = list_drivers()


### PR DESCRIPTION
Exposes check for valid GDAL / PROJ data file discovery to Python, and adds associated tests.

These should fail if GDAL and PROJ data are not correctly discovered by GDAL / PROJ.

In the case of PROJ, this verifies that PROJ data files are actually used, because it initializes a CRS object, which would fail if data files are not present.

In the case of GDAL data, this verifies that a [sentinal file is in the expected location](https://github.com/rasterio/rasterio/issues/1631#issuecomment-462395938).