### PR TITLE
TST: Add test to verify GDAL detects zip archives

### DIFF
--- a/pyogrio/tests/test_path.py
+++ b/pyogrio/tests/test_path.py
@@ -120,6 +120,14 @@ def test_zip_path(naturalearth_lowres_vsi):
     assert len(df) == 177
 
 
+@pytest.mark.filterwarnings("ignore: Measured")
+def test_detect_zip_path(data_dir):
+    path = data_dir / "test_fgdb.gdb.zip"
+
+    df = pyogrio.read_dataframe(path, layer="test_lines")
+    assert len(df) == 2
+
+
 @pytest.mark.network
 def test_url():
     df = pyogrio.read_dataframe(
@@ -143,5 +151,5 @@ def aws_env_setup(monkeypatch):
 
 @pytest.mark.network
 def test_uri_s3(aws_env_setup):
-    df = pyogrio.read_dataframe('zip+s3://fiona-testing/coutwildrnp.zip')
+    df = pyogrio.read_dataframe("zip+s3://fiona-testing/coutwildrnp.zip")
     assert len(df) == 67


### PR DESCRIPTION
[GeoPandas crossref](https://github.com/geopandas/geopandas/pull/2225#issuecomment-1086589092)

GDAL already detects ZIP archives without needing `/vsizip/` or `zip://` prefix.  This adds a test to demonstrate that.

This does not add Fiona's full parsing of URLs, which includes splitting on `!` to separate out archive vs file within archive components; I don't have a good test string for that kind of path, and from [Fiona #742](https://github.com/Toblerity/Fiona/issues/742) I'm not sure if we should support it.