### PR TITLE
CI: Add specific test for sdist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,13 @@ jobs:
         with:
           path: wheelhouse
 
+      - name: Log paths
+        run: |
+          echo "wheelhouse/*"
+          ls wheelhouse/*
+          echo "/wheelhouse/*"
+          ls /wheelhouse/*
+
       - name: Install python
         run: |
           apt-get update && apt-get install -y python3 python3-pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,129 +42,14 @@ jobs:
           path: ./dist/*.tar.gz
           retention-days: 5
 
-  build-wheels-linux:
-    name: Build wheels on Linux
-    runs-on: "ubuntu-20.04"
+  test-sdist:
+    name: Test sdist
+    needs: [build-sdist]
+    runs-on: ubuntu-latest
+    container:
+      image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          install: true
-          buildkitd-flags: --debug
-
-      - name: Build Docker image with vcpkg and gdal
-        # using build-push-action (without push) to make use of cache arguments
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
-          tags: manylinux-vcpkg-gdal:latest
-          push: false
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-        env:
-          BUILDKIT_PROGRESS: plain
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-
-  build-wheels-mac-win:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: "macos-10.15"
-            triplet: "x64-osx-dynamic"
-            vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
-            vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
-
-          - os: "windows-2019"
-            triplet: "x64-windows"
-            # windows requires windows-specific paths
-            vcpkg_cache: "c:\\vcpkg\\installed"
-            vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
-
-    env:
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Cache vcpkg
-        uses: actions/cache@v3
-        id: vcpkgcache
-        with:
-          path: |
-            ${{ matrix.vcpkg_cache }}
-          # bump the last digit to avoid using previous build cache
-          key: ${{ matrix.os }}-x86_64-vcpkg-gdal3.4.2-cache4
-
-      # MacOS build requires aclocal, which is part of automake, but appears
-      # to be missing in default image
-      - name: Reinstall automake
-        if: runner.os == 'macOS'
-        run: |
-          brew reinstall automake
-          echo $(which aclocal)
-
-      - name: Install GDAL
-        env:
-          VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
-        shell: bash
-        run: |
-          vcpkg install --overlay-triplets=./ci/custom-triplets --feature-flags="versions,manifests" --x-manifest-root=./ci --x-install-root=$VCPKG_INSTALLATION_ROOT/installed
-          vcpkg list
-
-      - name: Upload vcpkg build logs
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ matrix.vcpkg_logs }}
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-
-  test-wheels:
-    name: Test wheels on ${{ matrix.os }} (Python ${{ matrix.python-version }})
-    needs: [build-wheels-linux, build-wheels-mac-win]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-10.15"]
-        python-version: ["3.8", "3.9"]
-        include:
-          # TODO macOS is failing on py 3.10 because of shapely failure
-          - os: "ubuntu-20.04"
-            python-version: "3.10"
-          - os: "windows-latest"
-            python-version: "3.10"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -172,74 +57,224 @@ jobs:
           cache: "pip"
           cache-dependency-path: "ci/requirements-wheel-test.txt"
 
-      - name: Download wheels from artifacts
+      - name: Download sdist from artifacts
         uses: actions/download-artifact@v2
         with:
           path: wheelhouse
 
-      - name: Install dependencies and pyogrio wheel
+      - name: Build from sdist
         shell: bash
         run: |
-          python -m pip install -r ci/requirements-wheel-test.txt
-          python -m pip install --no-deps geopandas
-          python -m pip install --find-links wheelhouse/artifact pyogrio
+          python -m pip install cython~=0.29
+          python -m pip install wheelhouse/*.tar.gz
           python -m pip list
-
-      # TODO temporary set env variable for curl certificate for Linux
-      - name: Set CURL_CA_BUNDLE environment variable
-        if: runner.os == 'Linux'
-        run: |
-          echo "CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
 
       - name: Run tests
         shell: bash
         run: |
           cd ..
+          python -m pip install pytest pandas pyproj shapely
+          python -m pip install --no-deps geopandas
           python -m pytest --pyargs pyogrio.tests -v
 
-  publish:
-    name: Publish pyogrio to GitHub / PyPI
-    needs: [build-sdist, test-wheels]
-    runs-on: ubuntu-latest
-    # release on every tag
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+  # build-wheels-linux:
+  #   name: Build wheels on Linux
+  #   runs-on: "ubuntu-20.04"
 
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@v1
+  #       with:
+  #         install: true
+  #         buildkitd-flags: --debug
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
+  #     - name: Build Docker image with vcpkg and gdal
+  #       # using build-push-action (without push) to make use of cache arguments
+  #       uses: docker/build-push-action@v2
+  #       with:
+  #         context: .
+  #         file: ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+  #         tags: manylinux-vcpkg-gdal:latest
+  #         push: false
+  #         load: true
+  #         cache-from: type=gha
+  #         cache-to: type=gha,mode=max
+  #       env:
+  #         BUILDKIT_PROGRESS: plain
 
-      - name: Get Asset name
-        run: |
-          export PKG=$(ls dist/ | grep tar)
-          set -- $PKG
-          echo "name=$1" >> $GITHUB_ENV
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v2.3.1
 
-      - name: Upload Release Asset (sdist) to GitHub
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/${{ env.name }}
-          asset_name: ${{ env.name }}
-          asset_content_type: application/zip
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  # build-wheels-mac-win:
+  #   name: Build wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: "macos-10.15"
+  #           triplet: "x64-osx-dynamic"
+  #           vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
+  #           vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
+
+  #         - os: "windows-2019"
+  #           triplet: "x64-windows"
+  #           # windows requires windows-specific paths
+  #           vcpkg_cache: "c:\\vcpkg\\installed"
+  #           vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
+
+  #   env:
+  #     MACOSX_DEPLOYMENT_TARGET: "10.15"
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Cache vcpkg
+  #       uses: actions/cache@v3
+  #       id: vcpkgcache
+  #       with:
+  #         path: |
+  #           ${{ matrix.vcpkg_cache }}
+  #         # bump the last digit to avoid using previous build cache
+  #         key: ${{ matrix.os }}-x86_64-vcpkg-gdal3.4.2-cache4
+
+  #     # MacOS build requires aclocal, which is part of automake, but appears
+  #     # to be missing in default image
+  #     - name: Reinstall automake
+  #       if: runner.os == 'macOS'
+  #       run: |
+  #         brew reinstall automake
+  #         echo $(which aclocal)
+
+  #     - name: Install GDAL
+  #       env:
+  #         VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+  #       shell: bash
+  #       run: |
+  #         vcpkg install --overlay-triplets=./ci/custom-triplets --feature-flags="versions,manifests" --x-manifest-root=./ci --x-install-root=$VCPKG_INSTALLATION_ROOT/installed
+  #         vcpkg list
+
+  #     - name: Upload vcpkg build logs
+  #       if: ${{ failure() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ${{ matrix.vcpkg_logs }}
+
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v2.3.1
+
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  # # test-wheels:
+  #   name: Test wheels on ${{ matrix.os }} (Python ${{ matrix.python-version }})
+  #   needs: [build-wheels-linux, build-wheels-mac-win]
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-10.15"]
+  #       python-version: ["3.8", "3.9"]
+  #       include:
+  #         # TODO macOS is failing on py 3.10 because of shapely failure
+  #         - os: "ubuntu-20.04"
+  #           python-version: "3.10"
+  #         - os: "windows-latest"
+  #           python-version: "3.10"
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #         cache: "pip"
+  #         cache-dependency-path: "ci/requirements-wheel-test.txt"
+
+  #     - name: Download wheels from artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: wheelhouse
+
+  #     - name: Install dependencies and pyogrio wheel
+  #       shell: bash
+  #       run: |
+  #         python -m pip install -r ci/requirements-wheel-test.txt
+  #         python -m pip install --no-deps geopandas
+  #         python -m pip install --find-links wheelhouse/artifact pyogrio
+  #         python -m pip list
+
+  #     # TODO temporary set env variable for curl certificate for Linux
+  #     - name: Set CURL_CA_BUNDLE environment variable
+  #       if: runner.os == 'Linux'
+  #       run: |
+  #         echo "CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
+
+  #     - name: Run tests
+  #       shell: bash
+  #       run: |
+  #         cd ..
+  #         python -m pytest --pyargs pyogrio.tests -v
+
+  # publish:
+  #   name: Publish pyogrio to GitHub / PyPI
+  #   needs: [build-sdist, test-wheels]
+  #   runs-on: ubuntu-latest
+  #   # release on every tag
+  #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: artifact
+  #         path: dist
+
+  #     - name: Publish distribution to PyPI
+  #       uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_API_TOKEN }}
+
+  #     - name: Create GitHub Release
+  #       id: create_release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+  #       with:
+  #         tag_name: ${{ github.ref }}
+  #         release_name: ${{ github.ref }}
+  #         draft: false
+  #         prerelease: false
+
+  #     - name: Get Asset name
+  #       run: |
+  #         export PKG=$(ls dist/ | grep tar)
+  #         set -- $PKG
+  #         echo "name=$1" >> $GITHUB_ENV
+
+  #     - name: Upload Release Asset (sdist) to GitHub
+  #       id: upload-release-asset
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: dist/${{ env.name }}
+  #         asset_name: ${{ env.name }}
+  #         asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,6 @@ jobs:
         with:
           path: wheelhouse
 
-      - name: Log paths
-        run: |
-          echo "wheelhouse/*"
-          ls wheelhouse/*
-
       - name: Install python
         run: |
           apt-get update && apt-get install -y python3 python3-pip
@@ -79,204 +74,204 @@ jobs:
           python3 -m pip install --no-cache-dir --no-deps geopandas
           python3 -m pytest --pyargs pyogrio.tests -v
 
-  # build-wheels-linux:
-  #   name: Build wheels on Linux
-  #   runs-on: "ubuntu-20.04"
+  build-wheels-linux:
+    name: Build wheels on Linux
+    runs-on: "ubuntu-20.04"
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up Docker Buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@v1
-  #       with:
-  #         install: true
-  #         buildkitd-flags: --debug
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          buildkitd-flags: --debug
 
-  #     - name: Build Docker image with vcpkg and gdal
-  #       # using build-push-action (without push) to make use of cache arguments
-  #       uses: docker/build-push-action@v2
-  #       with:
-  #         context: .
-  #         file: ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
-  #         tags: manylinux-vcpkg-gdal:latest
-  #         push: false
-  #         load: true
-  #         cache-from: type=gha
-  #         cache-to: type=gha,mode=max
-  #       env:
-  #         BUILDKIT_PROGRESS: plain
+      - name: Build Docker image with vcpkg and gdal
+        # using build-push-action (without push) to make use of cache arguments
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+          tags: manylinux-vcpkg-gdal:latest
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        env:
+          BUILDKIT_PROGRESS: plain
 
-  #     - name: Build wheels
-  #       uses: pypa/cibuildwheel@v2.3.1
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
 
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
 
-  # build-wheels-mac-win:
-  #   name: Build wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - os: "macos-10.15"
-  #           triplet: "x64-osx-dynamic"
-  #           vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
-  #           vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
+  build-wheels-mac-win:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "macos-10.15"
+            triplet: "x64-osx-dynamic"
+            vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
+            vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
 
-  #         - os: "windows-2019"
-  #           triplet: "x64-windows"
-  #           # windows requires windows-specific paths
-  #           vcpkg_cache: "c:\\vcpkg\\installed"
-  #           vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
+          - os: "windows-2019"
+            triplet: "x64-windows"
+            # windows requires windows-specific paths
+            vcpkg_cache: "c:\\vcpkg\\installed"
+            vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
 
-  #   env:
-  #     MACOSX_DEPLOYMENT_TARGET: "10.15"
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - name: Cache vcpkg
-  #       uses: actions/cache@v3
-  #       id: vcpkgcache
-  #       with:
-  #         path: |
-  #           ${{ matrix.vcpkg_cache }}
-  #         # bump the last digit to avoid using previous build cache
-  #         key: ${{ matrix.os }}-x86_64-vcpkg-gdal3.4.2-cache4
+      - name: Cache vcpkg
+        uses: actions/cache@v3
+        id: vcpkgcache
+        with:
+          path: |
+            ${{ matrix.vcpkg_cache }}
+          # bump the last digit to avoid using previous build cache
+          key: ${{ matrix.os }}-x86_64-vcpkg-gdal3.4.2-cache4
 
-  #     # MacOS build requires aclocal, which is part of automake, but appears
-  #     # to be missing in default image
-  #     - name: Reinstall automake
-  #       if: runner.os == 'macOS'
-  #       run: |
-  #         brew reinstall automake
-  #         echo $(which aclocal)
+      # MacOS build requires aclocal, which is part of automake, but appears
+      # to be missing in default image
+      - name: Reinstall automake
+        if: runner.os == 'macOS'
+        run: |
+          brew reinstall automake
+          echo $(which aclocal)
 
-  #     - name: Install GDAL
-  #       env:
-  #         VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
-  #       shell: bash
-  #       run: |
-  #         vcpkg install --overlay-triplets=./ci/custom-triplets --feature-flags="versions,manifests" --x-manifest-root=./ci --x-install-root=$VCPKG_INSTALLATION_ROOT/installed
-  #         vcpkg list
+      - name: Install GDAL
+        env:
+          VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+        shell: bash
+        run: |
+          vcpkg install --overlay-triplets=./ci/custom-triplets --feature-flags="versions,manifests" --x-manifest-root=./ci --x-install-root=$VCPKG_INSTALLATION_ROOT/installed
+          vcpkg list
 
-  #     - name: Upload vcpkg build logs
-  #       if: ${{ failure() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         path: ${{ matrix.vcpkg_logs }}
+      - name: Upload vcpkg build logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ matrix.vcpkg_logs }}
 
-  #     - name: Build wheels
-  #       uses: pypa/cibuildwheel@v2.3.1
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
 
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
 
-  # # test-wheels:
-  #   name: Test wheels on ${{ matrix.os }} (Python ${{ matrix.python-version }})
-  #   needs: [build-wheels-linux, build-wheels-mac-win]
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-10.15"]
-  #       python-version: ["3.8", "3.9"]
-  #       include:
-  #         # TODO macOS is failing on py 3.10 because of shapely failure
-  #         - os: "ubuntu-20.04"
-  #           python-version: "3.10"
-  #         - os: "windows-latest"
-  #           python-version: "3.10"
+  test-wheels:
+    name: Test wheels on ${{ matrix.os }} (Python ${{ matrix.python-version }})
+    needs: [build-wheels-linux, build-wheels-mac-win]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-10.15"]
+        python-version: ["3.8", "3.9"]
+        include:
+          # TODO macOS is failing on py 3.10 because of shapely failure
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+          - os: "windows-latest"
+            python-version: "3.10"
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         cache: "pip"
-  #         cache-dependency-path: "ci/requirements-wheel-test.txt"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "ci/requirements-wheel-test.txt"
 
-  #     - name: Download wheels from artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: wheelhouse
+      - name: Download wheels from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: wheelhouse
 
-  #     - name: Install dependencies and pyogrio wheel
-  #       shell: bash
-  #       run: |
-  #         python -m pip install -r ci/requirements-wheel-test.txt
-  #         python -m pip install --no-deps geopandas
-  #         python -m pip install --find-links wheelhouse/artifact pyogrio
-  #         python -m pip list
+      - name: Install dependencies and pyogrio wheel
+        shell: bash
+        run: |
+          python -m pip install -r ci/requirements-wheel-test.txt
+          python -m pip install --no-deps geopandas
+          python -m pip install --find-links wheelhouse/artifact pyogrio
+          python -m pip list
 
-  #     # TODO temporary set env variable for curl certificate for Linux
-  #     - name: Set CURL_CA_BUNDLE environment variable
-  #       if: runner.os == 'Linux'
-  #       run: |
-  #         echo "CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
+      # TODO temporary set env variable for curl certificate for Linux
+      - name: Set CURL_CA_BUNDLE environment variable
+        if: runner.os == 'Linux'
+        run: |
+          echo "CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
 
-  #     - name: Run tests
-  #       shell: bash
-  #       run: |
-  #         cd ..
-  #         python -m pytest --pyargs pyogrio.tests -v
+      - name: Run tests
+        shell: bash
+        run: |
+          cd ..
+          python -m pytest --pyargs pyogrio.tests -v
 
-  # publish:
-  #   name: Publish pyogrio to GitHub / PyPI
-  #   needs: [build-sdist, test-wheels]
-  #   runs-on: ubuntu-latest
-  #   # release on every tag
-  #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+  publish:
+    name: Publish pyogrio to GitHub / PyPI
+    needs: [build-sdist, test-wheels]
+    runs-on: ubuntu-latest
+    # release on every tag
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
 
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: artifact
-  #         path: dist
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
 
-  #     - name: Publish distribution to PyPI
-  #       uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
-  #     - name: Create GitHub Release
-  #       id: create_release
-  #       uses: actions/create-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-  #       with:
-  #         tag_name: ${{ github.ref }}
-  #         release_name: ${{ github.ref }}
-  #         draft: false
-  #         prerelease: false
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
 
-  #     - name: Get Asset name
-  #       run: |
-  #         export PKG=$(ls dist/ | grep tar)
-  #         set -- $PKG
-  #         echo "name=$1" >> $GITHUB_ENV
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/ | grep tar)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
 
-  #     - name: Upload Release Asset (sdist) to GitHub
-  #       id: upload-release-asset
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
-  #         asset_path: dist/${{ env.name }}
-  #         asset_name: ${{ env.name }}
-  #         asset_content_type: application/zip
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
+      volumes:
+        - ./wheelhouse:wheelhouse
 
     steps:
       - name: Download sdist from artifacts
@@ -62,16 +64,16 @@ jobs:
       - name: Build from sdist
         shell: bash
         run: |
-          python3 -m pip install cython~=0.29
-          python3 -m pip install wheelhouse/*.tar.gz
+          python3 -m pip install --no-cache-dir cython~=0.29
+          python3 -m pip install --no-cache-dir --no-build-isolation wheelhouse/*.tar.gz
           python3 -m pip list
 
       - name: Run tests
         shell: bash
         run: |
           cd ..
-          python3 -m pip install pytest pandas pyproj shapely
-          python3 -m pip install --no-deps geopandas
+          python3 -m pip install --no-cache-dir pytest pandas pyproj shapely
+          python3 -m pip install --no-cache-dir --no-deps geopandas
           python3 -m pytest --pyargs pyogrio.tests -v
 
   # build-wheels-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,23 +55,22 @@ jobs:
         with:
           path: wheelhouse
 
-      - name: Install python
+      - name: Install pip
         run: |
-          apt-get update && apt-get install -y python3 python3-pip
+          apt-get update && apt-get install -y python3-pip
 
-      - name: Build from sdist
+      - name: Build from sdist and install test dependencies
         shell: bash
         run: |
-          python3 -m pip install --no-cache-dir cython~=0.29
-          python3 -m pip install --no-cache-dir --no-build-isolation wheelhouse/artifact/*.tar.gz
+          python3 -m pip install --no-cache-dir wheelhouse/artifact/*.tar.gz
+          python3 -m pip install --no-cache-dir pytest pandas pyproj shapely
+          python3 -m pip install --no-cache-dir --no-deps geopandas
           python3 -m pip list
 
       - name: Run tests
         shell: bash
         run: |
           cd ..
-          python3 -m pip install --no-cache-dir pytest pandas pyproj shapely
-          python3 -m pip install --no-cache-dir --no-deps geopandas
           python3 -m pytest --pyargs pyogrio.tests -v
 
   build-wheels-linux:
@@ -231,7 +230,7 @@ jobs:
 
   publish:
     name: Publish pyogrio to GitHub / PyPI
-    needs: [build-sdist, test-wheels]
+    needs: [test-sdist, test-wheels]
     runs-on: ubuntu-latest
     # release on every tag
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
-      volumes:
-        - /__w/pyogrio/pyogrio/wheelhouse/artifact:/wheelhouse
 
     steps:
       - name: Download sdist from artifacts
@@ -61,8 +59,6 @@ jobs:
         run: |
           echo "wheelhouse/*"
           ls wheelhouse/*
-          echo "/wheelhouse/*"
-          ls /wheelhouse/*
 
       - name: Install python
         run: |
@@ -72,7 +68,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --no-cache-dir cython~=0.29
-          python3 -m pip install --no-cache-dir --no-build-isolation /wheelhouse/*.tar.gz
+          python3 -m pip install --no-cache-dir --no-build-isolation wheelhouse/artifact/*.tar.gz
           python3 -m pip list
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,32 +50,29 @@ jobs:
       image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "ci/requirements-wheel-test.txt"
-
       - name: Download sdist from artifacts
         uses: actions/download-artifact@v2
         with:
           path: wheelhouse
 
+      - name: Install python
+        run: |
+          apt-get update && apt-get install -y python3 python3-pip
+
       - name: Build from sdist
         shell: bash
         run: |
-          python -m pip install cython~=0.29
-          python -m pip install wheelhouse/*.tar.gz
-          python -m pip list
+          python3 -m pip install cython~=0.29
+          python3 -m pip install wheelhouse/*.tar.gz
+          python3 -m pip list
 
       - name: Run tests
         shell: bash
         run: |
           cd ..
-          python -m pip install pytest pandas pyproj shapely
-          python -m pip install --no-deps geopandas
-          python -m pytest --pyargs pyogrio.tests -v
+          python3 -m pip install pytest pandas pyproj shapely
+          python3 -m pip install --no-deps geopandas
+          python3 -m pytest --pyargs pyogrio.tests -v
 
   # build-wheels-linux:
   #   name: Build wheels on Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     container:
       image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
       volumes:
-        - ./wheelhouse:wheelhouse
+        - /__w/pyogrio/pyogrio/wheelhouse/artifact:/wheelhouse
 
     steps:
       - name: Download sdist from artifacts
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --no-cache-dir cython~=0.29
-          python3 -m pip install --no-cache-dir --no-build-isolation wheelhouse/*.tar.gz
+          python3 -m pip install --no-cache-dir --no-build-isolation /wheelhouse/*.tar.gz
           python3 -m pip list
 
       - name: Run tests


### PR DESCRIPTION
Adds a specific test to the release builds to ensure that the source distribution can be successfully built (just using the GDAL container to keep this easy) and prevent future occurrences of broken sdist builds (xref #76).