### PR TITLE
Correctly write mixed geometry types

### DIFF
--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -190,11 +190,12 @@ def write_dataframe(df, path, layer=None, driver=None, encoding=None, **kwargs):
     # TODO: may need to fill in pd.NA, etc
     field_data = [df[f].values for f in fields]
 
+    geometry_type = "Unknown"
     if not df.empty:
         # TODO: validate geometry types, not all combinations are valid
-        geometry_type = geometry.type.unique()[0]
-    else:
-        geometry_type = "Unknown"
+        geometry_types = geometry.type.unique()
+        if len(geometry_types) == 1:
+            geometry_type = geometry_types[0]
 
     crs = None
     if geometry.crs:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -5,8 +5,8 @@ import pandas as pd
 from pandas.testing import assert_frame_equal, assert_index_equal
 import pytest
 
-from pyogrio import list_layers
-from pyogrio.errors import DataLayerError
+from pyogrio import list_layers, read_info
+from pyogrio.errors import DataLayerError, FeatureError
 from pyogrio.geopandas import read_dataframe, write_dataframe
 
 try:
@@ -257,6 +257,44 @@ def test_write_empty_dataframe(tmpdir, driver, ext):
     df = read_dataframe(filename)
 
     assert_geodataframe_equal(df, expected)
+
+
+@pytest.mark.parametrize(
+    "driver,ext", [("GeoJSON", "geojson"), ("GPKG", "gpkg"), ("FlatGeobuf", "fbg")]
+)
+def test_write_mixed_geometries(tmp_path, driver, ext):
+    from shapely.geometry import Point, LineString, box
+
+    df = gp.GeoDataFrame(
+        {"col": [1.0, 2.0, 3.0]},
+        geometry=[Point(0, 0), LineString([(0, 0), (1, 1)]), box(0, 0, 1, 1)],
+        crs="EPSG:4326"
+    )
+
+    filename = tmp_path / f"test.{ext}"
+    write_dataframe(df, filename, driver=driver)
+
+    assert read_info(filename)["geometry_type"] == "Unknown"
+    result = read_dataframe(filename)
+    if driver == "FlatGeobuf":
+        # FlatGeobuf results in mixed row order in case of mixed geometries
+        result = result.sort_values("col").reset_index(drop=True)
+    assert_geodataframe_equal(result, df)
+
+
+def test_write_mixed_geometries_unsupported(tmp_path):
+    # Shapefile doesn't support generic "Geometry" / "Unknown" type
+    # for mixed geometries
+    from shapely.geometry import Point, LineString, box
+
+    df = gp.GeoDataFrame(
+        {"col": [1.0, 2.0, 3.0]},
+        geometry=[Point(0, 0), LineString([(0, 0), (1, 1)]), box(0, 0, 1, 1)],
+        crs="EPSG:4326"
+    )
+
+    with pytest.raises(FeatureError):
+        write_dataframe(df, tmp_path / "test.shp", driver="ESRI Shapefile")
 
 
 def test_write_dataframe_gdalparams(tmp_path, naturalearth_lowres):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -260,7 +260,7 @@ def test_write_empty_dataframe(tmpdir, driver, ext):
 
 
 @pytest.mark.parametrize(
-    "driver,ext", [("GeoJSON", "geojson"), ("GPKG", "gpkg"), ("FlatGeobuf", "fbg")]
+    "driver,ext", [("GeoJSON", "geojson"), ("GPKG", "gpkg"), ("FlatGeobuf", "fgb")]
 )
 def test_write_mixed_geometries(tmp_path, driver, ext):
     from shapely.geometry import Point, LineString, box

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -274,6 +274,7 @@ def test_write_mixed_geometries(tmp_path, driver, ext):
     filename = tmp_path / f"test.{ext}"
     write_dataframe(df, filename, driver=driver)
 
+    # Drivers that support mixed geometries will default to "Unknown" geometry type
     assert read_info(filename)["geometry_type"] == "Unknown"
     result = read_dataframe(filename)
     if driver == "FlatGeobuf":
@@ -293,7 +294,8 @@ def test_write_mixed_geometries_unsupported(tmp_path):
         crs="EPSG:4326"
     )
 
-    with pytest.raises(FeatureError):
+    # TODO propagate better error message from GDAL
+    with pytest.raises(FeatureError, match="Could not add feature to layer"):
         write_dataframe(df, tmp_path / "test.shp", driver="ESRI Shapefile")
 
 


### PR DESCRIPTION
Related to the discussion in https://github.com/geopandas/pyogrio/pull/75

This is a very simple change (not yet trying to detect if mixed geometries are truly mixed or only single/multi of the same type): if there is more than 1 geometry type, we create the GDAL dataset with "Unknown" geometry type ("Unknown" here is the slightly confusing name for "any" geometry type: *Use wkbUnknown if there are no constraints on the types geometry to be written.* from https://gdal.org/api/raster_c_api.html#gdal_8h_1a7f01d3d8584f29e4ef3c56b5af49d816) 

This is consistent with what Fiona (and therefore geopandas) currently does. 
And I would argue that this is also what GDAL does to some extent (although it is of course not exactly equivalent situation). If you start from a source like GeoJSON which does not encode geometry type information and can store any mix of types (thus, very similar to a GeoDataFrame), GDAL (or `ogrinfo`) will infer it as "Unknown (any)", and for example when converting this GeoJSON file to a GPKG using `ogr2ogr` it will keep this "Unknown" geometry type. 

Without this change, the tests that I added would fail (except for GeoJSON): for GPKG it "works" but sets a "Point" geometry type in the file, which is thus a "wrong" file. For FGB it actually errors. 