### PR TITLE
ENH: expose geometry_type keyword in write_dataframe to manually set type

### DIFF
--- a/pyogrio/_geometry.pxd
+++ b/pyogrio/_geometry.pxd
@@ -1,2 +1,2 @@
 cdef str get_geometry_type(void *ogr_layer)
-cdef int get_geometry_type_code(str geometry_type)
+cdef int get_geometry_type_code(str geometry_type) except *

--- a/pyogrio/_geometry.pyx
+++ b/pyogrio/_geometry.pyx
@@ -101,7 +101,7 @@ cdef str get_geometry_type(void *ogr_layer):
     return GEOMETRY_TYPES[ogr_type]
 
 
-cdef int get_geometry_type_code(str geometry_type):
+cdef int get_geometry_type_code(str geometry_type) except *:
     """Get geometry type code for string geometry type.
 
     Parameters

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -136,7 +136,9 @@ def read_dataframe(
 
 
 # TODO: handle index properly
-def write_dataframe(df, path, layer=None, driver=None, encoding=None, **kwargs):
+def write_dataframe(
+    df, path, layer=None, driver=None, encoding=None, geometry_type=None, **kwargs
+):
     """
     Write GeoPandas GeoDataFrame to an OGR file format.
 
@@ -152,6 +154,12 @@ def write_dataframe(df, path, layer=None, driver=None, encoding=None, **kwargs):
     encoding : str, optional (default: None)
         If present, will be used as the encoding for writing string values to
         the file.
+    geometry_type : string, optional (default: None)
+        The geometry type for the dataset layer that will be written.
+        By default will be inferred from the data, but this parameter allows
+        to override this and specify the geometry type manually. Possible
+        values: 'Unknown', 'Point', 'LineString', 'Polygon', 'MultiPoint',
+        'MultiLineString', 'MultiPolygon', 'GeometryCollection'.
 
     **kwargs
         The kwargs passed to OGR.
@@ -190,11 +198,12 @@ def write_dataframe(df, path, layer=None, driver=None, encoding=None, **kwargs):
     # TODO: may need to fill in pd.NA, etc
     field_data = [df[f].values for f in fields]
 
-    if not df.empty:
-        # TODO: validate geometry types, not all combinations are valid
-        geometry_type = geometry.type.unique()[0]
-    else:
-        geometry_type = "Unknown"
+    if geometry_type is None:
+        if not df.empty:
+            # TODO: validate geometry types, not all combinations are valid
+            geometry_type = geometry.type.unique()[0]
+        else:
+            geometry_type = "Unknown"
 
     crs = None
     if geometry.crs:

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -156,7 +156,7 @@ def write_dataframe(
         the file.
     geometry_type : string, optional (default: None)
         The geometry type for the dataset layer that will be written.
-        By default will be inferred from the data, but this parameter allows
+        By default will be inferred from the data, but this parameter allows you
         to override this and specify the geometry type manually. Possible
         values: 'Unknown', 'Point', 'LineString', 'Polygon', 'MultiPoint',
         'MultiLineString', 'MultiPolygon', 'GeometryCollection'.

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -267,7 +267,7 @@ def test_write_dataframe_geometry_type(tmp_path, naturalearth_lowres):
     write_dataframe(df, filename, geometry_type="MultiPolygon")
     assert read_info(filename)["geometry_type"] == "MultiPolygon"
 
-    with pytest.raises(GeometryError):
+    with pytest.raises(GeometryError, match="Geometry type is not supported: NotSupported"):
         write_dataframe(df, filename, geometry_type="NotSupported")
 
 


### PR DESCRIPTION
Another small PR related to the discussions in https://github.com/geopandas/pyogrio/pull/75 and https://github.com/geopandas/pyogrio/pull/82. Regardless of the eventual outcome about what kind of default behaviour for inferring the geometry type we end up with, I think we will always want to give the option to overrule that by the user? 
So therefore this PR is already exposing the existing `geometry_type` keyword in the `write_dataframe` function (currently it only exists in the `pyogrio.raw.write(..)`.

(I was using this locally anyway to experiment with the geometry type impact)