### PR TITLE
Propagate GDAL error message when geometry cannot be added to the layer

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1352,9 +1352,10 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
 
 
             # Add feature to the layer
-            err = OGR_L_CreateFeature(ogr_layer, ogr_feature)
-            if err:
-                raise FeatureError(f"Could not add feature to layer at index {i}")
+            try:
+                exc_wrap_int(OGR_L_CreateFeature(ogr_layer, ogr_feature))
+            except CPLE_BaseError as exc:
+                raise FeatureError(f"Could not add feature to layer at index {i}: {exc}") from None
 
         finally:
             if ogr_feature != NULL:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -501,8 +501,12 @@ def test_write_mixed_geometries_unsupported(tmp_path):
         crs="EPSG:4326"
     )
 
-    # TODO propagate better error message from GDAL
-    with pytest.raises(FeatureError, match="Could not add feature to layer"):
+    # ensure error message from GDAL is included
+    msg = (
+        "Could not add feature to layer at index 1: Attempt to "
+        r"write non-point \(LINESTRING\) geometry to point shapefile."
+    )
+    with pytest.raises(FeatureError, match=msg):
         write_dataframe(df, tmp_path / "test.shp", driver="ESRI Shapefile")
 
 


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/pyogrio/pull/82 to give a more informative error message of the GDAL driver errors in case of mixed geometries