### PR TITLE
Fix "no features to read" warning in "test_read_where_invalid"

### DIFF
--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -178,6 +178,7 @@ def test_read_where(naturalearth_lowres_all_ext):
     assert len(df) == 0
 
 
+@pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 def test_read_where_invalid(naturalearth_lowres_all_ext):
     if naturalearth_lowres_all_ext.suffix in [".gpkg"]:
         # Geopackage doesn't raise, but returns empty df?


### PR DESCRIPTION
Fixes warning in the tests:

pyogrio/tests/test_geopandas_io.py::test_read_where_invalid[.gpkg]
  /__w/pyogrio/pyogrio/pyogrio/raw.py:1[26](https://github.com/geopandas/pyogrio/runs/6164109003?check_suite_focus=true#step:6:26): UserWarning: Layer 'b'naturalearth_lowres'' does not have any features to read
    result = ogr_read(