### PR TITLE
Use certifi to set GDAL_CURL_CA_BUNDLE / PROJ_CURL_CA_BUNDLE defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,12 +216,6 @@ jobs:
           python -m pip install --find-links wheelhouse/artifact pyogrio
           python -m pip list
 
-      # TODO temporary set env variable for curl certificate for Linux
-      - name: Set CURL_CA_BUNDLE environment variable
-        if: runner.os == 'Linux'
-        run: |
-          echo "CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
-
       - name: Run tests
         shell: bash
         run: |

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - certifi
   - numpy
   - libgdal
   - pytest

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,6 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
+  - certifi
   - numpy
   - libgdal
   - pytest

--- a/pyogrio/_env.py
+++ b/pyogrio/_env.py
@@ -15,8 +15,19 @@ import sys
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-gdal_dll_dir = None
 
+try:
+    # set GDAL_CURL_CA_BUNDLE / PROJ_CURL_CA_BUNDLE for GDAL >= 3.2
+    import certifi
+
+    ca_bundle = certifi.where()
+    os.environ.setdefault("GDAL_CURL_CA_BUNDLE", ca_bundle)
+    os.environ.setdefault("PROJ_CURL_CA_BUNDLE", ca_bundle)
+except ImportError:
+    pass
+
+
+gdal_dll_dir = None
 
 if platform.system() == "Windows" and sys.version_info >= (3, 8):
     # if loading of extension modules fails, search for gdal dll directory

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ setup(
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
     python_requires=">=3.8",
-    install_requires=["numpy"],
+    install_requires=["certifi", "numpy"],
     extras_require={
         "dev": ["Cython"],
         "test": ["pytest", "pytest-cov"],


### PR DESCRIPTION
Resolves #66

This makes `certifi` and installation requirement and follows approach from [Fiona #1095](https://github.com/Toblerity/Fiona/pull/1095) and [rasterio #2459](https://github.com/rasterio/rasterio/pull/2459)