### PR TITLE
CI: Try setting blosc version manually for conda test environment

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,3 +7,6 @@ dependencies:
   - pytest
   - pygeos
   - geopandas-base
+
+  # temporary: to get around issues with GDAL using libblosc 1.21.1
+  - blosc==1.21.0


### PR DESCRIPTION
We're running into CI errors with GDAL loading Blosc dynamically; looks possibly related to recent updates with blosc package on conda-forge.