### PR TITLE
Add auto detection of driver for .geojson, .geojsonl and .geojsons files

### DIFF
--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -14,6 +14,8 @@ DRIVERS = {
     ".gpkg": "GPKG",
     ".shp": "ESRI Shapefile",
     ".json": "GeoJSON",
+    ".geojson": "GeoJSON",
+    ".geojsons": "GeoJSONSeq",
     ".fgb": "FlatGeobuf",
 }
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -16,6 +16,7 @@ DRIVERS = {
     ".json": "GeoJSON",
     ".geojson": "GeoJSON",
     ".geojsons": "GeoJSONSeq",
+    ".geojsonl": "GeoJSONSeq",
     ".fgb": "FlatGeobuf",
 }
 

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -8,7 +8,7 @@ import pyogrio
 
 
 _data_dir = Path(__file__).parent.resolve() / "fixtures"
-ALL_EXTS = [".shp", ".gpkg", ".geojson", ".geojsons"]
+ALL_EXTS = [".shp", ".gpkg", ".geojson", ".geojsonl", ".geojsons"]
 
 
 def pytest_report_header(config):

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -8,7 +8,7 @@ import pyogrio
 
 
 _data_dir = Path(__file__).parent.resolve() / "fixtures"
-ALL_EXTS = [".shp", ".gpkg", ".geojson", ".geojsonl", ".geojsons"]
+ALL_EXTS = [".shp", ".gpkg", ".geojson", ".geojsonl"]
 
 
 def pytest_report_header(config):

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -8,7 +8,7 @@ import pyogrio
 
 
 _data_dir = Path(__file__).parent.resolve() / "fixtures"
-ALL_EXTS = [".shp", ".gpkg", ".json"]
+ALL_EXTS = [".shp", ".gpkg", ".geojson", ".geojsons"]
 
 
 def pytest_report_header(config):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -447,25 +447,21 @@ def test_write_dataframe(tmpdir, naturalearth_lowres, driver, ext):
 
 
 @pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
-@pytest.mark.parametrize(
-    "driver,ext", [("ESRI Shapefile", "shp"), ("GeoJSON", "geojson"), ("GPKG", "gpkg")]
-)
-def test_write_empty_dataframe(tmpdir, driver, ext):
+@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".geojsons"])
+def test_write_empty_dataframe(tmp_path, ext):
     expected = gp.GeoDataFrame(geometry=[], crs=4326)
 
-    filename = os.path.join(str(tmpdir), f"test.{ext}")
-    write_dataframe(expected, filename, driver=driver)
+    filename = tmp_path / f"test{ext}"
+    write_dataframe(expected, filename)
 
-    assert os.path.exists(filename)
-
+    assert filename.exists()
     df = read_dataframe(filename)
-
     assert_geodataframe_equal(df, expected)
 
 
 def test_write_empty_dataframe_unsupported(tmp_path):
-    # Writing empty dataframe to .geojsons results in a 0 byte file, which
-    # is invalid to read again.
+    # Writing empty dataframe to .geojsons results in a 0 byte file, which is invalid 
+    # to read again. More info here: https://github.com/geopandas/pyogrio/issues/94
     expected = gp.GeoDataFrame(geometry=[], crs=4326)
 
     filename = tmp_path / "test.geojsons"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -447,7 +447,9 @@ def test_write_dataframe(tmpdir, naturalearth_lowres, driver, ext):
 
 
 @pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
-@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".geojsons"])
+@pytest.mark.parametrize(
+    "ext", [ext for ext in ALL_EXTS if ext not in [".geojsonl", ".geojsons"]]
+)
 def test_write_empty_dataframe(tmp_path, ext):
     expected = gp.GeoDataFrame(geometry=[], crs=4326)
 
@@ -459,12 +461,13 @@ def test_write_empty_dataframe(tmp_path, ext):
     assert_geodataframe_equal(df, expected)
 
 
-def test_write_empty_dataframe_unsupported(tmp_path):
-    # Writing empty dataframe to .geojsons results in a 0 byte file, which is invalid 
+@pytest.mark.parametrize("ext", [".geojsonl", ".geojsons"])
+def test_write_empty_dataframe_unsupported(tmp_path, ext):
+    # Writing empty dataframe to .geojsons results in a 0 byte file, which is invalid
     # to read again. More info here: https://github.com/geopandas/pyogrio/issues/94
     expected = gp.GeoDataFrame(geometry=[], crs=4326)
 
-    filename = tmp_path / "test.geojsons"
+    filename = tmp_path / f"test{ext}"
     write_dataframe(expected, filename)
 
     assert filename.exists()

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -462,9 +462,10 @@ def test_write_empty_dataframe(tmp_path, ext):
 
 
 @pytest.mark.parametrize("ext", [".geojsonl", ".geojsons"])
-def test_write_empty_dataframe_unsupported(tmp_path, ext):
-    # Writing empty dataframe to .geojsons results in a 0 byte file, which is invalid
-    # to read again. More info here: https://github.com/geopandas/pyogrio/issues/94
+def test_write_read_empty_dataframe_unsupported(tmp_path, ext):
+    # Writing empty dataframe to .geojsons or .geojsonl results logically in a 0 byte
+    # file, but gdal isn't able to read those again at the time of writing.
+    # Issue logged here: https://github.com/geopandas/pyogrio/issues/94
     expected = gp.GeoDataFrame(geometry=[], crs=4326)
 
     filename = tmp_path / f"test{ext}"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -463,6 +463,21 @@ def test_write_empty_dataframe(tmpdir, driver, ext):
     assert_geodataframe_equal(df, expected)
 
 
+def test_write_empty_dataframe_unsupported(tmp_path):
+    # Writing empty dataframe to .geojsons results in a 0 byte file, which
+    # is invalid to read again.
+    expected = gp.GeoDataFrame(geometry=[], crs=4326)
+
+    filename = tmp_path / "test.geojsons"
+    write_dataframe(expected, filename)
+
+    assert filename.exists()
+    with pytest.raises(
+        Exception, match=".* not recognized as a supported file format."
+    ):
+        _ = read_dataframe(filename)
+
+
 def test_write_dataframe_gdalparams(tmp_path, naturalearth_lowres):
     original_df = read_dataframe(naturalearth_lowres)
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -11,31 +11,6 @@ from pyogrio.errors import DataSourceError, DataLayerError, FeatureError
 from pyogrio.tests.conftest import prepare_testfile
 
 
-@pytest.mark.parametrize("ext", DRIVERS)
-def test_autodetect_driver(tmp_path, naturalearth_lowres, ext):
-    # Test all supported autodetect drivers
-    testfile = prepare_testfile(naturalearth_lowres, dst_dir=tmp_path, ext=ext)
-
-    assert testfile.suffix == ext
-    assert testfile.exists()
-    meta, _, geometry, fields = read(testfile)
-
-    assert meta["crs"] == "EPSG:4326"
-    assert meta["encoding"] == "UTF-8"
-    assert meta["fields"].shape == (5,)
-
-    assert meta["fields"].tolist() == [
-        "pop_est",
-        "continent",
-        "name",
-        "iso_a3",
-        "gdp_md_est",
-    ]
-
-    assert len(fields) == 5
-    assert len(geometry) == len(fields[0])
-
-
 def test_read(naturalearth_lowres):
     meta, _, geometry, fields = read(naturalearth_lowres)
 
@@ -57,6 +32,32 @@ def test_read(naturalearth_lowres):
 
     # quick test that WKB is a Polygon type
     assert geometry[0][:6] == b"\x01\x06\x00\x00\x00\x03"
+
+
+@pytest.mark.parametrize("ext", DRIVERS)
+def test_read_autodetect_driver(tmp_path, naturalearth_lowres, ext):
+    # Test all supported autodetect drivers
+    testfile = prepare_testfile(naturalearth_lowres, dst_dir=tmp_path, ext=ext)
+
+    assert testfile.suffix == ext
+    assert testfile.exists()
+    meta, _, geometry, fields = read(testfile)
+
+    assert meta["crs"] == "EPSG:4326"
+    assert meta["geometry_type"] in ("Polygon", "Unknown")
+    assert meta["encoding"] == "UTF-8"
+    assert meta["fields"].shape == (5,)
+
+    assert meta["fields"].tolist() == [
+        "pop_est",
+        "continent",
+        "name",
+        "iso_a3",
+        "gdp_md_est",
+    ]
+
+    assert len(fields) == 5
+    assert len(geometry) == len(fields[0])
 
 
 def test_read_invalid_layer(naturalearth_lowres):

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -18,10 +18,9 @@ def test_autodetect_driver(tmp_path, naturalearth_lowres, ext):
 
     assert testfile.suffix == ext
     assert testfile.exists()
-    meta, _, geometry, fields = read(naturalearth_lowres)
+    meta, _, geometry, fields = read(testfile)
 
     assert meta["crs"] == "EPSG:4326"
-    assert meta["geometry_type"] == "Polygon"
     assert meta["encoding"] == "UTF-8"
     assert meta["fields"].shape == (5,)
 
@@ -35,9 +34,6 @@ def test_autodetect_driver(tmp_path, naturalearth_lowres, ext):
 
     assert len(fields) == 5
     assert len(geometry) == len(fields[0])
-
-    # quick test that WKB is a Polygon type
-    assert geometry[0][:6] == b"\x01\x06\x00\x00\x00\x03"
 
 
 def test_read(naturalearth_lowres):

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -6,8 +6,38 @@ from numpy import array_equal
 import pytest
 
 from pyogrio import list_layers, list_drivers
-from pyogrio.raw import read, write
+from pyogrio.raw import DRIVERS, read, write
 from pyogrio.errors import DataSourceError, DataLayerError, FeatureError
+from pyogrio.tests.conftest import prepare_testfile
+
+
+@pytest.mark.parametrize("ext", DRIVERS)
+def test_autodetect_driver(tmp_path, naturalearth_lowres, ext):
+    # Test all supported autodetect drivers
+    testfile = prepare_testfile(naturalearth_lowres, dst_dir=tmp_path, ext=ext)
+
+    assert testfile.suffix == ext
+    assert testfile.exists()
+    meta, _, geometry, fields = read(naturalearth_lowres)
+
+    assert meta["crs"] == "EPSG:4326"
+    assert meta["geometry_type"] == "Polygon"
+    assert meta["encoding"] == "UTF-8"
+    assert meta["fields"].shape == (5,)
+
+    assert meta["fields"].tolist() == [
+        "pop_est",
+        "continent",
+        "name",
+        "iso_a3",
+        "gdp_md_est",
+    ]
+
+    assert len(fields) == 5
+    assert len(geometry) == len(fields[0])
+
+    # quick test that WKB is a Polygon type
+    assert geometry[0][:6] == b"\x01\x06\x00\x00\x00\x03"
 
 
 def test_read(naturalearth_lowres):
@@ -407,4 +437,3 @@ def test_read_data_types_numeric_with_null(test_gpkg_nulls):
             assert field.dtype == "float32"
         else:
             assert field.dtype == "float64"
-


### PR DESCRIPTION
\+ add to file formats that should be tested.

Issue found: writing empty file to .geojsons is appartently not supported: logged here: #94