### PR TITLE
ENH: consistent handling of path or buffer in read functions

### DIFF
--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -67,12 +67,12 @@ def list_layers(path_or_buffer, /):
         array of pairs of [<layer name>, <layer geometry type>]
         Note: geometry is `None` for nonspatial layers.
     """
-    path, from_buffer = get_vsi_path(path_or_buffer)
+    path, buffer = get_vsi_path(path_or_buffer)
 
     try:
         result = ogr_list_layers(path)
     finally:
-        if from_buffer:
+        if buffer is not None:
             remove_virtual_file(path)
     return result
 
@@ -115,7 +115,7 @@ def read_bounds(
         fids are global IDs read from the FID field of the dataset
         bounds are ndarray of shape(4, n) containig ``xmin``, ``ymin``, ``xmax``, ``ymax``
     """
-    path, from_buffer = get_vsi_path(path_or_buffer)
+    path, buffer = get_vsi_path(path_or_buffer)
 
     try:   
         result = ogr_read_bounds(
@@ -127,7 +127,7 @@ def read_bounds(
             bbox=bbox,
         )
     finally:
-        if from_buffer:
+        if buffer is not None:
             remove_virtual_file(path)
     return result
 
@@ -162,12 +162,12 @@ def read_info(path_or_buffer, /, layer=None, encoding=None):
                 "features": <feature count>
             }
     """
-    path, from_buffer = get_vsi_path(path_or_buffer)
+    path, buffer = get_vsi_path(path_or_buffer)
 
     try:   
         result = ogr_read_info(path, layer=layer, encoding=encoding)
     finally:
-        if from_buffer:
+        if buffer is not None:
             remove_virtual_file(path)
     return result
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -3,11 +3,11 @@ import os
 
 from pyogrio._env import GDALEnv
 from pyogrio.errors import DataSourceError
-from pyogrio.util import vsi_path
+from pyogrio.util import get_vsi_path
 
 with GDALEnv():
     from pyogrio._io import ogr_read, ogr_read_info, ogr_list_layers, ogr_write
-    from pyogrio._ogr import buffer_to_virtual_file, remove_virtual_file
+    from pyogrio._ogr import remove_virtual_file
 
 
 DRIVERS = {
@@ -103,21 +103,7 @@ def read(
             "geometry": "<geometry type>"
         }
     """
-    if hasattr(path_or_buffer, "read"):
-        path_or_buffer = path_or_buffer.read()
-
-    from_buffer = False
-    if isinstance(path_or_buffer, bytes):
-        from_buffer = True
-        ext = ""
-        is_zipped = path_or_buffer[:4].startswith(b'PK\x03\x04')
-        if is_zipped:
-            ext = ".zip"
-        path = buffer_to_virtual_file(path_or_buffer, ext=ext)
-        if is_zipped:
-            path = "/vsizip/" + path
-    else:
-        path = vsi_path(str(path_or_buffer))
+    path, from_buffer = get_vsi_path(path_or_buffer)
 
     try:
         result = ogr_read(

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -111,7 +111,7 @@ def read(
             "geometry": "<geometry type>"
         }
     """
-    path, from_buffer = get_vsi_path(path_or_buffer)
+    path, buffer = get_vsi_path(path_or_buffer)
 
     try:
         result = ogr_read(
@@ -131,7 +131,7 @@ def read(
             return_fids=return_fids,
         )
     finally:
-        if from_buffer:
+        if buffer is not None:
             remove_virtual_file(path)
 
     return result

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -13,9 +13,9 @@ def get_vsi_path(path_or_buffer):
     if hasattr(path_or_buffer, "read"):
         path_or_buffer = path_or_buffer.read()
 
-    from_buffer = False
+    buffer = None
     if isinstance(path_or_buffer, bytes):
-        from_buffer = True
+        buffer = path_or_buffer
         ext = ""
         is_zipped = path_or_buffer[:4].startswith(b'PK\x03\x04')
         if is_zipped:
@@ -26,7 +26,7 @@ def get_vsi_path(path_or_buffer):
     else:
         path = vsi_path(str(path_or_buffer))
 
-    return path, from_buffer
+    return path, buffer
 
 
 def vsi_path(path: str) -> str:

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -2,6 +2,32 @@ import re
 import sys
 from urllib.parse import urlparse
 
+from pyogrio._env import GDALEnv
+
+with GDALEnv():
+    from pyogrio._ogr import buffer_to_virtual_file
+
+
+def get_vsi_path(path_or_buffer):
+
+    if hasattr(path_or_buffer, "read"):
+        path_or_buffer = path_or_buffer.read()
+
+    from_buffer = False
+    if isinstance(path_or_buffer, bytes):
+        from_buffer = True
+        ext = ""
+        is_zipped = path_or_buffer[:4].startswith(b'PK\x03\x04')
+        if is_zipped:
+            ext = ".zip"
+        path = buffer_to_virtual_file(path_or_buffer, ext=ext)
+        if is_zipped:
+            path = "/vsizip/" + path
+    else:
+        path = vsi_path(str(path_or_buffer))
+
+    return path, from_buffer
+
 
 def vsi_path(path: str) -> str:
     """


### PR DESCRIPTION
Currently we have the custom logic to also handle buffers or file-like objects inside `pyogrio.raw.read` (and thus used for `read_dataframe`), but `list_layers` only takes a string path, and `read_info` and `read_bounds` as well (although those will already prepare your string path into a vsi path). 

I think it can be useful to make this input path/buffer handling consistent for all read functions? 