### PR TITLE
Add --no-use-pep517 to get around pip oldest-supported-numpy issue

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python3 -m pip install --no-cache-dir -U pip wheel
-          python3 -m pip install --no-cache-dir cython~=0.29
-          python3 -m pip install --no-cache-dir --no-build-isolation --no-use-pep517 -e .[dev,test,geopandas]
+          python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python3 -m pip install --no-cache-dir -U pip wheel
           python3 -m pip install --no-cache-dir cython~=0.29
-          python3 -m pip install --no-cache-dir --no-build-isolation -e .[dev,test,geopandas]
+          python3 -m pip install --no-cache-dir --no-build-isolation --no-use-pep517 -e .[dev,test,geopandas]
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
Resolves #107 

As I understand it, a recent pip upgrade now runs into issues with `oldest-supported-numpy` declared in `pyproject.toml` when running with `--no-build-isolation` when `numpy` isn't yet installed.  The fix is to add `--no-use-pep517`.

This updates to do the same thing as pandas: https://github.com/pandas-dev/pandas/pull/47015