### PR TITLE
ENH: read DateTime fields with millisecond accuracy

### DIFF
--- a/docs/source/known_issues.md
+++ b/docs/source/known_issues.md
@@ -54,3 +54,12 @@ with obscure error messages.
 
 Date fields are not yet fully supported. These will be supported in a future
 release.
+
+## Support for reading and writing DateTimes
+
+Currently only reading datetime values is supported.
+
+GDAL only supports datetimes at a millisecond resolution. Reading data will thus
+give at most millisecond resolution (`datetime64[ms]` data type), even though
+the data is cast `datetime64[ns]` data type when reading into a data frame
+using `pyogrio.read_dataframe()`.

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -43,7 +43,7 @@ FIELD_TYPES = [
     'object',        #  OFTBinary, Raw Binary data
     'datetime64[D]', # OFTDate, Date
     None,            # OFTTime, Time, NOTE: not directly supported in numpy
-    'datetime64[us]',# OFTDateTime, Date and Time
+    'datetime64[ms]',# OFTDateTime, Date and Time
     'int64',         # OFTInteger64, Single 64bit integer
     None             # OFTInteger64List, List of 64bit integers, not supported
 ]

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -197,7 +197,7 @@ cdef extern from "ogr_api.h":
     int64_t         OGR_F_GetFID(OGRFeatureH feature)
     OGRGeometryH    OGR_F_GetGeometryRef(OGRFeatureH feature)
     GByte*          OGR_F_GetFieldAsBinary(OGRFeatureH feature, int n, int *s)
-    int             OGR_F_GetFieldAsDateTime(OGRFeatureH feature, int n, int *y, int *m, int *d, int *h, int *m, int *s, int *z)
+    int             OGR_F_GetFieldAsDateTimeEx(OGRFeatureH feature, int n, int *y, int *m, int *d, int *h, int *m, float *s, int *z)
     double          OGR_F_GetFieldAsDouble(OGRFeatureH feature, int n)
     int             OGR_F_GetFieldAsInteger(OGRFeatureH feature, int n)
     long            OGR_F_GetFieldAsInteger64(OGRFeatureH feature, int n)

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -80,3 +80,8 @@ def test_gpkg_nulls():
 @pytest.fixture(scope="session")
 def test_ogr_types_list():
     return _data_dir / "test_ogr_types_list.geojson"
+
+
+@pytest.fixture(scope="session")
+def test_datetime():
+    return _data_dir / "test_datetime.geojson"

--- a/pyogrio/tests/fixtures/test_datetime.geojson
+++ b/pyogrio/tests/fixtures/test_datetime.geojson
@@ -1,0 +1,7 @@
+{
+"type": "FeatureCollection",
+"features": [
+{ "type": "Feature", "properties": { "col": "2020-01-01T09:00:00.123" }, "geometry": { "type": "Point", "coordinates": [ 1.0, 1.0 ] } },
+{ "type": "Feature", "properties": { "col": "2020-01-01T10:00:00" }, "geometry": { "type": "Point", "coordinates": [ 2.0, 2.0 ] } }
+]
+}

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -443,3 +443,10 @@ def test_read_unsupported_types(test_ogr_types_list):
 
     fields = read(test_ogr_types_list, columns=["int64"])[3]
     assert len(fields) == 1
+
+
+def test_read_datetime_millisecond(test_datetime):
+    field = read(test_datetime)[3][0]
+    assert field.dtype == "datetime64[ms]"
+    assert field[0] == np.datetime64("2020-01-01 09:00:00.123")
+    assert field[1] == np.datetime64("2020-01-01 10:00:00.000")


### PR DESCRIPTION
This came up in the geopandas tests. WIP: I still need to add a test for this (but because we don't yet have support for writing datetimes, that's a bit harder)