### PR TITLE
Rename layer_geometry_type to geometry_type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 -   support use of a sql statement in read_dataframe (#70)
 -   correctly write geometry type for layer when dataset has multiple geometry types (#82)
 -   support reading `bool`, `int16`, `float32` into correct dtypes (#83)
--   add `layer_geometry_type` to `write_dataframe` to set geometry type for layer (#85)
+-   add `geometry_type` to `write_dataframe` to set geometry type for layer (#85)
 -   Use certifi to set `GDAL_CURL_CA_BUNDLE` / `PROJ_CURL_CA_BUNDLE` defaults (#97)
 -   automatically detect driver for `.geojson`, `.geojsonl` and `.geojsons` files (#101)
 
@@ -35,9 +35,9 @@
 -   by default, writing GeoDataFrames with mixed singular and multi geometry
     types will automatically promote to the multi type if the driver does not
     support mixed geometry types (e.g., `FGB`, though it can write mixed geometry
-    types if `layer_geometry_type` is set to `"Unknown"`)
+    types if `geometry_type` is set to `"Unknown"`)
 -   the geometry type of datasets with multiple geometry types will be set to
-    `"Unknown"` unless overridden using `layer_geometry_type`. Note:
+    `"Unknown"` unless overridden using `geometry_type`. Note:
     `"Unknown"` may be ignored by some drivers (e.g., shapefile)
 
 ### Bug fixes
@@ -46,6 +46,10 @@
 -   raise error if layer cannot be opened (#35)
 -   fix passing gdal creation parameters in `write_dataframe` (#62)
 -   fix passing kwargs to GDAL in `write_dataframe` (#67)
+
+### Changes from 0.4.0a1
+
+-   `layer_geometry_type` introduced in 0.4.0a1 was renamed to `geometry_type` for consistency
 
 ## 0.3.0
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -172,7 +172,7 @@ def write_dataframe(
     layer=None,
     driver=None,
     encoding=None,
-    layer_geometry_type=None,
+    geometry_type=None,
     promote_to_multi=None,
     **kwargs,
 ):
@@ -191,7 +191,7 @@ def write_dataframe(
     encoding : str, optional (default: None)
         If present, will be used as the encoding for writing string values to
         the file.
-    layer_geometry_type : string, optional (default: None)
+    geometry_type : string, optional (default: None)
         By default, the geometry type of the layer will be inferred from the
         data, after applying the promote_to_multi logic. If the data only contains a
         single geometry type (after applying the logic of promote_to_multi), this type
@@ -251,21 +251,21 @@ def write_dataframe(
     # TODO: may need to fill in pd.NA, etc
     field_data = [df[f].values for f in fields]
 
-    # Determine layer_geometry_type and/or promote_to_multi
-    if layer_geometry_type is None or promote_to_multi is None:
-        tmp_layer_geometry_type = "Unknown"
+    # Determine geometry_type and/or promote_to_multi
+    if geometry_type is None or promote_to_multi is None:
+        tmp_geometry_type = "Unknown"
 
         # If there is data, infer layer geometry type + promote_to_multi
         if not df.empty:
             geometry_types = geometry.type.unique()
             if len(geometry_types) == 1:
-                tmp_layer_geometry_type = geometry_types[0]
-                if promote_to_multi and tmp_layer_geometry_type in (
+                tmp_geometry_type = geometry_types[0]
+                if promote_to_multi and tmp_geometry_type in (
                     "Point",
                     "LineString",
                     "Polygon",
                 ):
-                    tmp_layer_geometry_type = f"Multi{tmp_layer_geometry_type}"
+                    tmp_geometry_type = f"Multi{tmp_geometry_type}"
             elif len(geometry_types) == 2:
                 # Check if the types are corresponding multi + single types
                 if "Polygon" in geometry_types and "MultiPolygon" in geometry_types:
@@ -288,10 +288,10 @@ def write_dataframe(
                     ):
                         promote_to_multi = True
                     if promote_to_multi:
-                        tmp_layer_geometry_type = multi_type
+                        tmp_geometry_type = multi_type
 
-        if layer_geometry_type is None:
-            layer_geometry_type = tmp_layer_geometry_type
+        if geometry_type is None:
+            geometry_type = tmp_geometry_type
 
     crs = None
     if geometry.crs:
@@ -311,7 +311,7 @@ def write_dataframe(
         field_data=field_data,
         fields=fields,
         crs=crs,
-        geometry_type=layer_geometry_type,
+        geometry_type=geometry_type,
         encoding=encoding,
         promote_to_multi=promote_to_multi,
         **kwargs,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -740,6 +740,6 @@ def test_write_geometry_z_types(tmp_path, wkt, geom_types):
 
     gdf = gp.GeoDataFrame(geometry=[pygeos.from_wkt(wkt)], crs="EPSG:4326")
     for geom_type in geom_types:
-        write_dataframe(gdf, filename, layer_geometry_type=geom_type)
+        write_dataframe(gdf, filename, geometry_type=geom_type)
         df = read_dataframe(filename)
         assert_geodataframe_equal(df, gdf)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -8,10 +8,7 @@ import pytest
 from pyogrio import list_layers, read_info, __gdal_geos_version__
 from pyogrio.errors import DataLayerError, DataSourceError, FeatureError, GeometryError
 from pyogrio.geopandas import read_dataframe, write_dataframe
-from pyogrio.raw import (
-    DRIVERS,
-    DRIVERS_NO_MIXED_SINGLE_MULTI,
-)
+from pyogrio.raw import DRIVERS, DRIVERS_NO_MIXED_SINGLE_MULTI
 from pyogrio.tests.conftest import ALL_EXTS
 
 try:
@@ -410,10 +407,7 @@ def test_read_sql_dialect_sqlite_gpkg(naturalearth_lowres):
     assert df.iloc[0].geometry.area > area_canada
 
 
-@pytest.mark.parametrize(
-    "ext",
-    ALL_EXTS,
-)
+@pytest.mark.parametrize("ext", ALL_EXTS)
 def test_write_dataframe(tmp_path, naturalearth_lowres, ext):
     input_gdf = read_dataframe(naturalearth_lowres)
     output_path = tmp_path / f"test{ext}"
@@ -496,7 +490,7 @@ def test_write_dataframe_gdalparams(tmp_path, naturalearth_lowres):
 
 
 @pytest.mark.parametrize(
-    "ext, promote_to_multi, expected_geometry_types, expected_layer_geometry_type",
+    "ext, promote_to_multi, expected_geometry_types, expected_geometry_type",
     [
         (".fgb", None, ["MultiPolygon"], "MultiPolygon"),
         (".fgb", True, ["MultiPolygon"], "MultiPolygon"),
@@ -512,27 +506,23 @@ def test_write_dataframe_promote_to_multi(
     ext,
     promote_to_multi,
     expected_geometry_types,
-    expected_layer_geometry_type,
+    expected_geometry_type,
 ):
     input_gdf = read_dataframe(naturalearth_lowres)
 
     output_path = tmp_path / f"test_promote{ext}"
-    write_dataframe(
-        input_gdf,
-        output_path,
-        promote_to_multi=promote_to_multi,
-    )
+    write_dataframe(input_gdf, output_path, promote_to_multi=promote_to_multi)
 
     assert output_path.exists()
     output_gdf = read_dataframe(output_path)
     geometry_types = sorted(output_gdf.geometry.type.unique())
     assert geometry_types == expected_geometry_types
-    assert read_info(output_path)["geometry_type"] == expected_layer_geometry_type
+    assert read_info(output_path)["geometry_type"] == expected_geometry_type
 
 
 @pytest.mark.parametrize(
-    "ext, promote_to_multi, layer_geometry_type, "
-    "expected_geometry_types, expected_layer_geometry_type",
+    "ext, promote_to_multi, geometry_type, "
+    "expected_geometry_types, expected_geometry_type",
     [
         (".fgb", None, "Unknown", ["MultiPolygon"], "Unknown"),
         (".geojson", False, "Unknown", ["MultiPolygon", "Polygon"], "Unknown"),
@@ -559,9 +549,9 @@ def test_write_dataframe_promote_to_multi_layer_geom_type(
     naturalearth_lowres,
     ext,
     promote_to_multi,
-    layer_geometry_type,
+    geometry_type,
     expected_geometry_types,
-    expected_layer_geometry_type,
+    expected_geometry_type,
 ):
     input_gdf = read_dataframe(naturalearth_lowres)
 
@@ -570,18 +560,18 @@ def test_write_dataframe_promote_to_multi_layer_geom_type(
         input_gdf,
         output_path,
         promote_to_multi=promote_to_multi,
-        layer_geometry_type=layer_geometry_type,
+        geometry_type=geometry_type,
     )
 
     assert output_path.exists()
     output_gdf = read_dataframe(output_path)
     geometry_types = sorted(output_gdf.geometry.type.unique())
     assert geometry_types == expected_geometry_types
-    assert read_info(output_path)["geometry_type"] == expected_layer_geometry_type
+    assert read_info(output_path)["geometry_type"] == expected_geometry_type
 
 
 @pytest.mark.parametrize(
-    "ext, promote_to_multi, layer_geometry_type, expected_raises_match",
+    "ext, promote_to_multi, geometry_type, expected_raises_match",
     [
         (".fgb", False, "MultiPolygon", "Mismatched geometry type"),
         (".fgb", False, "Polygon", "Mismatched geometry type"),
@@ -595,7 +585,7 @@ def test_write_dataframe_promote_to_multi_layer_geom_type_invalid(
     naturalearth_lowres,
     ext,
     promote_to_multi,
-    layer_geometry_type,
+    geometry_type,
     expected_raises_match,
 ):
     input_gdf = read_dataframe(naturalearth_lowres)
@@ -606,7 +596,7 @@ def test_write_dataframe_promote_to_multi_layer_geom_type_invalid(
             input_gdf,
             output_path,
             promote_to_multi=promote_to_multi,
-            layer_geometry_type=layer_geometry_type,
+            geometry_type=geometry_type,
         )
 
 
@@ -617,13 +607,10 @@ def test_write_dataframe_layer_geom_type_invalid(tmp_path, naturalearth_lowres):
     with pytest.raises(
         GeometryError, match="Geometry type is not supported: NotSupported"
     ):
-        write_dataframe(df, filename, layer_geometry_type="NotSupported")
+        write_dataframe(df, filename, geometry_type="NotSupported")
 
 
-@pytest.mark.parametrize(
-    "ext",
-    [ext for ext in ALL_EXTS if ext not in ".shp"],
-)
+@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".shp"])
 def test_write_dataframe_truly_mixed(tmp_path, ext):
     from shapely.geometry import (
         box,
@@ -644,9 +631,7 @@ def test_write_dataframe_truly_mixed(tmp_path, ext):
     ]
 
     df = gp.GeoDataFrame(
-        {"col": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
-        geometry=geometry,
-        crs="EPSG:4326",
+        {"col": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}, geometry=geometry, crs="EPSG:4326"
     )
 
     filename = tmp_path / f"test{ext}"


### PR DESCRIPTION
Resolves #114 

As discussed on 6/2/2022 GeoPandas dev team call; renaming for consistency throughout (`layer_geometry_type` was used only in geopandas I/O functions; `geometry_type` is used on other places).

Includes minor formatting cleanup of test file, sorry!