### PR TITLE
CI: Enable linting on CI using GeoPandas configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  Linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+files: 'pyogrio\/'
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        language: python_venv

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -66,6 +66,10 @@ GDAL paths), or either the `GDAL_INCLUDE_PATH`, `GDAL_LIBRARY_PATH`, and
 
 Building Pyogrio requires requires `Cython`, `numpy`, and `pandas`.
 
+Pyogrio follows the
+[GeoPandas Style Guide](https://geopandas.org/en/stable/community/contributing.html#style-guide-linting) and uses `Black` and `Flake8` to ensure consistent
+formatting.
+
 Run `python setup.py develop` to build the extensions in Cython.
 
 Tests are run using `pytest`:

--- a/pyogrio/__init__.py
+++ b/pyogrio/__init__.py
@@ -17,16 +17,16 @@ __version__ = get_versions()["version"]
 del get_versions
 
 __all__ = [
-    list_drivers,
-    list_layers,
-    read_bounds,
-    read_info,
-    set_gdal_config_options,
-    get_gdal_config_option,
-    read_dataframe,
-    write_dataframe,
-    __gdal_version__,
-    __gdal_version_string__,
-    __gdal_geos_version__,
-    __version__,
+    "list_drivers",
+    "list_layers",
+    "read_bounds",
+    "read_info",
+    "set_gdal_config_options",
+    "get_gdal_config_option",
+    "read_dataframe",
+    "write_dataframe",
+    "__gdal_version__",
+    "__gdal_version_string__",
+    "__gdal_geos_version__",
+    "__version__",
 ]

--- a/pyogrio/__init__.py
+++ b/pyogrio/__init__.py
@@ -15,3 +15,18 @@ from pyogrio._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions
+
+__all__ = [
+    list_drivers,
+    list_layers,
+    read_bounds,
+    read_info,
+    set_gdal_config_options,
+    get_gdal_config_option,
+    read_dataframe,
+    write_dataframe,
+    __gdal_version__,
+    __gdal_version_string__,
+    __gdal_geos_version__,
+    __version__,
+]

--- a/pyogrio/_env.py
+++ b/pyogrio/_env.py
@@ -32,7 +32,7 @@ gdal_dll_dir = None
 if platform.system() == "Windows" and sys.version_info >= (3, 8):
     # if loading of extension modules fails, search for gdal dll directory
     try:
-        import pyogrio._io
+        import pyogrio._io  # NOQA
 
     except ImportError:
         for path in os.getenv("PATH", "").split(os.pathsep):
@@ -59,4 +59,3 @@ def GDALEnv():
     finally:
         if dll_dir is not None:
             dll_dir.close()
-

--- a/pyogrio/_version.py
+++ b/pyogrio/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -114,16 +117,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -183,7 +192,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -192,7 +201,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -200,19 +209,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -227,8 +243,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -236,10 +251,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -262,17 +286,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -281,10 +304,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -295,13 +320,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     # Use only the last line.  Previous lines may contain GPG signature
     # information.
     date = date.splitlines()[-1]
@@ -335,8 +360,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -450,11 +474,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -474,9 +500,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -490,8 +520,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -500,13 +529,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -520,6 +552,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -78,7 +78,13 @@ def list_layers(path_or_buffer, /):
 
 
 def read_bounds(
-    path_or_buffer, /, layer=None, skip_features=0, max_features=None, where=None, bbox=None
+    path_or_buffer,
+    /,
+    layer=None,
+    skip_features=0,
+    max_features=None,
+    where=None,
+    bbox=None,
 ):
     """Read bounds of each feature.
 
@@ -113,11 +119,12 @@ def read_bounds(
     -------
     tuple of (fids, bounds)
         fids are global IDs read from the FID field of the dataset
-        bounds are ndarray of shape(4, n) containig ``xmin``, ``ymin``, ``xmax``, ``ymax``
+        bounds are ndarray of shape(4, n) containing ``xmin``, ``ymin``, ``xmax``,
+        ``ymax``
     """
     path, buffer = get_vsi_path(path_or_buffer)
 
-    try:   
+    try:
         result = ogr_read_bounds(
             path,
             layer=layer,
@@ -164,7 +171,7 @@ def read_info(path_or_buffer, /, layer=None, encoding=None):
     """
     path, buffer = get_vsi_path(path_or_buffer)
 
-    try:   
+    try:
         result = ogr_read_info(path, layer=layer, encoding=encoding)
     finally:
         if buffer is not None:

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -142,14 +142,16 @@ def detect_driver(path):
     parts = os.path.splitext(path)
     if len(parts) != 2:
         raise ValueError(
-            f"Could not infer driver from path: {path}; please specify driver explicitly"
+            f"Could not infer driver from path: {path}; please specify driver "
+            "explicitly"
         )
 
     ext = parts[1].lower()
     driver = DRIVERS.get(ext, None)
     if driver is None:
         raise ValueError(
-            f"Could not infer driver from path: {path}; please specify driver explicitly"
+            f"Could not infer driver from path: {path}; please specify driver "
+            "explicitly"
         )
 
     return driver

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -20,12 +20,14 @@ with GDALEnv():
 
 
 def test_gdal_data():
-    # test will fail if GDAL data files cannot be found, indicating an installation error
+    # test will fail if GDAL data files cannot be found, indicating an
+    # installation error
     assert has_gdal_data()
 
 
 def test_proj_data():
-    # test will fail if PROJ data files cannot be found, indicating an installation error
+    # test will fail if PROJ data files cannot be found, indicating an
+    # installation error
     assert has_proj_data()
 
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -122,7 +122,7 @@ def test_read_null_values(test_fgdb_vsi):
     df = read_dataframe(test_fgdb_vsi, read_geometry=False)
 
     # make sure that Null values are preserved
-    assert df.SEGMENT_NAME.isnull().max() == True
+    assert df.SEGMENT_NAME.isnull().max()
     assert df.loc[df.SEGMENT_NAME.isnull()].SEGMENT_NAME.iloc[0] is None
 
 
@@ -694,7 +694,7 @@ def test_custom_crs_io(tmpdir, naturalearth_lowres_all_ext):
 def test_write_read_null(tmp_path):
     from shapely.geometry import Point
 
-    output_path = tmp_path / f"test_write_nan.gpkg"
+    output_path = tmp_path / "test_write_nan.gpkg"
     geom = Point(0, 0)
     test_data = {
         "geometry": [geom, geom, geom],
@@ -725,7 +725,7 @@ def test_write_read_null(tmp_path):
             ["2.5D MultiLineString", "MultiLineString Z"],
         ),
         (
-            "MultiPolygon Z (((0 0 0, 0 1 0, 1 1 0, 0 0 0)), ((1 1 1, 1 2 1, 2 2 1, 1 1 1)))",
+            "MultiPolygon Z (((0 0 0, 0 1 0, 1 1 0, 0 0 0)), ((1 1 1, 1 2 1, 2 2 1, 1 1 1)))",  # NOQA
             ["2.5D MultiPolygon", "MultiPolygon Z"],
         ),
         (

--- a/pyogrio/tests/test_path.py
+++ b/pyogrio/tests/test_path.py
@@ -9,7 +9,7 @@ import pyogrio.raw
 from pyogrio.util import vsi_path
 
 try:
-    import geopandas as gp
+    import geopandas  # NOQA
 
     has_geopandas = True
 except ImportError:
@@ -175,13 +175,13 @@ def test_zip_path(naturalearth_lowres_vsi):
     path_zip = "zip://" + str(path)
 
     # absolute zip path
-    result = pyogrio.raw.read(path)
+    result = pyogrio.raw.read(path_zip)
     assert len(result[2]) == 177
 
-    result = pyogrio.read_info(path)
+    result = pyogrio.read_info(path_zip)
     assert result["features"] == 177
 
-    result = pyogrio.read_bounds(path)
+    result = pyogrio.read_bounds(path_zip)
     assert len(result[0]) == 177
 
     # absolute vsizip path
@@ -279,7 +279,7 @@ def test_url():
 
 @pytest.mark.skipif(not has_geopandas, reason="GeoPandas not available")
 def test_url_dataframe():
-    url = "https://raw.githubusercontent.com/geopandas/pyogrio/main/pyogrio/tests/fixtures/naturalearth_lowres/naturalearth_lowres.shp"
+    url = "https://raw.githubusercontent.com/geopandas/pyogrio/main/pyogrio/tests/fixtures/naturalearth_lowres/naturalearth_lowres.shp"  # NOQA
 
     assert len(pyogrio.read_dataframe(url)) == 177
 

--- a/pyogrio/tests/test_path.py
+++ b/pyogrio/tests/test_path.py
@@ -185,7 +185,7 @@ def test_detect_zip_path(tmp_path, naturalearth_lowres):
 @pytest.mark.network
 def test_url():
     df = pyogrio.read_dataframe(
-        "https://raw.githubusercontent.com/geopandas/pyogrio/main/pyogrio/tests/fixtures/naturalearth_lowres/naturalearth_lowres.shp"
+        "https://raw.githubusercontent.com/geopandas/pyogrio/main/pyogrio/tests/fixtures/naturalearth_lowres/naturalearth_lowres.shp"  # NOQA
     )
     assert len(df) == 177
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -295,7 +295,7 @@ def test_write_geojson(tmpdir, naturalearth_lowres):
     [
         driver
         for driver in list_drivers(write=True)
-        if not driver in ("ESRI Shapefile", "GPKG", "GeoJSON")
+        if driver not in ("ESRI Shapefile", "GPKG", "GeoJSON")
     ],
 )
 def test_write_supported(tmpdir, naturalearth_lowres, driver):

--- a/pyogrio/tests/win32.py
+++ b/pyogrio/tests/win32.py
@@ -84,4 +84,3 @@ if platform.system() == "Windows":
             test_write_geojson(tmpdir, naturalearth_lowres)
         except Exception as ex:
             print(ex)
-

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -17,7 +17,7 @@ def get_vsi_path(path_or_buffer):
     if isinstance(path_or_buffer, bytes):
         buffer = path_or_buffer
         ext = ""
-        is_zipped = path_or_buffer[:4].startswith(b'PK\x03\x04')
+        is_zipped = path_or_buffer[:4].startswith(b"PK\x03\x04")
         if is_zipped:
             ext = ".zip"
         path = buffer_to_virtual_file(path_or_buffer, ext=ext)
@@ -80,7 +80,7 @@ CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == "curl"])
 
 
 def _parse_uri(path: str):
-    """"
+    """ "
     Parse a URI
 
     Returns a tuples of (path, archive, scheme)

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -80,7 +80,7 @@ CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == "curl"])
 
 
 def _parse_uri(path: str):
-    """ "
+    """
     Parse a URI
 
     Returns a tuples of (path, archive, scheme)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,11 @@ testpaths = pyogrio/tests
 
 markers =
     network: marks tests that require a network connection
+
+[flake8]
+# Black enforces 88 characters line length
+max_line_length = 88
+
+ignore =
+    E203,  # Space before : (needed for black formatting of slices)
+    W503,  # Line break before binary operator (needed for black)


### PR DESCRIPTION
This copies the linting CI step and pre-commit config from GeoPandas.  Includes auto-formatting using Black and manual updates to make Flake8 happy.

Note: all changes in `_version.py` are autoformatting and can be ignored.