### PR TITLE
CI: Cancel jobs on subsequent push to PR

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# cancel running jobs on new commit to PR
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   TestLinux:
     name: GDAL ${{ matrix.container }}

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -12,8 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# FIXME: remove
-
 jobs:
   TestLinux:
     name: GDAL ${{ matrix.container }}

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# FIXME: remove
+
 jobs:
   TestLinux:
     name: GDAL ${{ matrix.container }}

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -9,7 +9,7 @@ on:
 
 # cancel running jobs on new commit to PR
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
       - "setup.py"
   workflow_dispatch:
 
+# cancel running jobs on new commit to PR
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-sdist:
     name: Build pyogrio sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 # cancel running jobs on new commit to PR
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# cancel running jobs on new commit to PR
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.os }} (Python ${{ matrix.python }})

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -9,7 +9,7 @@ on:
 
 # cancel running jobs on new commit to PR
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This uses the [concurrency feature](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) of GH actions to cancel previous runs for a PR when a new commit comes in.  This may be useful for other projects that have longer-running test suites (e.g., Shapely, GeoPandas)