### PR TITLE
Remove noindex option under geopandas section so that permalinks work

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,5 @@ Core
 GeoPandas integration
 ---------------------
 
-.. automodule:: pyogrio.geopandas
 .. autofunction:: pyogrio.read_dataframe
 .. autofunction:: pyogrio.write_dataframe


### PR DESCRIPTION
Hi there, I was trying to add an intersphinx link using "py:func:\`pyogrio.read_dataframe\`" at https://github.com/weiji14/zen3geo/pull/19#discussion_r893027681 but it seems like there wasn't a permalink available. The closest link I could find was https://pyogrio.readthedocs.io/en/latest/api.html#geopandas-integration, but ideally it would be possible to link directly to `pyorgio.read_dataframe`.

This Pull Request removes the `:noindex:` option added in #18 (specifically at commit 679b81b880f744960efaa81b8f4e4b9ac92d2b91) so that intersphinx will work and the permalink shows up, like so:

![Screenshot at 2022-06-09 11-34-53](https://user-images.githubusercontent.com/23487320/172887188-d9b5f264-a0b0-4038-a5a6-34c95ff4b450.png)

And you can then click on https://pyogrio--130.org.readthedocs.build/en/130/api.html#pyogrio.read_dataframe!
