### PR TITLE
CI: Fix minimal test env and remove deps on pandas / geopandas

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -24,6 +24,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         python: ["3.9", "3.10"]
+        environment-file: environment.yml
+        include:
+          # minimal environment without optional dependencies
+          - os: "ubuntu-latest"
+            python: "3.10"
+            environment-file: environment-minimal.yml
 
     steps:
       - name: Checkout repo
@@ -32,7 +38,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          environment-file: ci/environment.yml
+          environment-file: ci/${{ matrix.environment-file }}
           extra-specs: python=${{ matrix.python }}
           cache-env: true
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         python: ["3.9", "3.10"]
-        environment-file: "environment.yml"
+        env: "environment.yml"
         include:
           # minimal environment without optional dependencies
           - os: "ubuntu-latest"
             python: "3.10"
-            environment-file: "environment-minimal.yml"
+            env: "environment-minimal.yml"
 
     steps:
       - name: Checkout repo
@@ -38,7 +38,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          environment-file: ci/${{ matrix.environment-file }}
+          environment-file: ci/${{ matrix.env }}
           extra-specs: python=${{ matrix.python }}
           cache-env: true
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         python: ["3.9", "3.10"]
-        environment-file: environment.yml
+        environment-file: "environment.yml"
         include:
           # minimal environment without optional dependencies
           - os: "ubuntu-latest"
             python: "3.10"
-            environment-file: environment-minimal.yml
+            environment-file: "environment-minimal.yml"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         python: ["3.9", "3.10"]
-        env: "environment.yml"
+        env: ["environment.yml"]
         include:
           # minimal environment without optional dependencies
           - os: "ubuntu-latest"

--- a/ci/environment-minimal.yml
+++ b/ci/environment-minimal.yml
@@ -1,0 +1,8 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - libgdal
+  - pytest
+

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2,8 +2,6 @@ from datetime import datetime
 import os
 
 import numpy as np
-import pandas as pd
-from pandas.testing import assert_frame_equal, assert_index_equal
 import pytest
 
 from pyogrio import list_layers, read_info, __gdal_geos_version__
@@ -13,6 +11,9 @@ from pyogrio.raw import DRIVERS, DRIVERS_NO_MIXED_SINGLE_MULTI
 from pyogrio.tests.conftest import ALL_EXTS
 
 try:
+    import pandas as pd
+    from pandas.testing import assert_frame_equal, assert_index_equal
+
     import geopandas as gp
     from geopandas.testing import assert_geodataframe_equal
 


### PR DESCRIPTION
Supersedes #132 (thanks @jorisvandenbossche !)

Cleans up a dependency on pandas outside of our try / catch block for GeoPandas, and uses raw IO methods for preparing test files instead of geopandas