### PR TITLE
BUG: fix geometry type inference in case of missing geometries

### DIFF
--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -224,6 +224,7 @@ def write_dataframe(
     try:
         import geopandas as gp
         from geopandas.array import to_wkb
+        import pandas as pd
 
         # if geopandas is available so is pyproj
         from pyproj.enums import WktVersion
@@ -262,7 +263,7 @@ def write_dataframe(
 
         # If there is data, infer layer geometry type + promote_to_multi
         if not df.empty:
-            geometry_types = geometry.type.unique()
+            geometry_types = pd.Series(geometry.type.unique()).dropna().values
             if len(geometry_types) == 1:
                 tmp_geometry_type = geometry_types[0]
                 if promote_to_multi and tmp_geometry_type in (

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -18,18 +18,16 @@ try:
     from geopandas.testing import assert_geodataframe_equal
 
     from shapely.geometry import Point
-
-    has_geopandas = True
 except ImportError:
-    has_geopandas = False
+    pass
+
+
+pytest.importorskip("geopandas")
 
 
 # Note: this will also be false for GDAL < 3.4 when GEOS may be present but we
 # cannot verify it
 has_geos = __gdal_geos_version__ is not None
-
-
-pytestmark = pytest.mark.skipif(not has_geopandas, reason="GeoPandas not available")
 
 
 def spatialite_available(path):


### PR DESCRIPTION
Ran into this in the geopandas tests: currently if there is a missing geometry, we might either consider it as mixed instead of uniform geom type (which can error in case of Shapefiles) or take the `None` geometry type which then errors somewhere in our code expecting this keyword to be set.