### PR TITLE
FIX: register drivers on import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
--   register GDAL drivers during initial import of pyogrio
+-   register GDAL drivers during initial import of pyogrio (#145)
 
 ## 0.4.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## O.4.2
+
+### Bug fixes
+
+-   register GDAL drivers during initial import of pyogrio
+
 ## 0.4.1
 
 ### Bug fixes

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -116,9 +116,6 @@ cdef void* ogr_open(const char* path_c, int mode, options) except NULL:
     cdef void* ogr_driver = NULL
     cdef char **open_opts = NULL
 
-    # Register all drivers
-    GDALAllRegister()
-
     # Force linear approximations in all cases
     OGRSetNonLinearGeometriesEnabledFlag(0)
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -124,9 +124,6 @@ def ogr_list_drivers():
     cdef int i
     cdef char *name_c
 
-    # Register all drivers
-    GDALAllRegister()
-
     drivers = dict()
     for i in range(OGRGetDriverCount()):
         driver = OGRGetDriver(i)
@@ -272,3 +269,8 @@ def init_proj_data():
         return
 
     warnings.warn("Could not detect PROJ data files.  Set PROJ_LIB environment variable to the correct path.", RuntimeWarning)
+
+
+def _register_drivers():
+    # Register all drivers
+    GDALAllRegister()

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -13,11 +13,13 @@ with GDALEnv():
         init_gdal_data as _init_gdal_data,
         init_proj_data as _init_proj_data,
         remove_virtual_file,
+        _register_drivers,
     )
     from pyogrio._io import ogr_list_layers, ogr_read_bounds, ogr_read_info
 
     _init_gdal_data()
     _init_proj_data()
+    _register_drivers()
 
     __gdal_version__ = get_gdal_version()
     __gdal_version_string__ = get_gdal_version_string()


### PR DESCRIPTION
Resoves #144 

This moves driver registration to the import step.  We were not using it consistently across all internal functions, and this seemed the best way to make sure it was done up front and not repeated.