### PR TITLE
CI: Fix tests on GDAL Docker container

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install --no-cache-dir -U pip wheel setuptools
-          python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
+          python3 -m pip install --no-cache-dir -U pip wheel
+          python3 -m pip install --no-cache-dir --no-use-pep517 -e .[dev,test,geopandas]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -30,16 +30,16 @@ jobs:
       image: ${{ matrix.container }}
 
     steps:
-      - uses: actions/checkout@v3
-
       - name: Install packages
         run: |
-          apt-get update && apt-get install -y python3-pip
+          apt-get update && apt-get install -y git python3-pip
+
+      - uses: actions/checkout@v3
 
       - name: Install Python Dependencies
         run: |
           python3 -m pip install --no-cache-dir -U pip wheel
-          python3 -m pip install --no-cache-dir --no-use-pep517 -e .[dev,test,geopandas]
+          python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install --no-cache-dir -U pip wheel
+          python3 -m pip install --no-cache-dir -U pip wheel setuptools
           python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
 
       - name: Test with pytest


### PR DESCRIPTION
Editable installs are failing with latest version of pip due to presence of `pyproject.toml` file but without properly set version number.

This uses `--no-use-pep517` to sidestep some of the enforcement around recent python packaging standards.

Resolves build error noted in #146 
