### PR TITLE
FIX: Avoid duplicate count of features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 -   register GDAL drivers during initial import of pyogrio (#145)
+-   avoid duplicate count of available features (#151)
 
 ## 0.4.1
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -607,6 +607,9 @@ cdef get_features(
     cdef int i
     cdef int field_index
 
+    # make sure layer is read from beginning
+    OGR_L_ResetReading(ogr_layer)
+
     if skip_features > 0:
         OGR_L_SetNextByIndex(ogr_layer, skip_features)
 
@@ -676,6 +679,9 @@ cdef get_features_by_fid(
     cdef int field_index
     cdef int count = len(fids)
 
+    # make sure layer is read from beginning
+    OGR_L_ResetReading(ogr_layer)
+
     if read_geometry:
         geometries = np.empty(shape=(count, ), dtype='object')
         geom_view = geometries[:]
@@ -728,6 +734,9 @@ cdef get_bounds(
     cdef OGRGeometryH ogr_geometry = NULL
     cdef OGREnvelope ogr_envelope # = NULL
     cdef int i
+
+    # make sure layer is read from beginning
+    OGR_L_ResetReading(ogr_layer)
 
     if skip_features > 0:
         OGR_L_SetNextByIndex(ogr_layer, skip_features)
@@ -813,9 +822,6 @@ def ogr_read(
             ogr_layer = get_ogr_layer(ogr_dataset, layer)
         else:
             ogr_layer = execute_sql(ogr_dataset, sql, sql_dialect)
-
-        # make sure layer is read from beginning
-        OGR_L_ResetReading(ogr_layer)
 
         crs = get_crs(ogr_layer)
 
@@ -930,9 +936,6 @@ def ogr_read_bounds(
 
     ogr_dataset = ogr_open(path_c, 0, kwargs)
     ogr_layer = get_ogr_layer(ogr_dataset, layer)
-
-    # make sure layer is read from beginning
-    OGR_L_ResetReading(ogr_layer)
 
     # Apply the attribute filter
     if where is not None and where != "":


### PR DESCRIPTION
As noted in #149 [comment](https://github.com/geopandas/pyogrio/issues/149#issuecomment-1221104056), we were calculating the count of features twice, which incurs extra and unnecessary overhead.  This removes that duplication.