### PR TITLE
BLD: fix library detection on Windows / CI: Upgrade macos runner from deprecated 10.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-10.15"
+          - os: "macos-11"
             triplet: "x64-osx-dynamic"
             vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
             vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-10.15"]
+        os: ["ubuntu-20.04", "windows-latest", "macos-latest", "macos-11"]
         python-version: ["3.8", "3.9"]
         include:
           # TODO macOS is failing on py 3.10 because of shapely failure

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -30,6 +30,11 @@ jobs:
           - os: "ubuntu-latest"
             python: "3.10"
             env: "environment-minimal.yml"
+          # environment for older Windows libgdal to make sure gdal_i.lib is
+          # properly detected
+          - os: "windows-2019"
+            python: "3.10"
+            env: "environment-libgdal3.5.1.yml"
 
     steps:
       - name: Checkout repo

--- a/ci/environment-libgdal3.5.1.yml
+++ b/ci/environment-libgdal3.5.1.yml
@@ -1,0 +1,9 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - libgdal==3.5.1
+  - pytest
+  - pygeos
+  - geopandas-base

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ def get_gdal_config():
         gdal_libs = ["gdal"]
 
         if platform.system() == "Windows":
-            # NOTE: libgdal on conda-forge now builds the library as "gdal" instead
-            # of "gdal_i", but older Windows builds still use "gdal_i"
+            # NOTE: if libgdal is built for Windows using CMake, it is now "gdal",
+            # but older Windows builds still use "gdal_i"
             if (Path(library_dir) / "gdal_i.lib").exists():
                 gdal_libs = ["gdal_i"]
 

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,16 @@ def get_gdal_config():
     gdal_version_str = os.environ.get("GDAL_VERSION")
 
     if include_dir and library_dir and gdal_version_str:
+        gdal_libs = ["gdal"]
+        if platform.system() == "Windows":
+            # NOTE: libgdal on conda-forge now builds the library as "gdal" instead
+            # of "gdal_i", but older Windows builds still use "gdal_i"
+            gdal_libs.append("gdal_i")
+
         return {
             "include_dirs": [include_dir],
             "library_dirs": [library_dir],
-            "libraries": ["gdal_i" if platform.system() == "Windows" else "gdal"],
+            "libraries": gdal_libs,
         }, gdal_version_str
 
     if include_dir or library_dir or gdal_version_str:
@@ -101,14 +107,15 @@ def get_gdal_config():
     except Exception as e:
         if platform.system() == "Windows":
             # Get GDAL API version from the command line if specified there.
-            if '--gdalversion' in sys.argv:
-                index = sys.argv.index('--gdalversion')
+            if "--gdalversion" in sys.argv:
+                index = sys.argv.index("--gdalversion")
                 sys.argv.pop(index)
                 gdal_version_str = sys.argv.pop(index)
             else:
                 print(
                     "GDAL_VERSION must be provided as an environment variable "
-                    "or as --gdalversion command line argument")
+                    "or as --gdalversion command line argument"
+                )
                 sys.exit(1)
 
             log.info(

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,12 @@ def get_gdal_config():
 
     if include_dir and library_dir and gdal_version_str:
         gdal_libs = ["gdal"]
+
         if platform.system() == "Windows":
             # NOTE: libgdal on conda-forge now builds the library as "gdal" instead
             # of "gdal_i", but older Windows builds still use "gdal_i"
-            gdal_libs.append("gdal_i")
+            if (Path(library_dir) / "gdal_i.lib").exists():
+                gdal_libs = ["gdal_i"]
 
         return {
             "include_dirs": [include_dir],


### PR DESCRIPTION
GitHub deprecated macOS 10.15 runners; this updates to 11 but retains the build target of 10.15, so everything should still work as before.