### PR TITLE
Benchmark fixes

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -17,13 +17,8 @@ def naturalearth_modres():
 
 
 @pytest.fixture(scope="session")
-def naturalearth_modres():
-    return data_dir / "ne_10m_admin_0_countries/ne_10m_admin_0_countries.shp"
-
-
-@pytest.fixture(scope="session")
 def naturalearth_modres_vsi():
-    path = data_dir / "ne_10m_admin_0_countries.zip/ne_10m_admin_0_countries"
+    path = data_dir / "ne_10m_admin_0_countries.zip/ne_10m_admin_0_countries.shp"
     return f"/vsizip/{path}"
 
 

--- a/benchmarks/test_raw_io_benchmarks.py
+++ b/benchmarks/test_raw_io_benchmarks.py
@@ -95,14 +95,14 @@ def test_read_only_meta_modres1(naturalearth_modres1, benchmark):
 
 @pytest.mark.benchmark(group="write-lowres")
 def test_write_lowres_shp(tmpdir, naturalearth_lowres, benchmark):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, _, geometry, field_data = read(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.shp")
     benchmark(write, filename, geometry, field_data, driver="ESRI Shapefile", **meta)
 
 
 @pytest.mark.benchmark(group="write-lowres")
 def test_write_lowres_gpkg(tmpdir, naturalearth_lowres, benchmark):
-    meta, geometry, field_data = read(naturalearth_lowres)
+    meta, _, geometry, field_data = read(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.gpkg")
     benchmark(write, filename, geometry, field_data, driver="GPKG", **meta)
 


### PR DESCRIPTION
Small fixes to benchmarks:
* _read_ returns fids (as None) even when return_fids=False
* Duplicate dataset fixture in conftest
* Dataset fixture without file extension when using VSI