### PR TITLE
windows CI: Always use latest patch version of setup-msbuild

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-gdal-${{ matrix.GDAL_VERSION }}
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1
 
       - name: Download GDAL
         run: |


### PR DESCRIPTION
By removing the exact patch version of the microsoft/setup-msbuild action, it will always use the latest patch version. This is also how it's suggested in the [setup-msbuild](https://github.com/microsoft/setup-msbuild) docs.

This PR replaces #171.

Major and minor version updates will be handled by https://github.com/geopandas/pyogrio/pull/168.