### PR TITLE
CI: workaround vcpkg bug in linux wheel docker

### DIFF
--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -11,7 +11,10 @@ RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg
 ENV VCPKG_INSTALLATION_ROOT="/opt/vcpkg"
 ENV PATH="${PATH}:/opt/vcpkg"
 
+# mkdir & touch -> workaround for https://github.com/microsoft/vcpkg/issues/27786
 RUN bootstrap-vcpkg.sh && \
+    mkdir -p /root/.vcpkg/ $HOME/.vcpkg && \
+    touch /root/.vcpkg/vcpkg.path.txt $HOME/.vcpkg/vcpkg.path.txt && \
     vcpkg integrate install && \
     vcpkg integrate bash
 


### PR DESCRIPTION
Adding a similar workaround for https://github.com/microsoft/vcpkg/issues/27786 as the github action images do as well (https://github.com/actions/runner-images/discussions/6600, https://github.com/actions/runner-images/blob/6ef9c61220d9712317731cbdaa53bb0b25e73f94/images/linux/scripts/installers/vcpkg.sh#L16-L19)