### PR TITLE
DEPS: don't require pygeos + update to test with both pygeos and shapely 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x.
 
-Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` enabled.
+Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` or `shapely>=2`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x.
 
-Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` or `shapely>=2`.
+Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos`
+or `geopandas>=0.12` with `shapely>=2`.
 
 ## Installation
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,5 +5,5 @@ dependencies:
   - numpy
   - libgdal
   - pytest
-  - pygeos
+  - shapely>=2
   - geopandas-base

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@ from pyogrio import __version__
 
 autodoc_mock_imports = [
     "geopandas",
-    "pygeos",
 ]
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -4,7 +4,7 @@
 
 Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x
 
-Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` enabled.
+Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` or `shapely>=2`.
 
 ## Installation
 
@@ -18,7 +18,7 @@ conda install -c conda-forge pyogrio
 ```
 
 This requires compatible versions of `GDAL` and `numpy` from `conda-forge` for
-raw I/O support and `geopandas`, `pygeos`, and their dependencies for GeoDataFrame
+raw I/O support and `geopandas` and their dependencies for GeoDataFrame
 I/O support.
 
 ### PyPI

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -4,7 +4,8 @@
 
 Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x
 
-Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` or `shapely>=2`.
+Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos`
+or `geopandas>=0.12` with `shapely>=2`.
 
 ## Installation
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -770,7 +770,7 @@ def test_write_geometry_z_types(tmp_path, wkt, geom_types):
 
     filename = tmp_path / "test.fgb"
 
-    gdf = gp.GeoDataFrame(geometry=[from_wkt(wkt)], crs="EPSG:4326")
+    gdf = gp.GeoDataFrame(geometry=from_wkt([wkt]), crs="EPSG:4326")
     for geom_type in geom_types:
         write_dataframe(gdf, filename, geometry_type=geom_type)
         df = read_dataframe(filename)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -766,10 +766,11 @@ def test_write_read_null(tmp_path):
     ],
 )
 def test_write_geometry_z_types(tmp_path, wkt, geom_types):
-    pygeos = pytest.importorskip("pygeos")
+    from geopandas.array import from_wkt
+
     filename = tmp_path / "test.fgb"
 
-    gdf = gp.GeoDataFrame(geometry=[pygeos.from_wkt(wkt)], crs="EPSG:4326")
+    gdf = gp.GeoDataFrame(geometry=[from_wkt(wkt)], crs="EPSG:4326")
     for geom_type in geom_types:
         write_dataframe(gdf, filename, geometry_type=geom_type)
         df = read_dataframe(filename)

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -341,10 +341,10 @@ def assert_equal_result(result1, result2):
     # the WKB values are not exactly equal, therefore parsing with pygeos to compare
     # with tolerance
     try:
-        from pygeos import from_wkb, equals_exact
+        from shapely import from_wkb, equals_exact
     except ImportError:
         try:
-            from shapely import from_wkb, equals_exact
+            from pygeos import from_wkb, equals_exact
         except ImportError:
             pytest.skip("Test requires pygeos or shapely>=2")
     assert equals_exact(

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -340,9 +340,15 @@ def assert_equal_result(result1, result2):
     # a plain `assert np.array_equal(geometry1, geometry2)` doesn't work because
     # the WKB values are not exactly equal, therefore parsing with pygeos to compare
     # with tolerance
-    pygeos = pytest.importorskip("pygeos")
-    assert pygeos.equals_exact(
-        pygeos.from_wkb(geometry1), pygeos.from_wkb(geometry2), tolerance=0.00001
+    try:
+        from pygeos import from_wkb, equals_exact
+    except ImportError:
+        try:
+            from shapely import from_wkb, equals_exact
+        except ImportError:
+            pytest.skip("Test requires pygeos or shapely>=2")
+    assert equals_exact(
+        from_wkb(geometry1), from_wkb(geometry2), tolerance=0.00001
     ).all()
     assert all([np.array_equal(f1, f2) for f1, f2 in zip(field_data1, field_data2)])
 

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,7 @@ setup(
         "dev": ["Cython"],
         "test": ["pytest", "pytest-cov"],
         "benchmark": ["pytest-benchmark"],
-        "geopandas": ["pygeos", "geopandas"],
+        "geopandas": ["geopandas"],
     },
     include_package_data=True,
     cmdclass=cmdclass,


### PR DESCRIPTION
We don't strictly require pygeos, it's just best to use geopandas with pygeos under the hood. Updated the documentation to mention both pygeos or shapely>=2, ensured to have a test build with shapely 2 instead of pygeos, and updated some tests to be more generic (and not rely on pygeos). 
And also removed "pygeos" from the extra requirement.