### PR TITLE
CI: include Python 3.11 in test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04", "windows-latest", "macos-10.15", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python: ["3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
         env: ["environment.yml"]
         include:
           # minimal environment without optional dependencies

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11"]
         env: ["environment.yml"]
         include:
           # minimal environment without optional dependencies
           - os: "ubuntu-latest"
-            python: "3.10"
+            python: "3.9"
             env: "environment-minimal.yml"
           # environment for older Windows libgdal to make sure gdal_i.lib is
           # properly detected

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 ## Requirements
 
-Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x.
+Supports Python 3.8 - 3.11 and GDAL 3.1.x - 3.6.x.
 
 Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` enabled.
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Supports Python 3.8 - 3.10 and GDAL 3.1.x - 3.5.x
+Supports Python 3.8 - 3.11 and GDAL 3.1.x - 3.6.x
 
 Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos` enabled.
 


### PR DESCRIPTION
Wheels are already built for 3.11, so updating docs and test CI as well.