### PR TITLE
ENH: support dataset creation options (use metadata to split dataset/layer creation options)

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1077,7 +1077,7 @@ def ogr_list_layers(str path):
 
 # NOTE: all modes are write-only
 # some data sources have multiple layers
-cdef void * ogr_create(const char* path_c, const char* driver_c) except NULL:
+cdef void * ogr_create(const char* path_c, const char* driver_c, char** options) except NULL:
     cdef void *ogr_driver = NULL
     cdef OGRDataSourceH ogr_dataset = NULL
 
@@ -1093,7 +1093,7 @@ cdef void * ogr_create(const char* path_c, const char* driver_c) except NULL:
 
     # Create the dataset
     try:
-        ogr_dataset = exc_wrap_pointer(GDALCreate(ogr_driver, path_c, 0, 0, 0, GDT_Unknown, NULL))
+        ogr_dataset = exc_wrap_pointer(GDALCreate(ogr_driver, path_c, 0, 0, 0, GDT_Unknown, options))
 
     except NullPointerError:
         raise DataSourceError(f"Failed to create dataset with driver: {path_c.decode('utf-8')} {driver_c.decode('utf-8')}") from None
@@ -1175,14 +1175,16 @@ cdef infer_field_types(list dtypes):
 # TODO: handle updateable data sources, like GPKG
 # TODO: set geometry and field data as memory views?
 def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
-    str crs, str geometry_type, str encoding, bint promote_to_multi=False, **kwargs):
+    str crs, str geometry_type, str encoding, object dataset_kwargs,
+    object layer_kwargs, bint promote_to_multi=False):
 
     cdef const char *path_c = NULL
     cdef const char *layer_c = NULL
     cdef const char *driver_c = NULL
     cdef const char *crs_c = NULL
     cdef const char *encoding_c = NULL
-    cdef char **options = NULL
+    cdef char **dataset_options = NULL
+    cdef char **layer_options = NULL
     cdef const char *ogr_name = NULL
     cdef OGRDataSourceH ogr_dataset = NULL
     cdef OGRLayerH ogr_layer = NULL
@@ -1199,6 +1201,9 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
     cdef int i = 0
     cdef int num_records = len(geometry)
     cdef int num_fields = len(field_data) if field_data else 0
+
+    print(dataset_kwargs)
+    print(layer_kwargs)
 
     if len(field_data) != len(fields):
         raise ValueError("field_data and fields must be same length")
@@ -1249,7 +1254,12 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
 
     # either it didn't exist or could not open it in write mode
     if ogr_dataset == NULL:
-        ogr_dataset = ogr_create(path_c, driver_c)
+        for k, v in dataset_kwargs.items():
+            k = k.encode('UTF-8')
+            v = v.encode('UTF-8')
+            dataset_options = CSLAddNameValue(dataset_options, <const char *>k, <const char *>v)
+
+        ogr_dataset = ogr_create(path_c, driver_c, dataset_options)
 
     ### Create the CRS
     if crs is not None:
@@ -1270,22 +1280,13 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
         # encoding as an option.
         encoding_b = encoding.upper().encode('UTF-8')
         encoding_c = encoding_b
-        options = CSLSetNameValue(options, "ENCODING", encoding_c)
+        layer_options = CSLSetNameValue(layer_options, "ENCODING", encoding_c)
 
     # Setup other layer creation options
-    for k, v in kwargs.items():
-        if v is None:
-            continue
-
-        k = k.upper().encode('UTF-8')
-
-        if isinstance(v, bool):
-            v = ('ON' if v else 'OFF').encode('utf-8')
-        else:
-            v = str(v).encode('utf-8')
-
-        options = CSLAddNameValue(options, <const char *>k, <const char *>v)
-
+    for k, v in layer_kwargs.items():
+        k = k.encode('UTF-8')
+        v = v.encode('UTF-8')
+        layer_options = CSLAddNameValue(layer_options, <const char *>k, <const char *>v)
 
     ### Get geometry type
     # TODO: this is brittle for 3D / ZM / M types
@@ -1296,7 +1297,8 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
     try:
         ogr_layer = exc_wrap_pointer(
                 GDALDatasetCreateLayer(ogr_dataset, layer_c, ogr_crs,
-                        <OGRwkbGeometryType>geometry_code, options))
+                                       <OGRwkbGeometryType>geometry_code,
+                                       layer_options))
 
     except Exception as exc:
         OGRReleaseDataSource(ogr_dataset)
@@ -1308,9 +1310,9 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
             OSRRelease(ogr_crs)
             ogr_crs = NULL
 
-        if options != NULL:
-            CSLDestroy(<char**>options)
-            options = NULL
+        if layer_options != NULL:
+            CSLDestroy(<char**>layer_options)
+            layer_options = NULL
 
     ### Create the fields
     field_types = infer_field_types([field.dtype for field in field_data])

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1265,6 +1265,10 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
 
         except Exception as exc:
             OGRReleaseDataSource(ogr_dataset)
+            ogr_dataset = NULL
+            if dataset_options != NULL:
+                CSLDestroy(<char**>dataset_options)
+                dataset_options = NULL
             raise exc
 
 
@@ -1306,6 +1310,10 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
         if ogr_crs != NULL:
             OSRRelease(ogr_crs)
             ogr_crs = NULL
+
+        if dataset_options != NULL:
+            CSLDestroy(<char**>dataset_options)
+            dataset_options = NULL
 
         if layer_options != NULL:
             CSLDestroy(<char**>layer_options)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1202,9 +1202,6 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
     cdef int num_records = len(geometry)
     cdef int num_fields = len(field_data) if field_data else 0
 
-    print(dataset_kwargs)
-    print(layer_kwargs)
-
     if len(field_data) != len(fields):
         raise ValueError("field_data and fields must be same length")
 

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -309,6 +309,7 @@ cdef extern from "gdal.h":
 
     ctypedef void* GDALDatasetH
     ctypedef void* GDALDriverH
+    ctypedef void * GDALMajorObjectH
 
     void GDALAllRegister()
 
@@ -349,6 +350,7 @@ cdef extern from "gdal.h":
     OGRErr          GDALDatasetStartTransaction(GDALDatasetH ds, int bForce)
     OGRErr          GDALDatasetCommitTransaction(GDALDatasetH ds)
     OGRErr          GDALDatasetRollbackTransaction(GDALDatasetH ds)
+    const char*     GDALGetMetadataItem(GDALMajorObjectH obj, const char *pszName, const char *pszDomain)
     const char*     GDALVersionInfo(const char *pszRequest)
 
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -221,7 +221,8 @@ def write_dataframe(
         attempting to write mixed singular and multi geometry types to drivers that do
         not support such combinations.
     **kwargs
-        The kwargs passed to OGR.
+        Additional driver-specific dataset or layer creation options passed
+        to OGR.
     """
     # TODO: add examples to the docstring (e.g. OGR kwargs)
     try:

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -177,6 +177,8 @@ def write_dataframe(
     encoding=None,
     geometry_type=None,
     promote_to_multi=None,
+    dataset_options=None,
+    layer_options=None,
     **kwargs,
 ):
     """
@@ -220,9 +222,20 @@ def write_dataframe(
         types will not be promoted, which may result in errors or invalid files when
         attempting to write mixed singular and multi geometry types to drivers that do
         not support such combinations.
+    dataset_options : dict, optional
+        Dataset creation option (format specific) passed to OGR. Specify as
+        a key-value dictionary.
+    layer_options : dict, optional
+        Layer creation option (format specific) passed to OGR. Specify as
+        a key-value dictionary.
     **kwargs
         Additional driver-specific dataset or layer creation options passed
-        to OGR.
+        to OGR. pyogrio will attempt to automatically pass those keywords
+        either as dataset or as layer creation option based on the known
+        options for the specific driver. Alternatively, you can use the
+        explicit `dataset_options` or `layer_options` keywords to manually
+        do this (for example if an option exists as both dataset and layer
+        option).
     """
     # TODO: add examples to the docstring (e.g. OGR kwargs)
     try:
@@ -324,5 +337,7 @@ def write_dataframe(
         geometry_type=geometry_type,
         encoding=encoding,
         promote_to_multi=promote_to_multi,
+        dataset_options=dataset_options,
+        layer_options=layer_options,
         **kwargs,
     )

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -181,9 +181,9 @@ def _parse_options_names(xml):
     if xml:
         root = ET.fromstring(xml)
         for option in root.iter("Option"):
-            if option.attrib.get("scope", "vector") == "raster":
-                continue
-            options.append(option.attrib["name"])
+            # some options explicitly have scope='raster'
+            if option.attrib.get("scope", "vector") != "raster":
+                options.append(option.attrib["name"])
 
     return options
 
@@ -194,7 +194,7 @@ def _preprocess_options_key_value(options):
     to `SPATIAL_INDEX="YES"`.
     """
     if not isinstance(options, dict):
-        raise TypeError(f"Expected a dict as options, got {type(options)}")
+        raise TypeError(f"Expected options to be a dict, got {type(options)}")
 
     result = {}
     for k, v in options.items():

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -513,7 +513,9 @@ def test_read_write_null_geometry(tmp_path, ext):
     )
     field_data = [np.array([1, 2], dtype="int32")]
     fields = ["col"]
-    meta = dict(geometry_type="Point", crs="EPSG:4326", spatial_index=False)
+    meta = dict(geometry_type="Point", crs="EPSG:4326")
+    if ext == "gpkg":
+        meta["spatial_index"] = False
 
     filename = tmp_path / f"test.{ext}"
     write(filename, geometry, field_data, fields, **meta)


### PR DESCRIPTION
Closes https://github.com/geopandas/pyogrio/issues/177

This PR adds a minimal implementation of querying metadata items (based on https://github.com/Toblerity/Fiona/pull/950), not yet publicly exposed (we should do that as well at some point), but just enough to use internally.

We then use the metadata to check the dataset and layer creation options for the specific driver, so we can split the `**kwargs` in separate layer and dataset creation kwargs.