### PR TITLE
ENH: expose Arrow-based IO as read_arrow + doc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,9 @@
 
 -   Support for reading based on Arrow as the transfer mechanism of the data
     from GDAL to Python (requires GDAL >= 3.6 and `pyarrow` to be installed).
-    This can be enabled by passing `use_arrow=True` to `pyogrio.read_dataframe`,
-    and provides a further speed-up (#155).
+    This can be enabled by passing `use_arrow=True` to `pyogrio.read_dataframe`
+    (or by using `pyogrio.raw.read_arrow` directly), and provides a further
+    speed-up (#155).
 
 ## O.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.5.0
+
+### Major enhancements
+
+-   Support for reading based on Arrow as the transfer mechanism of the data
+    from GDAL to Python (requires GDAL >= 3.6 and `pyarrow` to be installed).
+    This can be enabled by passing `use_arrow=True` to `pyogrio.read_dataframe`,
+    and provides a further speed-up (#155).
+
 ## O.4.2
 
 ### Improvements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
     from GDAL to Python (requires GDAL >= 3.6 and `pyarrow` to be installed).
     This can be enabled by passing `use_arrow=True` to `pyogrio.read_dataframe`
     (or by using `pyogrio.raw.read_arrow` directly), and provides a further
-    speed-up (#155).
+    speed-up (#155, #191).
 
 ## O.4.2
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1092,12 +1092,7 @@ def ogr_read_arrow(
             GDALClose(ogr_dataset)
             ogr_dataset = NULL
 
-    return (
-        meta,
-        table,
-        None, #geometries,
-        None, #field_data
-    )
+    return meta, table
 
 
 def ogr_read_bounds(

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -1,5 +1,5 @@
 from pyogrio.raw import DRIVERS_NO_MIXED_SINGLE_MULTI
-from pyogrio.raw import detect_driver, read, write
+from pyogrio.raw import detect_driver, read, read_arrow, write
 
 
 def _stringify_path(path):
@@ -115,6 +115,11 @@ def read_dataframe(
     fid_as_index : bool, optional (default: False)
         If True, will use the FIDs of the features that were read as the
         index of the GeoDataFrame.  May start at 0 or 1 depending on the driver.
+    use_arrow : bool, default False
+        Whether to use Arrow as the transfer mechanism of the read data
+        from GDAL to Python (requires GDAL >= 3.6 and `pyarrow` to be
+        installed). When enabled, this provides a further speed-up.
+        Currently not enabled by default.
 
     Returns
     -------
@@ -135,7 +140,8 @@ def read_dataframe(
 
     path_or_buffer = _stringify_path(path_or_buffer)
 
-    meta, index, geometry, field_data = read(
+    read_func = read_arrow if use_arrow else read
+    result = read_func(
         path_or_buffer,
         layer=layer,
         encoding=encoding,
@@ -150,11 +156,10 @@ def read_dataframe(
         sql=sql,
         sql_dialect=sql_dialect,
         return_fids=fid_as_index,
-        use_arrow=use_arrow,
     )
 
     if use_arrow:
-        table = index
+        meta, table = result
         df = table.to_pandas()
         geometry_name = meta["geometry_name"] or "wkb_geometry"
         if geometry_name in df.columns:
@@ -162,6 +167,8 @@ def read_dataframe(
             return gp.GeoDataFrame(df, geometry="geometry")
         else:
             return df
+
+    meta, index, geometry, field_data = result
 
     columns = meta["fields"].tolist()
     data = {columns[i]: field_data[i] for i in range(len(columns))}

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -119,7 +119,6 @@ def read_dataframe(
         Whether to use Arrow as the transfer mechanism of the read data
         from GDAL to Python (requires GDAL >= 3.6 and `pyarrow` to be
         installed). When enabled, this provides a further speed-up.
-        Currently not enabled by default.
 
     Returns
     -------

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pyogrio import __gdal_version__, read_dataframe
+from pyogrio.raw import read_arrow
 
 try:
     import pandas as pd
@@ -11,7 +12,7 @@ except ImportError:
 
 
 pytest.importorskip("geopandas")
-pytest.importorskip("pyarrow")
+pyarrow = pytest.importorskip("pyarrow")
 
 pytestmark = pytest.mark.skipif(
     __gdal_version__ < (3, 6, 0), reason="Arrow tests require GDAL>=3.6"
@@ -67,3 +68,9 @@ def test_read_arrow_nested_types(test_ogr_types_list):
     result = read_dataframe(test_ogr_types_list, use_arrow=True)
     assert "list_int64" in result.columns
     assert result["list_int64"][0].tolist() == [0, 1]
+
+
+def test_read_arrow_raw(naturalearth_lowres):
+    meta, table = read_arrow(naturalearth_lowres)
+    assert isinstance(meta, dict)
+    assert isinstance(table, pyarrow.Table)


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/pyogrio/pull/155 to address the comment at https://github.com/geopandas/pyogrio/pull/155#pullrequestreview-1103120659 to add a raw IO function for pyarrow.Table (so without already the direct conversion to (geo)pandas). 

This PR adds a `read_arrow` function (and removing it as option from the numpy-based raw `read` function).

