### PR TITLE
CI: Fix GDAL docker github action

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -42,7 +42,7 @@ jobs:
           python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
 
       - name: Install pyarrow
-        if: matrix.container == "osgeo/gdal:ubuntu-small-latest"
+        if: matrix.container == 'osgeo/gdal:ubuntu-small-latest'
         run: |
           python3 -m pip install pyarrow
 


### PR DESCRIPTION
Because just to be fun Github actions sometimes allow single or double quotes without caring, but for `if` expressions they [must be single quotes](https://docs.github.com/en/actions/learn-github-actions/expressions#literals).