### PR TITLE
ENH: Add append support to write functions

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -17,6 +17,7 @@ jobs:
     name: GDAL ${{ matrix.container }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container:
           - "osgeo/gdal:ubuntu-small-latest" # >= python 3.8.10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
     This can be enabled by passing `use_arrow=True` to `pyogrio.read_dataframe`
     (or by using `pyogrio.raw.read_arrow` directly), and provides a further
     speed-up (#155, #191).
+-   Support for appending to an existing data source when supported by GDAL by
+    passing `append=True` to `pyogrio.write_dataframe` (#197).
 
 ## O.4.2
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -340,8 +340,8 @@ overrule the default driver for an extension, you can specify the driver with th
 
 ## Appending to an existing data source
 
-Certain drivers may support the ability to append records to an existing data
-source. See the
+Certain drivers may support the ability to append records to an existing
+data layer in an existing data source. See the
 [GDAL driver listing](https://gdal.org/drivers/vector/index.html)
 for details about the capabilities of a driver for your version of GDAL.
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -24,10 +24,15 @@ Not all geometry or field types may be supported for all drivers.
 {...'GeoJSON': 'rw', 'GeoJSONSeq': 'rw',...}
 ```
 
-Drivers that are not known to be supported are listed with `"?"` for capabilities.
-Drivers that are known to support write capability end in `"w"`.
+Drivers that support write capability in your version of GDAL end in `"w"`.
+Certain drivers that are known to be unsupported in Pyogrio are disabled for
+write capabilities.
 
-To find subsets of drivers that have known support:
+NOTE: not all drivers support writing the contents of a GeoDataFrame; you may
+encounter errors due to unsupported data types, unsupported geometry types,
+or other driver-related errors when writing to a data source.
+
+To find subsets of drivers that support read or write capabilities:
 
 ```python
 >>> list_drivers(read=True)
@@ -38,8 +43,13 @@ See the full list of [drivers](https://gdal.org/drivers/vector/index.html) for
 more information about specific drivers, including their write support and
 configuration options.
 
-You can certainly try to read or write using unsupported drivers that are
-available in your installation, but you may encounter errors.
+The following drivers are known to be well-supported and tested in Pyogrio:
+
+-   `ESRI Shapefile`
+-   `FlatGeobuf`
+-   `GeoJSON`
+-   `GeoJSONSeq`
+-   `GPKG`
 
 ## List available layers
 
@@ -327,6 +337,23 @@ By default, the appropriate driver is inferred from the extension of the filenam
 If you want to write another file format supported by GDAL or if you want to
 overrule the default driver for an extension, you can specify the driver with the
 `driver` keyword, e.g. `driver="GPKG"`.
+
+## Appending to an existing data source
+
+Certain drivers may support the ability to append records to an existing data
+source. See the
+[GDAL driver listing](https://gdal.org/drivers/vector/index.html)
+for details about the capabilities of a driver for your version of GDAL.
+
+```
+>>> write_dataframe(df, "/tmp/existing_file.gpkg", append=True)
+```
+
+NOTE: the data structure of the data frame you are appending to the existing
+data source must exactly match the structure of the existing data source.
+
+NOTE: not all drivers that support write capabilities support append
+capabilities for a given GDAL version.
 
 ## Reading from compressed files / archives
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -125,7 +125,6 @@ cdef void* ogr_open(const char* path_c, int mode, options) except NULL:
     else:
         flags |= GDAL_OF_READONLY
 
-    # TODO: other open opts from fiona
     open_opts = CSLAddNameValue(open_opts, "VALIDATE_OPEN_OPTIONS", "NO")
 
     try:
@@ -1062,7 +1061,7 @@ def ogr_read_arrow(
 
         IF CTE_GDAL_VERSION < (3, 6, 0):
             raise RuntimeError("Need GDAL>=3.6 for Arrow support")
-        
+
         if not OGR_L_GetArrowStream(ogr_layer, &stream, options):
             raise RuntimeError("Failed to open ArrowArrayStream from Layer")
 
@@ -1316,10 +1315,10 @@ cdef infer_field_types(list dtypes):
     return field_types
 
 
-# TODO: handle updateable data sources, like GPKG
 # TODO: set geometry and field data as memory views?
 def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
-    str crs, str geometry_type, str encoding, bint promote_to_multi=False, **kwargs):
+    str crs, str geometry_type, str encoding, bint promote_to_multi=False,
+    bint append=False, **kwargs):
 
     cdef const char *path_c = NULL
     cdef const char *layer_c = NULL
@@ -1361,21 +1360,19 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
     if not layer:
         layer = os.path.splitext(os.path.split(path)[1])[0]
 
-    layer_b = layer.encode('UTF-8')
-    layer_c = layer_b
 
     # if shapefile, GeoJSON, or FlatGeobuf, always delete first
     # for other types, check if we can create layers
     # GPKG might be the only multi-layer writeable type.  TODO: check this
     if driver in ('ESRI Shapefile', 'GeoJSON', 'GeoJSONSeq', 'FlatGeobuf') and os.path.exists(path):
-        os.unlink(path)
+        if not append:
+            os.unlink(path)
 
-    # TODO: invert this: if exists then try to update it, if that doesn't work then always create
+    layer_exists = False
     if os.path.exists(path):
         try:
             ogr_dataset = ogr_open(path_c, 1, None)
 
-            # If layer exists, delete it.
             for i in range(GDALDatasetGetLayerCount(ogr_dataset)):
                 name = OGR_L_GetName(GDALDatasetGetLayer(ogr_dataset, i))
                 if layer == name.decode('UTF-8'):
@@ -1383,11 +1380,17 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
                     break
 
             if layer_idx >= 0:
-                GDALDatasetDeleteLayer(ogr_dataset, layer_idx)
+                layer_exists = True
 
-        except DataSourceError:
-            # open failed, so create from scratch
-            # force delete it first
+                if not append:
+                    GDALDatasetDeleteLayer(ogr_dataset, layer_idx)
+
+        except DataSourceError as e:
+            # open failed
+            if append:
+                raise e
+
+            # otherwise create from scratch
             os.unlink(path)
             ogr_dataset = NULL
 
@@ -1395,8 +1398,12 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
     if ogr_dataset == NULL:
         ogr_dataset = ogr_create(path_c, driver_c)
 
+    # if we are not appending to an existing layer, we need to create
+    # the layer and all associated properties (CRS, field defs, etc)
+    create_layer = not (append and layer_exists)
+
     ### Create the CRS
-    if crs is not None:
+    if create_layer and crs is not None:
         try:
             ogr_crs = create_crs(crs)
 
@@ -1405,42 +1412,48 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
             raise exc
 
 
-    ### Create options
-    if not encoding:
-        encoding = locale.getpreferredencoding()
-
-    if driver == 'ESRI Shapefile':
-        # Fiona only sets encoding for shapefiles; other drivers do not support
-        # encoding as an option.
-        encoding_b = encoding.upper().encode('UTF-8')
-        encoding_c = encoding_b
-        options = CSLSetNameValue(options, "ENCODING", encoding_c)
-
-    # Setup other layer creation options
-    for k, v in kwargs.items():
-        if v is None:
-            continue
-
-        k = k.upper().encode('UTF-8')
-
-        if isinstance(v, bool):
-            v = ('ON' if v else 'OFF').encode('utf-8')
-        else:
-            v = str(v).encode('utf-8')
-
-        options = CSLAddNameValue(options, <const char *>k, <const char *>v)
-
-
-    ### Get geometry type
-    # TODO: this is brittle for 3D / ZM / M types
-    # TODO: fail on M / ZM types
-    geometry_code = get_geometry_type_code(geometry_type or "Unknown")
-
     ### Create the layer
+    if create_layer:
+        # Setup layer creation options
+        if not encoding:
+            encoding = locale.getpreferredencoding()
+
+        if driver == 'ESRI Shapefile':
+            # Fiona only sets encoding for shapefiles; other drivers do not support
+            # encoding as an option.
+            encoding_b = encoding.upper().encode('UTF-8')
+            encoding_c = encoding_b
+            options = CSLSetNameValue(options, "ENCODING", encoding_c)
+
+        for k, v in kwargs.items():
+            if v is None:
+                continue
+
+            k = k.upper().encode('UTF-8')
+
+            if isinstance(v, bool):
+                v = ('ON' if v else 'OFF').encode('utf-8')
+            else:
+                v = str(v).encode('utf-8')
+
+            options = CSLAddNameValue(options, <const char *>k, <const char *>v)
+
+        layer_b = layer.encode('UTF-8')
+        layer_c = layer_b
+
+        ### Get geometry type
+        # TODO: this is brittle for 3D / ZM / M types
+        # TODO: fail on M / ZM types
+        geometry_code = get_geometry_type_code(geometry_type or "Unknown")
+
     try:
-        ogr_layer = exc_wrap_pointer(
-                GDALDatasetCreateLayer(ogr_dataset, layer_c, ogr_crs,
-                        <OGRwkbGeometryType>geometry_code, options))
+        if create_layer:
+            ogr_layer = exc_wrap_pointer(
+                    GDALDatasetCreateLayer(ogr_dataset, layer_c, ogr_crs,
+                            geometry_code, options))
+
+        else:
+            ogr_layer = exc_wrap_pointer(get_ogr_layer(ogr_dataset, layer))
 
     except Exception as exc:
         OGRReleaseDataSource(ogr_dataset)
@@ -1456,44 +1469,47 @@ def ogr_write(str path, str layer, str driver, geometry, field_data, fields,
             CSLDestroy(<char**>options)
             options = NULL
 
-    ### Create the fields
+
     field_types = infer_field_types([field.dtype for field in field_data])
-    for i in range(num_fields):
-        field_type, field_subtype, width, precision = field_types[i]
 
-        name_b = fields[i].encode(encoding)
-        try:
-            ogr_fielddef = exc_wrap_pointer(OGR_Fld_Create(name_b, field_type))
+    ### Create the fields
+    if create_layer:
+        for i in range(num_fields):
+            field_type, field_subtype, width, precision = field_types[i]
 
-            # subtypes, see: https://gdal.org/development/rfc/rfc50_ogr_field_subtype.html
-            if field_subtype != OFSTNone:
-                OGR_Fld_SetSubType(ogr_fielddef, field_subtype)
+            name_b = fields[i].encode(encoding)
+            try:
+                ogr_fielddef = exc_wrap_pointer(OGR_Fld_Create(name_b, field_type))
 
-            if width:
-                OGR_Fld_SetWidth(ogr_fielddef, width)
+                # subtypes, see: https://gdal.org/development/rfc/rfc50_ogr_field_subtype.html
+                if field_subtype != OFSTNone:
+                    OGR_Fld_SetSubType(ogr_fielddef, field_subtype)
 
-            # TODO: set precision
+                if width:
+                    OGR_Fld_SetWidth(ogr_fielddef, width)
 
-        except:
-            if ogr_fielddef != NULL:
-                OGR_Fld_Destroy(ogr_fielddef)
-                ogr_fielddef = NULL
+                # TODO: set precision
 
-            OGRReleaseDataSource(ogr_dataset)
-            ogr_dataset = NULL
-            raise FieldError(f"Error creating field '{fields[i]}' from field_data") from None
+            except:
+                if ogr_fielddef != NULL:
+                    OGR_Fld_Destroy(ogr_fielddef)
+                    ogr_fielddef = NULL
 
-        try:
-            exc_wrap_int(OGR_L_CreateField(ogr_layer, ogr_fielddef, 1))
+                OGRReleaseDataSource(ogr_dataset)
+                ogr_dataset = NULL
+                raise FieldError(f"Error creating field '{fields[i]}' from field_data") from None
 
-        except:
-            OGRReleaseDataSource(ogr_dataset)
-            ogr_dataset = NULL
-            raise FieldError(f"Error adding field '{fields[i]}' to layer") from None
+            try:
+                exc_wrap_int(OGR_L_CreateField(ogr_layer, ogr_fielddef, 1))
 
-        finally:
-            if ogr_fielddef != NULL:
-                OGR_Fld_Destroy(ogr_fielddef)
+            except:
+                OGRReleaseDataSource(ogr_dataset)
+                ogr_dataset = NULL
+                raise FieldError(f"Error adding field '{fields[i]}' to layer") from None
+
+            finally:
+                if ogr_fielddef != NULL:
+                    OGR_Fld_Destroy(ogr_fielddef)
 
 
     ### Create the features

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -103,7 +103,7 @@ def get_gdal_config_option(str name):
 def ogr_driver_supports_write(driver):
     # exclude drivers known to be unsupported by pyogrio even though they are
     # supported for write by GDAL
-    if driver in {"CSV", "XLSX"}:
+    if driver in {"XLSX"}:
         return False
 
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -189,6 +189,7 @@ def write_dataframe(
     encoding=None,
     geometry_type=None,
     promote_to_multi=None,
+    append=False,
     **kwargs,
 ):
     """
@@ -232,6 +233,10 @@ def write_dataframe(
         types will not be promoted, which may result in errors or invalid files when
         attempting to write mixed singular and multi geometry types to drivers that do
         not support such combinations.
+    append : bool, optional (default: False)
+        If True, the data source specified by path already exists, and the
+        driver supports appending to an existing data source, will cause the
+        data to be appended to the existing records in the data source.
     **kwargs
         The kwargs passed to OGR.
     """
@@ -335,5 +340,6 @@ def write_dataframe(
         geometry_type=geometry_type,
         encoding=encoding,
         promote_to_multi=promote_to_multi,
+        append=append,
         **kwargs,
     )

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -259,6 +259,7 @@ def write_dataframe(
         If True, the data source specified by path already exists, and the
         driver supports appending to an existing data source, will cause the
         data to be appended to the existing records in the data source.
+        NOTE: append support is limited to specific drivers and GDAL versions.
     **kwargs
         Additional driver-specific dataset or layer creation options passed
         to OGR. pyogrio will attempt to automatically pass those keywords

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -196,9 +196,9 @@ def write_dataframe(
     geometry_type=None,
     promote_to_multi=None,
     nan_as_null=True,
+    append=False,
     dataset_options=None,
     layer_options=None,
-    append=False,
     **kwargs,
 ):
     """
@@ -249,17 +249,17 @@ def write_dataframe(
         behaviour is format specific: some formats don't support NaNs by
         default (e.g. GeoJSON will skip this property) or might treat them as
         null anyway (e.g. GeoPackage).
+    append : bool, optional (default: False)
+        If True, the data source specified by path already exists, and the
+        driver supports appending to an existing data source, will cause the
+        data to be appended to the existing records in the data source.
+        NOTE: append support is limited to specific drivers and GDAL versions.
     dataset_options : dict, optional
         Dataset creation option (format specific) passed to OGR. Specify as
         a key-value dictionary.
     layer_options : dict, optional
         Layer creation option (format specific) passed to OGR. Specify as
         a key-value dictionary.
-    append : bool, optional (default: False)
-        If True, the data source specified by path already exists, and the
-        driver supports appending to an existing data source, will cause the
-        data to be appended to the existing records in the data source.
-        NOTE: append support is limited to specific drivers and GDAL versions.
     **kwargs
         Additional driver-specific dataset or layer creation options passed
         to OGR. pyogrio will attempt to automatically pass those keywords
@@ -370,8 +370,8 @@ def write_dataframe(
         encoding=encoding,
         promote_to_multi=promote_to_multi,
         nan_as_null=nan_as_null,
+        append=append,
         dataset_options=dataset_options,
         layer_options=layer_options,
-        append=append,
         **kwargs,
     )

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -271,9 +271,9 @@ def write(
     encoding=None,
     promote_to_multi=None,
     nan_as_null=True,
+    append=False,
     dataset_options=None,
     layer_options=None,
-    append=False,
     **kwargs,
 ):
     if geometry_type is None:
@@ -339,7 +339,7 @@ def write(
         encoding=encoding,
         promote_to_multi=promote_to_multi,
         nan_as_null=nan_as_null,
+        append=append,
         dataset_kwargs=dataset_kwargs,
         layer_kwargs=layer_kwargs,
-        append=append,
     )

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -6,7 +6,11 @@ from pyogrio.util import get_vsi_path
 
 with GDALEnv():
     from pyogrio._io import ogr_read, ogr_read_arrow, ogr_write
-    from pyogrio._ogr import remove_virtual_file, _get_driver_metadata_item
+    from pyogrio._ogr import (
+        get_gdal_version,
+        remove_virtual_file,
+        _get_driver_metadata_item,
+    )
 
 
 DRIVERS = {
@@ -274,6 +278,12 @@ def write(
 
     if driver is None:
         driver = detect_driver(path)
+
+    # prevent segfault from: https://github.com/OSGeo/gdal/issues/5739
+    if append and driver == "FlatGeobuf" and get_gdal_version() <= (3, 5, 0):
+        raise RuntimeError(
+            "append to FlatGeobuf is not supported for GDAL <= 3.5.0 due to segfault"
+        )
 
     if promote_to_multi is None:
         promote_to_multi = (

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -183,6 +183,7 @@ def write(
     crs=None,
     encoding=None,
     promote_to_multi=None,
+    append=False,
     **kwargs,
 ):
     if geometry_type is None:
@@ -215,5 +216,6 @@ def write(
         crs=crs,
         encoding=encoding,
         promote_to_multi=promote_to_multi,
+        append=append,
         **kwargs,
     )

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -12,7 +12,10 @@ ALL_EXTS = [".fgb", ".geojson", ".geojsonl", ".gpkg", ".shp"]
 
 
 def pytest_report_header(config):
-    drivers = ", ".join(sorted(list(list_drivers(read=True).keys())))
+    drivers = ", ".join(
+        f"{driver}({capability})"
+        for driver, capability in sorted(list_drivers().items())
+    )
     return (
         f"pyogrio {__version__}\n"
         f"GDAL {__gdal_version_string__}\n"

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -18,7 +18,7 @@ from pyogrio._env import GDALEnv
 with GDALEnv():
     # NOTE: this must be AFTER above imports, which init the GDAL and PROJ data
     # search paths
-    from pyogrio._ogr import has_gdal_data, has_proj_data
+    from pyogrio._ogr import ogr_driver_supports_write, has_gdal_data, has_proj_data
 
 
 def test_gdal_data():
@@ -43,6 +43,26 @@ def test_gdal_geos_version():
     assert __gdal_geos_version__ is None or isinstance(__gdal_geos_version__, tuple)
 
 
+@pytest.mark.parametrize(
+    "driver,expected",
+    [
+        # drivers known to be well-supported by pyogrio
+        ("ESRI Shapefile", True),
+        ("GeoJSON", True),
+        ("GeoJSONSeq", True),
+        ("GPKG", True),
+        # drivers not supported for write by GDAL
+        ("HTTP", False),
+        ("OAPIF", False),
+        # drivers currently unsupported for write even though GDAL can write them
+        ("CSV", False),
+        ("XLSX", False),
+    ],
+)
+def test_ogr_driver_supports_write(driver, expected):
+    assert ogr_driver_supports_write(driver) == expected
+
+
 def test_list_drivers():
     all_drivers = list_drivers()
 
@@ -50,8 +70,11 @@ def test_list_drivers():
     for name in ("ESRI Shapefile", "GeoJSON", "GeoJSONSeq", "GPKG", "OpenFileGDB"):
         assert name in all_drivers
 
-    assert all_drivers["ESRI Shapefile"] == "rw"
-    assert all_drivers["OpenFileGDB"] == "r"
+        expected_capability = "rw"
+        if name == "OpenFileGDB" and __gdal_version__ < (3, 6, 0):
+            expected_capability = "r"
+
+        assert all_drivers[name] == expected_capability
 
     drivers = list_drivers(read=True)
     expected = {k: v for k, v in all_drivers.items() if v.startswith("r")}

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -55,7 +55,6 @@ def test_gdal_geos_version():
         ("HTTP", False),
         ("OAPIF", False),
         # drivers currently unsupported for write even though GDAL can write them
-        ("CSV", False),
         ("XLSX", False),
     ],
 )

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -471,6 +471,36 @@ def test_write_read_empty_dataframe_unsupported(tmp_path, ext):
         _ = read_dataframe(filename)
 
 
+def test_write_dataframe_gpkg_multiple_layers(tmp_path, naturalearth_lowres):
+    input_gdf = read_dataframe(naturalearth_lowres)
+    output_path = tmp_path / "test.gpkg"
+
+    write_dataframe(input_gdf, output_path, layer="first", promote_to_multi=True)
+
+    assert os.path.exists(output_path)
+    assert np.array_equal(list_layers(output_path), [["first", "MultiPolygon"]])
+
+    write_dataframe(input_gdf, output_path, layer="second", promote_to_multi=True)
+    assert np.array_equal(
+        list_layers(output_path),
+        [["first", "MultiPolygon"], ["second", "MultiPolygon"]],
+    )
+
+
+@pytest.mark.parametrize("ext", ALL_EXTS)
+def test_write_dataframe_append(tmp_path, naturalearth_lowres, ext):
+    input_gdf = read_dataframe(naturalearth_lowres)
+    output_path = tmp_path / f"test{ext}"
+
+    write_dataframe(input_gdf, output_path)
+
+    assert os.path.exists(output_path)
+    assert len(read_dataframe(output_path)) == 177
+
+    write_dataframe(input_gdf, output_path, append=True)
+    assert len(read_dataframe(output_path)) == 354
+
+
 def test_write_dataframe_gdalparams(tmp_path, naturalearth_lowres):
     original_df = read_dataframe(naturalearth_lowres)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import pytest
 
-from pyogrio import list_layers, read_info, __gdal_geos_version__
+from pyogrio import list_layers, read_info, __gdal_version__, __gdal_geos_version__
 from pyogrio.errors import DataLayerError, DataSourceError, FeatureError, GeometryError
 from pyogrio.geopandas import read_dataframe, write_dataframe
 from pyogrio.raw import DRIVERS, DRIVERS_NO_MIXED_SINGLE_MULTI
@@ -489,6 +489,12 @@ def test_write_dataframe_gpkg_multiple_layers(tmp_path, naturalearth_lowres):
 
 @pytest.mark.parametrize("ext", ALL_EXTS)
 def test_write_dataframe_append(tmp_path, naturalearth_lowres, ext):
+    if ext == ".fgb" and __gdal_version__ <= (3, 5, 0):
+        pytest.skip("Append to FlatGeobuf fails for GDAL <= 3.5.0")
+
+    if ext in (".geojsonl", ".geojsons") and __gdal_version__ <= (3, 6, 0):
+        pytest.skip("Append to GeoJSONSeq only available for GDAL >= 3.6.0")
+
     input_gdf = read_dataframe(naturalearth_lowres)
     output_path = tmp_path / f"test{ext}"
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy import array_equal
 import pytest
 
-from pyogrio import list_layers, list_drivers, read_info
+from pyogrio import list_layers, list_drivers, read_info, __gdal_version__
 from pyogrio.raw import DRIVERS, read, write
 from pyogrio.errors import DataSourceError, DataLayerError, FeatureError
 from pyogrio.tests.conftest import prepare_testfile
@@ -313,6 +313,12 @@ def test_write_geojson(tmpdir, naturalearth_lowres):
 
 @pytest.mark.parametrize("ext", DRIVERS)
 def test_write_append(tmpdir, naturalearth_lowres, ext):
+    if ext == ".fgb" and __gdal_version__ <= (3, 5, 0):
+        pytest.skip("Append to FlatGeobuf fails for GDAL <= 3.5.0")
+
+    if ext in (".geojsonl", ".geojsons") and __gdal_version__ < (3, 6, 0):
+        pytest.skip("Append to GeoJSONSeq only available for GDAL >= 3.6.0")
+
     meta, _, geometry, field_data = read(naturalearth_lowres)
 
     # coerce output layer to MultiPolygon to avoid mixed type errors
@@ -331,22 +337,44 @@ def test_write_append(tmpdir, naturalearth_lowres, ext):
     assert read_info(filename)["features"] == 354
 
 
-def test_write_append_unsupported(tmpdir, naturalearth_lowres):
+@pytest.mark.parametrize("driver,ext", [("GML", ".gml"), ("GeoJSONSeq", ".geojsons")])
+def test_write_append_unsupported(tmpdir, naturalearth_lowres, driver, ext):
+    if ext == ".geojsons" and __gdal_version__ >= (3, 6, 0):
+        pytest.skip("Append to GeoJSONSeq supported for GDAL >= 3.6.0")
+
     meta, _, geometry, field_data = read(naturalearth_lowres)
 
     # GML does not support append functionality
-    filename = os.path.join(str(tmpdir), "test.gml")
-    write(filename, geometry, field_data, driver="GML", **meta)
+    filename = os.path.join(str(tmpdir), f"test{ext}")
+    write(filename, geometry, field_data, driver=driver, **meta)
 
     assert os.path.exists(filename)
 
     assert read_info(filename)["features"] == 177
 
     with pytest.raises(DataSourceError):
-        # NOTE: the raw error from GDAL is confusing:
-        # ("not recognized as a supported file format")
-        # TODO: we should probably check for append support ourselves
-        write(filename, geometry, field_data, driver="GML", append=True, **meta)
+        write(filename, geometry, field_data, driver=driver, append=True, **meta)
+
+
+@pytest.mark.skipif(
+    __gdal_version__ > (3, 5, 0),
+    reason="segfaults on FlatGeobuf limited to GDAL <= 3.5.0",
+)
+def test_write_append_prevent_gdal_segfault(tmpdir, naturalearth_lowres):
+    """GDAL <= 3.5.0 segfaults when appending to FlatGeobuf; this test
+    verifies that we catch that before segfault"""
+    meta, _, geometry, field_data = read(naturalearth_lowres)
+    meta["geometry_type"] = "MultiPolygon"
+
+    filename = os.path.join(str(tmpdir), "test.fgb")
+    write(filename, geometry, field_data, **meta)
+
+    assert os.path.exists(filename)
+
+    with pytest.raises(
+        RuntimeError,  # match="append to FlatGeobuf is not supported for GDAL <= 3.5.0"
+    ):
+        write(filename, geometry, field_data, append=True, **meta)
 
 
 @pytest.mark.parametrize(

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -379,14 +379,14 @@ def test_write_append_prevent_gdal_segfault(tmpdir, naturalearth_lowres):
 
 @pytest.mark.parametrize(
     "driver",
-    [
+    {
         driver
-        for driver in list_drivers(write=True)
+        for driver in DRIVERS.values()
         if driver not in ("ESRI Shapefile", "GPKG", "GeoJSON")
-    ],
+    },
 )
 def test_write_supported(tmpdir, naturalearth_lowres, driver):
-    """Test drivers not specifically tested above"""
+    """Test drivers known to work that are not specifically tested above"""
     meta, _, geometry, field_data = read(naturalearth_lowres, columns=["iso_a3"])
 
     # note: naturalearth_lowres contains mixed polygons / multipolygons, which
@@ -406,6 +406,9 @@ def test_write_supported(tmpdir, naturalearth_lowres, driver):
     assert filename.exists()
 
 
+@pytest.mark.skipif(
+    __gdal_version__ >= (3, 6, 0), reason="OpenFileGDB supports write for GDAL >= 3.6.0"
+)
 def test_write_unsupported(tmpdir, naturalearth_lowres):
     meta, _, geometry, field_data = read(naturalearth_lowres)
 


### PR DESCRIPTION
Resolves #137 

This adds basic support to append additional records to existing layers when supported by the driver.

This uses driver metadata plus a known list of drivers to exclude in order to determine which drivers support write capability (and updates listing from `list_drivers()`), and raises errors when attempting to write to unsupported drivers.

This adds a specific GDAL version test when appending to FlatGeobuf to avoid segfaults due to https://github.com/OSGeo/gdal/issues/5739; anything prior to GDAL 3.5.1 appears to segfault.

I could not find a driver metadata key that indicates if a driver supports append capability.  Rather than try to maintain a list of known drivers that support append, I think we probably just need to let GDAL raise the errors when a given driver / GDAL version does not support append.