### PR TITLE
CI: Update GDAL versions in docker GDAL tests

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -20,7 +20,8 @@ jobs:
       matrix:
         container:
           - "osgeo/gdal:ubuntu-small-latest" # >= python 3.8.10
-          - "osgeo/gdal:ubuntu-small-3.5.0" # python 3.8.10
+          - "osgeo/gdal:ubuntu-small-3.6.2" # python 3.10.6
+          - "osgeo/gdal:ubuntu-small-3.5.3" # python 3.8.10
           - "osgeo/gdal:ubuntu-small-3.4.3" # python 3.8.10
           - "osgeo/gdal:ubuntu-small-3.3.3" # python 3.8.10
           - "osgeo/gdal:ubuntu-small-3.2.3" # python 3.8.5


### PR DESCRIPTION
Updates to latest 3.5 version and adds entry for latest 3.6 version