### PR TITLE
FIX: Only use transactions when writing features if layer supports them

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1353,6 +1353,7 @@ def ogr_write(
     cdef unsigned char *wkb_buffer = NULL
     cdef OGRSpatialReferenceH ogr_crs = NULL
     cdef int layer_idx = -1
+    cdef int supports_transactions = 0
     cdef OGRwkbGeometryType geometry_code
     cdef int err = 0
     cdef int i = 0
@@ -1536,7 +1537,10 @@ def ogr_write(
     ### Create the features
     ogr_featuredef = OGR_L_GetLayerDefn(ogr_layer)
 
-    start_transaction(ogr_dataset, 0)
+    supports_transactions = OGR_L_TestCapability(ogr_layer, OLCTransactions)
+    if supports_transactions:
+        start_transaction(ogr_dataset, 0)
+
     for i in range(num_records):
         try:
             # create the feature
@@ -1668,7 +1672,8 @@ def ogr_write(
                 OGR_F_Destroy(ogr_feature)
                 ogr_feature = NULL
 
-    commit_transaction(ogr_dataset)
+    if supports_transactions:
+        commit_transaction(ogr_dataset)
 
     log.info(f"Created {num_records:,} records" )
 

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -294,6 +294,7 @@ cdef extern from "ogr_api.h":
     const char*     OLCRandomRead
     const char*     OLCFastSetNextByIndex
     const char*     OLCFastSpatialFilter
+    const char*     OLCTransactions
 
 
 IF CTE_GDAL_VERSION >= (3, 6, 0):

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -18,6 +18,7 @@ with GDALEnv():
 
 DRIVERS = {
     ".fgb": "FlatGeobuf",
+    ".gdb": "OpenFileGDB",
     ".geojson": "GeoJSON",
     ".geojsonl": "GeoJSONSeq",
     ".geojsons": "GeoJSONSeq",

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -18,7 +18,6 @@ with GDALEnv():
 
 DRIVERS = {
     ".fgb": "FlatGeobuf",
-    ".gdb": "OpenFileGDB",
     ".geojson": "GeoJSON",
     ".geojsonl": "GeoJSONSeq",
     ".geojsons": "GeoJSONSeq",

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -398,7 +398,7 @@ def test_write_append_prevent_gdal_segfault(tmpdir, naturalearth_lowres):
     {
         driver
         for driver in DRIVERS.values()
-        if driver not in ("ESRI Shapefile", "GPKG", "GeoJSON", "OpenFileGDB")
+        if driver not in ("ESRI Shapefile", "GPKG", "GeoJSON")
     },
 )
 def test_write_supported(tmpdir, naturalearth_lowres, driver):


### PR DESCRIPTION
OpenFileGDB now supports write from GDAL 3.6.0 onwards, but does not support transactions.  We were always assuming transaction support was present because it was available for all drivers we specifically tested previously (though GDAL makes clear not all datasets / layers support transactions).

This adds a check for that capability and creates features without a transaction if layer doesn't support them, and adds a test to ensure that we can write OpenFileGDB correctly now.