### PR TITLE
Fix memory leak in reading data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.5.1
+
+### Bug fixes
+
+-   Fix memory leak in reading files (#207)
+
 ## 0.5.0 (2023-01-16)
 
 ### Major enhancements


### PR DESCRIPTION
Closes #207

The diff looks messy, but the only thing that it did was putting a `try: ... finally: ...` around each block that deals with a feature (as we already did in the writing path).