### PR TITLE
Fixed URL for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ setup(
     name="pyogrio",
     version=version,
     packages=find_packages(),
-    url="https://github.com/pyogrio/pyogrio",
+    url="https://github.com/geopandas/pyogrio",
     license="MIT",
     author="Brendan C. Ward",
     author_email="bcward@astutespruce.com",


### PR DESCRIPTION
...clicking on "Homepage" lead to a 404