### PR TITLE
ENH: support mask for missing values when writing data / support writing pandas nullable dtypes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 -   Add "driver" property to `read_info` result (#224)
 -   Add support for dataset open options to `read`, `read_dataframe`, and
     `read_info` (#233)
+-   Add support for pandas' nullable data types in `write_dataframe`, or
+    specifying a mask manually for missing values in `write` (#219)
 
 ## 0.5.1 (2023-01-26)
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1403,7 +1403,7 @@ def ogr_write(
         if len(field_data) != len(field_mask):
             raise ValueError("field_data and field_mask must be same length")
         for i in range(0, len(field_mask)):
-            if field_data[i] is not None and len(field_data[i]) != num_records:
+            if field_mask[i] is not None and len(field_mask[i]) != num_records:
                 raise ValueError("field_mask arrays must be same length as geometry array")
     else:
         field_mask = [None] * len(field_data)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1404,7 +1404,7 @@ def ogr_write(
             raise ValueError("field_data and field_mask must be same length")
         for i in range(0, len(field_mask)):
             if field_data[i] is not None and len(field_data[i]) != num_records:
-                    raise ValueError("field_data arrays must be same length as geometry array")
+                raise ValueError("field_mask arrays must be same length as geometry array")
     else:
         field_mask = [None] * len(field_data)
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -310,12 +310,15 @@ def write_dataframe(
     field_mask = []
     for name in fields:
         col = df[name].values
-        if isinstance(
-            col,
-            (pd.arrays.BooleanArray, pd.arrays.IntegerArray, pd.arrays.FloatingArray),
-        ):
-            field_data.append(col._data)
-            field_mask.append(col._mask)
+        if isinstance(col, pd.api.extensions.ExtensionArray):
+            from pandas.arrays import IntegerArray, FloatingArray, BooleanArray
+
+            if isinstance(col, (IntegerArray, FloatingArray, BooleanArray)):
+                field_data.append(col._data)
+                field_mask.append(col._mask)
+            else:
+                field_data.append(np.asarray(col))
+                field_mask.append(np.asarray(col.isna()))
         else:
             field_data.append(col)
             field_mask.append(None)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -306,7 +306,19 @@ def write_dataframe(
     fields = [c for c in df.columns if not c == geometry_column]
 
     # TODO: may need to fill in pd.NA, etc
-    field_data = [df[f].values for f in fields]
+    field_data = []
+    field_mask = []
+    for name in fields:
+        col = df[name].values
+        if isinstance(
+            col,
+            (pd.arrays.BooleanArray, pd.arrays.IntegerArray, pd.arrays.FloatingArray),
+        ):
+            field_data.append(col._data)
+            field_mask.append(col._mask)
+        else:
+            field_data.append(col)
+            field_mask.append(None)
 
     # Determine geometry_type and/or promote_to_multi
     if geometry_type is None or promote_to_multi is None:
@@ -381,6 +393,7 @@ def write_dataframe(
         driver=driver,
         geometry=to_wkb(geometry.values),
         field_data=field_data,
+        field_mask=field_mask,
         fields=fields,
         crs=crs,
         geometry_type=geometry_type,

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -267,6 +267,7 @@ def write(
     geometry,
     field_data,
     fields,
+    field_mask=None,
     layer=None,
     driver=None,
     # derived from meta if roundtrip
@@ -338,6 +339,7 @@ def write(
         geometry=geometry,
         geometry_type=geometry_type,
         field_data=field_data,
+        field_mask=field_mask,
         fields=fields,
         crs=crs,
         encoding=encoding,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -952,3 +952,21 @@ def test_read_multisurface(data_dir):
 
     # MultiSurface should be converted to MultiPolygon
     assert df.geometry.type.tolist() == ["MultiPolygon"]
+
+
+def test_write_nullable_dtypes(tmp_path):
+    path = tmp_path / "test_nullable_dtypes.gpkg"
+    test_data = {
+        "col1": pd.Series([1, 2, 3], dtype="int64"),
+        "col2": pd.Series([1, 2, None], dtype="Int64"),
+        "col3": pd.Series([0.1, None, 0.3], dtype="Float32"),
+        "col4": pd.Series([True, False, None], dtype="boolean"),
+    }
+    input_gdf = gp.GeoDataFrame(test_data, geometry=[Point(0, 0)] * 3, crs="epsg:31370")
+    write_dataframe(input_gdf, path)
+    output_gdf = read_dataframe(path)
+    expected = input_gdf.copy()
+    expected["col2"] = expected["col2"].astype("float64")
+    expected["col3"] = expected["col3"].astype("float32")
+    expected["col4"] = expected["col4"].astype("float64")
+    assert_geodataframe_equal(output_gdf, expected)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1036,6 +1036,8 @@ def test_write_nullable_dtypes(tmp_path):
     input_gdf = gp.GeoDataFrame(test_data, geometry=[Point(0, 0)] * 3, crs="epsg:31370")
     write_dataframe(input_gdf, path)
     output_gdf = read_dataframe(path)
+    # We read it back as default (non-nullable) numpy dtypes, so we cast
+    # to those for the expected result
     expected = input_gdf.copy()
     expected["col2"] = expected["col2"].astype("float64")
     expected["col3"] = expected["col3"].astype("float32")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -961,6 +961,7 @@ def test_write_nullable_dtypes(tmp_path):
         "col2": pd.Series([1, 2, None], dtype="Int64"),
         "col3": pd.Series([0.1, None, 0.3], dtype="Float32"),
         "col4": pd.Series([True, False, None], dtype="boolean"),
+        "col5": pd.Series(["a", None, "b"], dtype="string"),
     }
     input_gdf = gp.GeoDataFrame(test_data, geometry=[Point(0, 0)] * 3, crs="epsg:31370")
     write_dataframe(input_gdf, path)
@@ -969,4 +970,5 @@ def test_write_nullable_dtypes(tmp_path):
     expected["col2"] = expected["col2"].astype("float64")
     expected["col3"] = expected["col3"].astype("float32")
     expected["col4"] = expected["col4"].astype("float64")
+    expected["col5"] = expected["col5"].astype(object)
     assert_geodataframe_equal(output_gdf, expected)


### PR DESCRIPTION
Closes https://github.com/geopandas/pyogrio/issues/219

The required change in cython to suppport passing a mask is actually quite limited, it's mostly new code in geopandas.py to get the proper data/mask.