### PR TITLE
Fix compile warning for OGRwkbGeometryType enum case

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1622,7 +1622,7 @@ def ogr_write(
             # TODO: geometry must not be null or errors
             wkb = geometry[i]
             if wkb is not None:
-                wkbtype = bytearray(wkb)[1]
+                wkbtype = <int>bytearray(wkb)[1]
                 # may need to consider all 4 bytes: int.from_bytes(wkb[0][1:4], byteorder="little")
                 # use "little" if the first byte == 1
                 ogr_geometry = OGR_G_CreateGeometry(<OGRwkbGeometryType>wkbtype)


### PR DESCRIPTION
To avoid warnings like

```
pyogrio/_io.c: In function ‘__pyx_pf_7pyogrio_3_io_10ogr_write’:
pyogrio/_io.c:23290:13: warning: case label value is less than minimum value for type
23290 |             case wkbPolygon25D:
      |             ^~~~
pyogrio/_io.c:23260:13: warning: case label value is less than minimum value for type
23260 |             case wkbLineString25D:
      |             ^~~~
...
```

Without the cast to int, I suppose `wkbtype` in interpreted as a `char` by cython, which is a single byte (so only range of int8), while some of the wkb types defined in the enum in GDAL are big integers: https://github.com/jorisvandenbossche/gdal/blob/481966e5099057d8cada051e036ae00dcb4af485/ogr/ogr_core.h#L406-L520

(in practice it seems to work though, since we can write 3D geometries, so it's just for getting rid of the warning)