### PR TITLE
TST: fix datetime test for pandas 2.0 (preserves ms resolution)

### DIFF
--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+from packaging.version import Version
 
 import numpy as np
 import pytest
@@ -130,7 +131,11 @@ def test_read_layer_invalid(naturalearth_lowres_all_ext):
 @pytest.mark.filterwarnings("ignore: Measured")
 def test_read_datetime(test_fgdb_vsi):
     df = read_dataframe(test_fgdb_vsi, layer="test_lines", max_features=1)
-    assert df.SURVEY_DAT.dtype.name == "datetime64[ns]"
+    if Version(pd.__version__) >= Version("2.0.0"):
+        # starting with pandas 2.0, it preserves the passed datetime resolution
+        assert df.SURVEY_DAT.dtype.name == "datetime64[ms]"
+    else:
+        assert df.SURVEY_DAT.dtype.name == "datetime64[ns]"
 
 
 def test_read_null_values(test_fgdb_vsi):


### PR DESCRIPTION
Pandas 2.0 was released, so our CI started to fail. 

We might want to add some various versions of (geo)pandas to the different CI builds, because right now basically all builds were failing, indicating they are all using pandas 2.0 already (except the one minimal build without (geo)pandas)