### PR TITLE
 ENH: raise Python warnings instead of printing to stderr for GDAL Warning messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,9 @@
     specifying a mask manually for missing values in `write` (#219)
 -   Standardized 3-dimensional geometry type labels from "2.5D <type>" to
     "<type> Z" for consistency with well-known text (WKT) formats (#234)
--   Failure error messages from GDAL are no longer printed to stderr (they were
-    already translated into Python exceptions as well) (#236).
+-   Failure and warning error messages from GDAL are no longer printed to
+    stderr: failures were already translated into Python exceptions as well,
+    and warning messages are now translated into Python warnings (#236, #242).
 
 ## 0.5.1 (2023-01-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 -   Standardized 3-dimensional geometry type labels from "2.5D <type>" to
     "<type> Z" for consistency with well-known text (WKT) formats (#234)
 -   Failure and warning error messages from GDAL are no longer printed to
-    stderr: failures were already translated into Python exceptions as well,
+    stderr: failures were already translated into Python exceptions
     and warning messages are now translated into Python warnings (#236, #242).
 
 ## 0.5.1 (2023-01-26)

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -1,5 +1,6 @@
 # ported from fiona::_err.pyx
 from enum import IntEnum
+import warnings
 
 from pyogrio._ogr cimport (
     CE_None, CE_Debug, CE_Warning, CE_Failure, CE_Fatal, CPLErrorReset,
@@ -227,6 +228,13 @@ cdef void error_handler(CPLErr err_class, int err_no, const char* err_msg) nogil
     elif err_class == CE_Failure:
         # For Failures, do nothing as those are explicitly caught
         # with error return codes and translated into Python exceptions
+        return
+
+    elif err_class == CE_Warning:
+        with gil:
+            msg_b = err_msg
+            msg = msg_b.decode('utf-8')
+            warnings.warn(msg, RuntimeWarning)
         return
 
     # Fall back to the default handler for non-failure messages since

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -165,7 +165,7 @@ def read_info(path_or_buffer, /, layer=None, encoding=None, **kwargs):
         source.
     **kwargs
         Additional driver-specific dataset open options passed to OGR.  Invalid
-        options are logged by OGR to stderr and are not captured.
+        options will trigger a warning.
 
     Returns
     -------

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -124,7 +124,7 @@ def read_dataframe(
         installed). When enabled, this provides a further speed-up.
     **kwargs
         Additional driver-specific dataset open options passed to OGR.  Invalid
-        options are logged by OGR to stderr and are not captured.
+        options will trigger a warning.
 
     Returns
     -------

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -110,7 +110,7 @@ def read(
         If True, will return the FIDs of the feature that were read.
     **kwargs
         Additional driver-specific dataset open options passed to OGR.  Invalid
-        options are logged by OGR to stderr and are not captured.
+        options will trigger a warning.
 
     Returns
     -------

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -42,6 +42,7 @@ def prepare_testfile(testfile_path, dst_dir, ext):
     elif ext == ".gpkg":
         # For .gpkg, spatial_index=False to avoid the rows being reordered
         meta["spatial_index"] = False
+        meta["geometry_type"] = "MultiPolygon"
 
     write(dst_path, geometry, field_data, **meta)
     return dst_path

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -298,3 +298,8 @@ def test_error_handling(capfd):
         read_info("non-existent.shp")
 
     assert capfd.readouterr().err == ""
+
+
+def test_error_handling_warning(capfd, naturalearth_lowres):
+    read_info(naturalearth_lowres, INVALID="YES")
+    assert "does not support open option INVALID" in capfd.readouterr().err

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -263,9 +263,9 @@ def test_read_info_dataset_kwargs(data_dir, dataset_kwargs, fields):
     assert meta["fields"].tolist() == fields
 
 
-def test_read_info_invalid_dataset_kwargs(capfd, naturalearth_lowres):
-    read_info(naturalearth_lowres, INVALID="YES")
-    assert "does not support open option INVALID" in capfd.readouterr().err
+def test_read_info_invalid_dataset_kwargs(naturalearth_lowres):
+    with pytest.warns(RuntimeWarning, match="does not support open option INVALID"):
+        read_info(naturalearth_lowres, INVALID="YES")
 
 
 @pytest.mark.parametrize(
@@ -301,5 +301,9 @@ def test_error_handling(capfd):
 
 
 def test_error_handling_warning(capfd, naturalearth_lowres):
-    read_info(naturalearth_lowres, INVALID="YES")
-    assert "does not support open option INVALID" in capfd.readouterr().err
+    # an operation that triggers a GDAL Warning
+    # -> translated into a Python warning + not printed to stderr
+    with pytest.warns(RuntimeWarning, match="does not support open option INVALID"):
+        read_info(naturalearth_lowres, INVALID="YES")
+
+    assert capfd.readouterr().err == ""

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import datetime
 import os
 from packaging.version import Version
@@ -649,12 +650,21 @@ def test_write_dataframe_promote_to_multi_layer_geom_type(
     input_gdf = read_dataframe(naturalearth_lowres)
 
     output_path = tmp_path / f"test_promote_layer_geom_type{ext}"
-    write_dataframe(
-        input_gdf,
-        output_path,
-        promote_to_multi=promote_to_multi,
-        geometry_type=geometry_type,
-    )
+
+    if ext == ".gpkg" and geometry_type in ("Polygon", "Point"):
+        ctx = pytest.warns(
+            RuntimeWarning, match="A geometry of type MULTIPOLYGON is inserted"
+        )
+    else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
+        write_dataframe(
+            input_gdf,
+            output_path,
+            promote_to_multi=promote_to_multi,
+            geometry_type=geometry_type,
+        )
 
     assert output_path.exists()
     output_gdf = read_dataframe(output_path)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1024,9 +1024,9 @@ def test_read_dataset_kwargs(data_dir, use_arrow):
         ),
     ],
 )
-def test_read_invalid_dataset_kwargs(capfd, naturalearth_lowres, use_arrow):
-    read_dataframe(naturalearth_lowres, use_arrow=use_arrow, INVALID="YES")
-    assert "does not support open option INVALID" in capfd.readouterr().err
+def test_read_invalid_dataset_kwargs(naturalearth_lowres, use_arrow):
+    with pytest.warns(RuntimeWarning, match="does not support open option INVALID"):
+        read_dataframe(naturalearth_lowres, use_arrow=use_arrow, INVALID="YES")
 
 
 def test_write_nullable_dtypes(tmp_path):


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/pyogrio/pull/236, xref https://github.com/geopandas/pyogrio/issues/91#issuecomment-1485913484