### PR TITLE
TST: Fix write of FlatGeobuf for empty / null geometries for GDAL >= 3.6.4

### DIFF
--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -949,7 +949,7 @@ def test_write_geometry_z_types_auto(
     if ext == ".fgb":
         # writing empty / null geometries not allowed by FlatGeobuf for
         # GDAL >= 3.6.4 and were simply not written previously
-        gdf = gdf.loc[~((gdf.geometry == np.array(None)) | gdf.geometry.is_empty)]
+        gdf = gdf.loc[~(gdf.geometry.isna() | gdf.geometry.is_empty)]
 
     if mixed_dimensions and DRIVERS[ext] in DRIVERS_NO_MIXED_DIMENSIONS:
         with pytest.raises(


### PR DESCRIPTION
GDAL 3.6.4 includes changes to the FlatGeobuf driver that disallows writing null / empty geometries when also writing a spatial index (the default).

This updates the failing test to strip those out before writing.

This fixes the failing tests for latest GDAL. 