### PR TITLE
Use gdal driver detection based on output path for writing files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
--   Support writing dataframes without geometry (#)
+-   Support writing dataframes without geometry (#267)
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 0.6.1 (???)
 
+### Improvements
+
+-   Support writing dataframes without geometry (#)
+
 ### Bug fixes
 
 -   Fix int32 overflow when reading int64 columns (#260)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1611,7 +1611,7 @@ def ogr_write(
         ### Get geometry type
         # TODO: this is brittle for 3D / ZM / M types
         # TODO: fail on M / ZM types
-        geometry_code = get_geometry_type_code(geometry_type or "Unknown")
+        geometry_code = get_geometry_type_code(geometry_type)
 
     try:
         if create_layer:

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -101,12 +101,6 @@ def get_gdal_config_option(str name):
 
 
 def ogr_driver_supports_write(driver):
-    # exclude drivers known to be unsupported by pyogrio even though they are
-    # supported for write by GDAL
-    if driver in {"XLSX"}:
-        return False
-
-
     # check metadata for driver to see if it supports write
     if _get_driver_metadata_item(driver, "DCAP_CREATE") == 'YES':
         return True

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -219,7 +219,7 @@ def write_dataframe(
 
     Parameters
     ----------
-    df : GeoDataFrame
+    df : GeoDataFrame or DataFrame
         The data to write. For attribute columns of the "object" dtype,
         all values will be converted to strings to be written to the
         output file, except None and np.nan, which will be set to NULL

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -387,9 +387,6 @@ def write(
     layer_options=None,
     **kwargs,
 ):
-    if geometry_type is None:
-        raise ValueError("geometry_type must be provided")
-
     if driver is None:
         driver = detect_driver(path)
 
@@ -421,13 +418,13 @@ def write(
                 if not isinstance(v, str):
                     raise ValueError(f"metadata value {v} must be a string")
 
-    if promote_to_multi is None:
+    if geometry_type is not None and promote_to_multi is None:
         promote_to_multi = (
             geometry_type.startswith("Multi")
             and driver in DRIVERS_NO_MIXED_SINGLE_MULTI
         )
 
-    if crs is None:
+    if geometry_type is not None and crs is None:
         warnings.warn(
             "'crs' was not provided.  The output dataset will not have "
             "projection information defined and may not be usable in other "

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -24,7 +24,6 @@ DRIVERS = {
     ".gpkg": "GPKG",
     ".json": "GeoJSON",
     ".shp": "ESRI Shapefile",
-    ".xlsx": "XLSX",
 }
 
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -24,6 +24,7 @@ DRIVERS = {
     ".gpkg": "GPKG",
     ".json": "GeoJSON",
     ".shp": "ESRI Shapefile",
+    ".xlsx": "XLSX",
 }
 
 

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -55,8 +55,6 @@ def test_gdal_geos_version():
         # drivers not supported for write by GDAL
         ("HTTP", False),
         ("OAPIF", False),
-        # drivers currently unsupported for write even though GDAL can write them
-        ("XLSX", False),
     ],
 )
 def test_ogr_driver_supports_write(driver, expected):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -460,7 +460,7 @@ def test_write_dataframe(tmp_path, naturalearth_lowres, ext):
     )
 
 
-@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS + [".xlsx"] if ext != ".fgb"])
+@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext != ".fgb"])
 def test_write_dataframe_nogeom(tmp_path, naturalearth_lowres, ext):
     """Test writing a dataframe, so without a geometry column.
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -460,6 +460,54 @@ def test_write_dataframe(tmp_path, naturalearth_lowres, ext):
     )
 
 
+@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS + [".xlsx"] if ext != ".fgb"])
+def test_write_dataframe_nogeom(tmp_path, naturalearth_lowres, ext):
+    """Test writing a dataframe, so without a geometry column.
+
+    FlatGeobuf (.fgb) doesn't seem to support this, and just writes an empty file.
+    """
+    # Prepare test data
+    input_gdf = read_dataframe(naturalearth_lowres)
+    input_df = input_gdf.drop(columns=["geometry"])
+    assert isinstance(input_df, pd.DataFrame)
+    assert not isinstance(input_df, gp.GeoDataFrame)
+
+    output_path = tmp_path / f"test{ext}"
+    write_dataframe(input_df, output_path)
+
+    if ext == ".shp":
+        # A shapefile without geometry column results in only a .dbf file.
+        output_path = output_path.with_suffix(".dbf")
+    assert output_path.exists()
+    result_df = read_dataframe(output_path)
+
+    assert isinstance(result_df, pd.DataFrame)
+
+    # some dtypes do not round-trip precisely through these file types
+    check_dtype = ext not in [".json", ".geojson", ".geojsonl", ".xlsx"]
+    
+    if ext in [".gpkg", ".shp", ".xlsx"]:
+        # These file types return a DataFrame when read.
+        assert not isinstance(result_df, gp.GeoDataFrame)
+        pd.testing.assert_frame_equal(
+            result_df,
+            input_df,
+            check_index_type=False,
+            check_dtype=check_dtype
+        )
+    else:
+        # These file types return a GeoDataFrame with None Geometries when read.
+        input_none_geom_gdf = gp.GeoDataFrame(
+            input_df, geometry=np.repeat(None, len(input_df)), crs="epsg:4326"
+        )
+        assert_geodataframe_equal(
+            result_df,
+            input_none_geom_gdf,
+            check_index_type=False,
+            check_dtype=check_dtype,
+        )
+
+
 @pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 @pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".geojsonl"])
 def test_write_empty_dataframe(tmp_path, ext):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -485,15 +485,12 @@ def test_write_dataframe_nogeom(tmp_path, naturalearth_lowres, ext):
 
     # some dtypes do not round-trip precisely through these file types
     check_dtype = ext not in [".json", ".geojson", ".geojsonl", ".xlsx"]
-    
+
     if ext in [".gpkg", ".shp", ".xlsx"]:
         # These file types return a DataFrame when read.
         assert not isinstance(result_df, gp.GeoDataFrame)
         pd.testing.assert_frame_equal(
-            result_df,
-            input_df,
-            check_index_type=False,
-            check_dtype=check_dtype
+            result_df, input_df, check_index_type=False, check_dtype=check_dtype
         )
     else:
         # These file types return a GeoDataFrame with None Geometries when read.

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -460,7 +460,7 @@ def test_write_dataframe(tmp_path, naturalearth_lowres, ext):
     )
 
 
-@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext != ".fgb"])
+@pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS + [".xlsx"] if ext != ".fgb"])
 def test_write_dataframe_nogeom(tmp_path, naturalearth_lowres, ext):
     """Test writing a dataframe, so without a geometry column.
 


### PR DESCRIPTION
Because I wanted to test .xlsx for #267, I was reminded that the driver detection for writing is really minimal at the moment.

For reading the driver detection is implicitly done by gdal resulting in automatic support of +- all gdal drivers. This PR is a proposal to follow the same principle: rely as much as possible on existing gdal logic to infer the driver from the output file.

Because it introduces a dependency on the gdal python bindings, I started with this first version as a POC. If the idea is supported I'll finish the implementation.

PS: I started this PR based on #267 to have the xlsx test case handy... but only the last commit is relevant for this PR.