### PR TITLE
DOC: improve doc of where param

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -168,15 +168,17 @@ processes:
 
 ## Filter records by attribute value
 
-You can use the `where` parameter to define a GDAL-compatible SQL WHERE query against
-the records in the dataset:
+You can use the `where` parameter to filter features in layer by attribute values. If
+the datasource natively supports SQL, its specific SQL dialect should be used
+(eg. SQLite and GeoPackage:
+[SQLITE](https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect), PostgreSQL).
+If it doesn't, the [OGRSQL WHERE](https://gdal.org/user/ogr_sql_dialect.html#where)
+syntax should be used. Note that it is not possible to overrule the SQL dialect, this is
+only possible when you use the `sql` parameter.
 
 ```python
 >>> read_dataframe('ne_10m_admin_0_countries.shp', where="POP_EST >= 10000000 AND POP_EST < 100000000")
 ```
-
-See [GDAL docs](https://gdal.org/api/vector_c_api.html#_CPPv424OGR_L_SetAttributeFilter9OGRLayerHPKc)
-for more information about restrictions of the `where` expression.
 
 ## Filter records by spatial extent
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -169,7 +169,7 @@ processes:
 ## Filter records by attribute value
 
 You can use the `where` parameter to filter features in layer by attribute values. If
-the datasource natively supports SQL, its specific SQL dialect should be used
+the data source natively supports SQL, its specific SQL dialect should be used
 (eg. SQLite and GeoPackage:
 [SQLITE](https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect), PostgreSQL).
 If it doesn't, the [OGRSQL WHERE](https://gdal.org/user/ogr_sql_dialect.html#where)
@@ -205,7 +205,7 @@ the dataset natively supports sql, the sql statement will be passed through
 as such. Hence, the sql query should be written in the relevant native sql
 dialect (e.g. [GeoPackage](https://gdal.org/drivers/vector/gpkg.html)/
 [Sqlite](https://gdal.org/drivers/vector/sqlite.html),
-[PostgreSQL](https://gdal.org/drivers/vector/pg.html)). If the datasource
+[PostgreSQL](https://gdal.org/drivers/vector/pg.html)). If the data source
 doesn't natively support sql (e.g.
 [ESRI Shapefile](https://gdal.org/drivers/vector/shapefile.html),
 [FlatGeobuf](https://gdal.org/drivers/vector/flatgeobuf.html)), you can choose

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -74,9 +74,11 @@ def read_dataframe(
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
-        Where clause to filter features in layer by attribute values.  Uses a
-        restricted form of SQL WHERE clause, defined here:
-        http://ogdi.sourceforge.net/prop/6.2.CapabilitiesMetadata.html
+        Where clause to filter features in layer by attribute values. Typically, the
+        'OGRSQL WHERE_' syntax can be used. In some cases (RDBMS backed drivers,
+        SQLite, GeoPackage) the native capabilities of the database may be used to to
+        interpret the WHERE clause, in which case the capabilities will be broader than
+        those of OGR SQL.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this
@@ -131,6 +133,7 @@ def read_dataframe(
     GeoDataFrame or DataFrame (if no geometry is present)
 
     .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
+    .. _OGRSQL WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
     .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -94,27 +94,27 @@ def read_dataframe(
         still depend on the specific file). The performance of reading a large
         number of features usings FIDs is also driver specific.
     sql : str, optional (default: None)
-        The sql statement to execute. Look at the sql_dialect parameter for
+        The SQL statement to execute. Look at the sql_dialect parameter for
         more information on the syntax to use for the query. When combined
         with other keywords like ``columns``, ``skip_features``,
         ``max_features``, ``where`` or ``bbox``, those are applied after the
-        sql query. Be aware that this can have an impact on performance,
+        SQL query. Be aware that this can have an impact on performance,
         (e.g. filtering with the ``bbox`` keyword may not use
         spatial indexes).
         Cannot be combined with the ``layer`` or ``fids`` keywords.
     sql_dialect : str, optional (default: None)
-        The sql dialect the sql statement is written in. Possible values:
+        The SQL dialect the SQL statement is written in. Possible values:
 
           - **None**: if the data source natively supports SQL, its specific SQL dialect
             will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL).
             If the data source doesn't natively support SQL, the `OGRSQL`_ dialect is
             the default.
           - '`OGRSQL`_': can be used on any data source. Performance can suffer
-            when used on data sources with native support for sql.
+            when used on data sources with native support for SQL.
           - '`SQLITE`_': can be used on any data source. All spatialite_
             functions can be used. Performance can suffer on data sources with
-            native support for sql, except for Geopackage and SQLite as this is
-            their native sql dialect.
+            native support for SQL, except for Geopackage and SQLite as this is
+            their native SQL dialect.
 
     fid_as_index : bool, optional (default: False)
         If True, will use the FIDs of the features that were read as the

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -76,7 +76,7 @@ def read_dataframe(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the OGRSQL-WHERE_ syntax
+        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL-WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -106,12 +106,12 @@ def read_dataframe(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports sql, its specific sql dialect
-            should be used (eg. SQLite and Geopackage: SQLITE_, PostgreSQL). If the
-            datasource doesn't natively support sql, the OGRSQL_ dialect is the
+            should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
+            datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
             default.
-          - 'OGRSQL_': can be used on any datasource. Performance can suffer
+          - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.
-          - 'SQLITE_': can be used on any datasource. All spatialite_
+          - '`SQLITE`_': can be used on any datasource. All spatialite_
             functions can be used. Performance can suffer on datasources with
             native support for sql, except for Geopackage and SQLite as this is
             their native sql dialect.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -76,7 +76,7 @@ def read_dataframe(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL-WHERE`_ syntax
+        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -131,13 +131,21 @@ def read_dataframe(
     -------
     GeoDataFrame or DataFrame (if no geometry is present)
 
-    .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
+    .. _OGRSQL:
 
-    .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+        https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
 
-    .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+    .. _OGRSQL WHERE:
 
-    .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
+        https://gdal.org/user/ogr_sql_dialect.html#where
+
+    .. _SQLITE:
+
+        https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+
+    .. _spatialite:
+
+        https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """
     try:

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -74,11 +74,11 @@ def read_dataframe(
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
-        Where clause to filter features in layer by attribute values. Typically, the
-        'OGRSQL WHERE_' syntax can be used. In some cases (RDBMS backed drivers,
-        SQLite, GeoPackage) the native capabilities of the database may be used to to
-        interpret the WHERE clause, in which case the capabilities will be broader than
-        those of OGR SQL.
+        Where clause to filter features in layer by attribute values. If the datasource
+        natively supports sql, its specific sql dialect should be used (eg. SQLite and
+        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the 'OGRSQL WHERE_' syntax
+        should be used. Note that it is not possible to overrule the sql dialect, this
+        is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this
@@ -105,16 +105,15 @@ def read_dataframe(
     sql_dialect : str, optional (default: None)
         The sql dialect the sql statement is written in. Possible values:
 
-          - **None**: if the datasource natively supports sql, the specific
-            sql syntax for this datasource should be used (eg. SQLite,
-            PostgreSQL, Oracle,...). If the datasource doesn't natively
-            support sql, the 'OGRSQL_' dialect is the
+          - **None**: if the datasource natively supports sql, its specific sql dialect
+            should be used (eg. SQLite and Geopackage: 'SQLITE_', PostgreSQL). If the
+            datasource doesn't natively support sql, the 'OGRSQL_' dialect is the
             default.
           - 'OGRSQL_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.
           - 'SQLITE_': can be used on any datasource. All spatialite_
             functions can be used. Performance can suffer on datasources with
-            native support for sql, except for GPKG and SQLite as this is
+            native support for sql, except for Geopackage and SQLite as this is
             their native sql dialect.
 
     fid_as_index : bool, optional (default: False)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -75,10 +75,10 @@ def read_dataframe(
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
-        natively supports SQL, its specific SQL dialect will be used by default (eg. SQLite and
-        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
-        should be used. Note that it is not possible to overrule the SQL dialect, this
-        is only possible when you use the ``sql`` parameter.
+        natively supports SQL, its specific SQL dialect will be used by default
+        (eg. SQLite and GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the
+        `OGRSQL WHERE`_ syntax should be used. Note that it is not possible to overrule
+        the SQL dialect, this is only possible when you use the ``sql`` parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this
@@ -106,8 +106,8 @@ def read_dataframe(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
-            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
-            datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
+            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL).
+            If the datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -107,7 +107,7 @@ def read_dataframe(
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
             should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
-            datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
+            datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -76,7 +76,7 @@ def read_dataframe(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the 'OGRSQL WHERE_' syntax
+        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the OGRSQL-WHERE_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -106,8 +106,8 @@ def read_dataframe(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports sql, its specific sql dialect
-            should be used (eg. SQLite and Geopackage: 'SQLITE_', PostgreSQL). If the
-            datasource doesn't natively support sql, the 'OGRSQL_' dialect is the
+            should be used (eg. SQLite and Geopackage: SQLITE_, PostgreSQL). If the
+            datasource doesn't natively support sql, the OGRSQL_ dialect is the
             default.
           - 'OGRSQL_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.
@@ -132,7 +132,7 @@ def read_dataframe(
     GeoDataFrame or DataFrame (if no geometry is present)
 
     .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
-    .. _OGRSQL WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+    .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
     .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -77,7 +77,7 @@ def read_dataframe(
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports SQL, its specific SQL dialect will be used by default (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
-        should be used. Note that it is not possible to overrule the sql dialect, this
+        should be used. Note that it is not possible to overrule the SQL dialect, this
         is only possible when you use the ``sql`` parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -75,10 +75,10 @@ def read_dataframe(
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
-        natively supports SQL, its specific SQL dialect will be used by default
-        (eg. SQLite and GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the
-        `OGRSQL WHERE`_ syntax should be used. Note that it is not possible to overrule
-        the SQL dialect, this is only possible when you use the ``sql`` parameter.
+        natively supports SQL, its specific SQL dialect should be used (eg. SQLite and
+        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
+        should be used. Note that it is not possible to overrule the SQL dialect, this
+        is only possible when you use the ``sql`` parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -78,7 +78,7 @@ def read_dataframe(
         natively supports SQL, its specific SQL dialect will be used by default (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
-        is only possible when you use the sql parameter.
+        is only possible when you use the ``sql`` parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax) (default: None)
         If present, will be used to filter records whose geometry intersects this

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -105,7 +105,7 @@ def read_dataframe(
     sql_dialect : str, optional (default: None)
         The sql dialect the sql statement is written in. Possible values:
 
-          - **None**: if the datasource natively supports sql, its specific sql dialect
+          - **None**: if the datasource natively supports SQL, its specific SQL dialect
             should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
             datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
             default.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -74,7 +74,7 @@ def read_dataframe(
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
-        Where clause to filter features in layer by attribute values. If the datasource
+        Where clause to filter features in layer by attribute values. If the data source
         natively supports SQL, its specific SQL dialect should be used (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the SQL dialect, this
@@ -105,14 +105,14 @@ def read_dataframe(
     sql_dialect : str, optional (default: None)
         The sql dialect the sql statement is written in. Possible values:
 
-          - **None**: if the datasource natively supports SQL, its specific SQL dialect
+          - **None**: if the data source natively supports SQL, its specific SQL dialect
             will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL).
-            If the datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
-            default.
-          - '`OGRSQL`_': can be used on any datasource. Performance can suffer
-            when used on datasources with native support for sql.
-          - '`SQLITE`_': can be used on any datasource. All spatialite_
-            functions can be used. Performance can suffer on datasources with
+            If the data source doesn't natively support SQL, the `OGRSQL`_ dialect is
+            the default.
+          - '`OGRSQL`_': can be used on any data source. Performance can suffer
+            when used on data sources with native support for sql.
+          - '`SQLITE`_': can be used on any data source. All spatialite_
+            functions can be used. Performance can suffer on data sources with
             native support for sql, except for Geopackage and SQLite as this is
             their native sql dialect.
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -75,7 +75,7 @@ def read_dataframe(
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
-        natively supports sql, its specific sql dialect should be used (eg. SQLite and
+        natively supports SQL, its specific SQL dialect will be used by default (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -106,7 +106,7 @@ def read_dataframe(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
-            should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
+            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
             datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -132,8 +132,11 @@ def read_dataframe(
     GeoDataFrame or DataFrame (if no geometry is present)
 
     .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
+
     .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+
     .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -120,7 +120,7 @@ def read(
     sql_dialect : str, optional (default: None)
         The SQL dialect the ``sql`` statement is written in. Possible values:
 
-          - **None**: if the datasource natively supports sql, its specific sql dialect
+          - **None**: if the datasource natively supports SQL, its specific SQL dialect
             should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
             datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
             default.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -91,7 +91,7 @@ def read(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the OGRSQL-WHERE_ syntax
+        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL-WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -121,12 +121,12 @@ def read(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports sql, its specific sql dialect
-            should be used (eg. SQLite and Geopackage: SQLITE_, PostgreSQL). If the
-            datasource doesn't natively support sql, the OGRSQL_ dialect is the
+            should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
+            datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
             default.
-          - 'OGRSQL_': can be used on any datasource. Performance can suffer
+          - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.
-          - 'SQLITE_': can be used on any datasource. All spatialite_
+          - '`SQLITE`_': can be used on any datasource. All spatialite_
             functions can be used. Performance can suffer on datasources with
             native support for sql, except for Geopackage and SQLite as this is
             their native sql dialect.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -155,8 +155,11 @@ def read(
         }
 
     .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
+
     .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+
     .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -89,10 +89,12 @@ def read(
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
-        Where clause to filter features in layer by attribute values.  Uses a
-        restricted form of SQL WHERE clause, defined here:
-        http://ogdi.sourceforge.net/prop/6.2.CapabilitiesMetadata.html
-        Examples: "ISO_A3 = 'CAN'", "POP_EST > 10000000 AND POP_EST < 100000000"
+        Where clause to filter features in layer by attribute values. Typically, the
+        'OGRSQL WHERE_' syntax can be used. In some cases (RDBMS backed drivers,
+        SQLite, GeoPackage) the native capabilities of the database may be used to to
+        interpret the WHERE clause, in which case the capabilities will be broader than
+        those of OGR SQL.
+        Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax), optional (default: None)
         If present, will be used to filter records whose geometry intersects this
         box.  This must be in the same CRS as the dataset.  If GEOS is present

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -121,7 +121,7 @@ def read(
         The SQL dialect the ``sql`` statement is written in. Possible values:
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
-            should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
+            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
             datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -122,7 +122,7 @@ def read(
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
             should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
-            datasource doesn't natively support sql, the `OGRSQL`_ dialect is the
+            datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -118,7 +118,7 @@ def read(
         spatial indexes).
         Cannot be combined with the ``layer`` or ``fids`` keywords.
     sql_dialect : str, optional (default: None)
-        The sql dialect the sql statement is written in. Possible values:
+        The SQL dialect the ``sql`` statement is written in. Possible values:
 
           - **None**: if the datasource natively supports sql, its specific sql dialect
             should be used (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -90,10 +90,10 @@ def read(
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the data source
-        natively supports sql, its specific sql dialect should be used (eg. SQLite and
+        natively supports SQL, its specific SQL dialect should be used (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
-        should be used. Note that it is not possible to overrule the sql dialect, this
-        is only possible when you use the sql parameter.
+        should be used. Note that it is not possible to overrule the SQL dialect, this
+        is only possible when you use the SQL parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
     bbox : tuple of (xmin, ymin, xmax, ymax), optional (default: None)
         If present, will be used to filter records whose geometry intersects this
@@ -125,11 +125,11 @@ def read(
             If the data source doesn't natively support SQL, the `OGRSQL`_ dialect is
             the default.
           - '`OGRSQL`_': can be used on any data source. Performance can suffer
-            when used on data sources with native support for sql.
+            when used on data sources with native support for SQL.
           - '`SQLITE`_': can be used on any data source. All spatialite_
             functions can be used. Performance can suffer on data sources with
-            native support for sql, except for Geopackage and SQLite as this is
-            their native sql dialect.
+            native support for SQL, except for Geopackage and SQLite as this is
+            their native SQL dialect.
 
     return_fids : bool, optional (default: False)
         If True, will return the FIDs of the feature that were read.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -113,7 +113,7 @@ def read(
         more information on the syntax to use for the query. When combined
         with other keywords like ``columns``, ``skip_features``,
         ``max_features``, ``where`` or ``bbox``, those are applied after the
-        sql query. Be aware that this can have an impact on performance,
+        SQL query. Be aware that this can have an impact on performance,
         (e.g. filtering with the ``bbox`` keyword may not use
         spatial indexes).
         Cannot be combined with the ``layer`` or ``fids`` keywords.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -109,7 +109,7 @@ def read(
         still depend on the specific file). The performance of reading a large
         number of features usings FIDs is also driver specific.
     sql : str, optional (default: None)
-        The sql statement to execute. Look at the sql_dialect parameter for
+        The SQL statement to execute. See the sql_dialect parameter for
         more information on the syntax to use for the query. When combined
         with other keywords like ``columns``, ``skip_features``,
         ``max_features``, ``where`` or ``bbox``, those are applied after the

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -121,8 +121,8 @@ def read(
         The SQL dialect the ``sql`` statement is written in. Possible values:
 
           - **None**: if the datasource natively supports SQL, its specific SQL dialect
-            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL). If the
-            datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
+            will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL).
+            If the datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
             default.
           - '`OGRSQL`_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -91,7 +91,7 @@ def read(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the 'OGRSQL WHERE_' syntax
+        GeoPackage: SQLITE_, PostgreSQL). If it doesn't, the OGRSQL-WHERE_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -121,8 +121,8 @@ def read(
         The sql dialect the sql statement is written in. Possible values:
 
           - **None**: if the datasource natively supports sql, its specific sql dialect
-            should be used (eg. SQLite and Geopackage: 'SQLITE_', PostgreSQL). If the
-            datasource doesn't natively support sql, the 'OGRSQL_' dialect is the
+            should be used (eg. SQLite and Geopackage: SQLITE_, PostgreSQL). If the
+            datasource doesn't natively support sql, the OGRSQL_ dialect is the
             default.
           - 'OGRSQL_': can be used on any datasource. Performance can suffer
             when used on datasources with native support for sql.
@@ -155,7 +155,7 @@ def read(
         }
 
     .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
-    .. _OGRSQL WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+    .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
     .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -89,7 +89,7 @@ def read(
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).
     where : str, optional (default: None)
-        Where clause to filter features in layer by attribute values. If the datasource
+        Where clause to filter features in layer by attribute values. If the data source
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
         GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
@@ -120,14 +120,14 @@ def read(
     sql_dialect : str, optional (default: None)
         The SQL dialect the ``sql`` statement is written in. Possible values:
 
-          - **None**: if the datasource natively supports SQL, its specific SQL dialect
+          - **None**: if the data source natively supports SQL, its specific SQL dialect
             will be used by default (eg. SQLite and Geopackage: `SQLITE`_, PostgreSQL).
-            If the datasource doesn't natively support SQL, the `OGRSQL`_ dialect is the
-            default.
-          - '`OGRSQL`_': can be used on any datasource. Performance can suffer
-            when used on datasources with native support for sql.
-          - '`SQLITE`_': can be used on any datasource. All spatialite_
-            functions can be used. Performance can suffer on datasources with
+            If the data source doesn't natively support SQL, the `OGRSQL`_ dialect is
+            the default.
+          - '`OGRSQL`_': can be used on any data source. Performance can suffer
+            when used on data sources with native support for sql.
+          - '`SQLITE`_': can be used on any data source. All spatialite_
+            functions can be used. Performance can suffer on data sources with
             native support for sql, except for Geopackage and SQLite as this is
             their native sql dialect.
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -91,7 +91,7 @@ def read(
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values. If the datasource
         natively supports sql, its specific sql dialect should be used (eg. SQLite and
-        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL-WHERE`_ syntax
+        GeoPackage: `SQLITE`_, PostgreSQL). If it doesn't, the `OGRSQL WHERE`_ syntax
         should be used. Note that it is not possible to overrule the sql dialect, this
         is only possible when you use the sql parameter.
         Examples: ``"ISO_A3 = 'CAN'"``, ``"POP_EST > 10000000 AND POP_EST < 100000000"``
@@ -154,13 +154,21 @@ def read(
             "geometry_type": "<geometry type>"
         }
 
-    .. _OGRSQL: https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
+    .. _OGRSQL:
 
-    .. _OGRSQL-WHERE: https://gdal.org/user/ogr_sql_dialect.html#where
+        https://gdal.org/user/ogr_sql_dialect.html#ogr-sql-dialect
 
-    .. _SQLITE: https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+    .. _OGRSQL WHERE:
 
-    .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
+        https://gdal.org/user/ogr_sql_dialect.html#where
+
+    .. _SQLITE:
+
+        https://gdal.org/user/sql_sqlite_dialect.html#sql-sqlite-dialect
+
+    .. _spatialite:
+
+        https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """
     path, buffer = get_vsi_path(path_or_buffer)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -404,7 +404,7 @@ def test_read_sql_dialect_sqlite_nogpkg(naturalearth_lowres):
     "naturalearth_lowres", [".gpkg"], indirect=["naturalearth_lowres"]
 )
 def test_read_sql_dialect_sqlite_gpkg(naturalearth_lowres):
-    # "INDIRECT_SQL" prohibits GDAL from passing the sql statement to sqlite.
+    # "INDIRECT_SQL" prohibits GDAL from passing the SQL statement to sqlite.
     # Because the statement is processed within GDAL it is possible to use
     # spatialite functions even if sqlite isn't built with spatialite support.
     sql = "SELECT * FROM naturalearth_lowres WHERE iso_a3 = 'CAN'"


### PR DESCRIPTION
reference #276

Note: for the links to external pages in the inline documentation, I had to put newlines around the links below, otherwise ".." is placed at the end of them and then most don't work anymore as intended.

For reference, this is the script used to test what the documentation should contain:
``` python
from pathlib import Path
import warnings
import pyogrio

# Ignore all warnings
warnings.simplefilter("ignore")

url_shp = "https://github.com/theroggy/pysnippets/raw/main/pysnippets/pyogrio/polygon-parcel_31370.zip"
url_gpkg = "https://github.com/geofileops/geofileops/raw/main/tests/data/polygon-parcel.gpkg"
wheres = [
    None,
    "LBLHFDTLT LIKE 'Gras%'",
    "LBLHFDTLT LIKE 'gras%'",
    "LBLHFDTLT ILIKE 'gras%'",
    "LBLHFDTLT NOT LIKE 'Gras%'",
    "LBLHFDTLT != 'Grasklaver'",
    "LBLHFDTLT IN ('Hoofdgebouwen', 'Grasklaver')",
    f"ST_Area({{geometrycolumn}}) > 1000",
]
    
for where in wheres:
    for url in [url_shp, url_gpkg]:
        for sql_dialect in [None, "OGRSQL", "SQLITE"]:
            where_f = where
            if where is not None:
                geometrycolumn = "geom" if url.endswith(".gpkg") else "geometry"
                where_f = where.format(geometrycolumn=geometrycolumn)
            try:
                df = pyogrio.read_dataframe(url, where=where_f)
                # print(f"\nnb_rows with where: {where}: {len(df)}")
                # print(df["LBLHFDTLT"].unique())
            except Exception as ex:
                name = Path(url).name
                print(f"Error, where={where_f}, sql_dialect={sql_dialect} on {name}")
```
Output:
```
Error, where=LBLHFDTLT ILIKE 'gras%', sql_dialect=None on polygon-parcel.gpkg
Error, where=LBLHFDTLT ILIKE 'gras%', sql_dialect=OGRSQL on polygon-parcel.gpkg
Error, where=LBLHFDTLT ILIKE 'gras%', sql_dialect=SQLITE on polygon-parcel.gpkg
Error, where=ST_Area(geometry) > 1000, sql_dialect=None on polygon-parcel_31370.zip
Error, where=ST_Area(geometry) > 1000, sql_dialect=OGRSQL on polygon-parcel_31370.zip
Error, where=ST_Area(geometry) > 1000, sql_dialect=SQLITE on polygon-parcel_31370.zip
```