### PR TITLE
Raise error if function is used with parameters to read no geometry, columns, or fids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
     performance impacts for some data sources that would otherwise return an
     unknown count (count is used in `read_info`, `read`, `read_dataframe`) (#271).
 -   Raise error if `read` or `read_dataframe` is called with parameters to read no
-    columns, no geometry and no fids (#280)
+    columns, geometry, or fids (#280)
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,12 @@
 ### Improvements
 
 -   Support writing dataframes without geometry column (#267)
-
 -   Calculate feature count by iterating over features if GDAL returns an
     unknown count for a data layer (e.g., OSM driver); this may have signficant
     performance impacts for some data sources that would otherwise return an
     unknown count (count is used in `read_info`, `read`, `read_dataframe`) (#271).
+-   Raise error if `read` or `read_dataframe` is called with parameters to read no
+    columns, no geometry and no fids (#263)
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
     performance impacts for some data sources that would otherwise return an
     unknown count (count is used in `read_info`, `read`, `read_dataframe`) (#271).
 -   Raise error if `read` or `read_dataframe` is called with parameters to read no
-    columns, no geometry and no fids (#263)
+    columns, no geometry and no fids (#280)
 
 ### Bug fixes
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1031,6 +1031,9 @@ def ogr_read(
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
 
+    if not read_geometry and columns is not None and len(columns) == 0:
+        raise ValueError("'read_geometry' False cannot be combined with 'columns'=[]")
+
     try:
         dataset_options = dict_to_options(dataset_kwargs)
         ogr_dataset = ogr_open(path_c, 0, dataset_options)
@@ -1192,6 +1195,9 @@ def ogr_open_arrow(
 
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
+
+    if not read_geometry and columns is not None and len(columns) == 0:
+        raise ValueError("'read_geometry' False cannot be combined with 'columns'=[]")
 
     reader = None
     try:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1031,8 +1031,10 @@ def ogr_read(
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
 
-    if not read_geometry and columns is not None and len(columns) == 0:
-        raise ValueError("'read_geometry' False cannot be combined with 'columns'=[]")
+    if not read_geometry and not return_fids and columns is not None and len(columns) == 0:
+        raise ValueError(
+            "reading no columns, no geometry and no fids is not supported"
+        )
 
     try:
         dataset_options = dict_to_options(dataset_kwargs)
@@ -1196,8 +1198,10 @@ def ogr_open_arrow(
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
 
-    if not read_geometry and columns is not None and len(columns) == 0:
-        raise ValueError("'read_geometry' False cannot be combined with 'columns'=[]")
+    if not read_geometry and not return_fids and columns is not None and len(columns) == 0:
+        raise ValueError(
+            "reading no columns, no geometry and no fids is not supported"
+        )
 
     reader = None
     try:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1031,9 +1031,10 @@ def ogr_read(
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
 
-    if not read_geometry and not return_fids and columns is not None and len(columns) == 0:
+    if not (read_geometry or return_fids or columns is None or len(columns) > 0):
         raise ValueError(
-            "reading no columns, no geometry and no fids is not supported"
+            "at least one of read_geometry or return_fids must be True or columns must "
+            "be None or non-empty"
         )
 
     try:
@@ -1198,9 +1199,10 @@ def ogr_open_arrow(
     if sql is not None and layer is not None:
         raise ValueError("'sql' paramater cannot be combined with 'layer'")
 
-    if not read_geometry and not return_fids and columns is not None and len(columns) == 0:
+    if not (read_geometry or return_fids or columns is None or len(columns) > 0):
         raise ValueError(
-            "reading no columns, no geometry and no fids is not supported"
+            "at least one of read_geometry or return_fids must be True or columns must "
+            "be None or non-empty"
         )
 
     reader = None

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -170,8 +170,12 @@ def read_dataframe(
         if fid_as_index:
             df = df.set_index(meta["fid_column"])
             df.index.names = ["fid"]
+
         geometry_name = meta["geometry_name"] or "wkb_geometry"
-        if geometry_name in df.columns:
+        if not fid_as_index and len(df.columns) == 0:
+            # Index not asked, no geometry column and no attribute columns: return empty
+            return pd.DataFrame()
+        elif geometry_name in df.columns:
             df["geometry"] = from_wkb(df.pop(geometry_name), crs=meta["crs"])
             return gp.GeoDataFrame(df, geometry="geometry")
         else:

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -1,5 +1,4 @@
 import math
-import re
 
 import pytest
 
@@ -53,7 +52,7 @@ def test_read_arrow_layer_without_geometry(test_fgdb_vsi):
     assert type(result) is pd.DataFrame
 
 
-def test_read_arrow_ignore_geometry(naturalearth_lowres):
+def test_read_arrow_no_geometry(naturalearth_lowres):
     result = read_dataframe(naturalearth_lowres, use_arrow=True, read_geometry=False)
     assert type(result) is pd.DataFrame
 
@@ -63,21 +62,24 @@ def test_read_arrow_ignore_geometry(naturalearth_lowres):
     assert_frame_equal(result, expected)
 
 
-def test_read_arrow_ignore_geometry_no_columns(naturalearth_lowres):
-    with pytest.raises(
-        ValueError,
-        match=re.escape("'read_geometry' False cannot be combined with 'columns'=[]"),
-    ):
-        _ = read_dataframe(
-            naturalearth_lowres, use_arrow=True, read_geometry=False, columns=[]
-        )
-
-
 def test_read_arrow_nested_types(test_ogr_types_list):
     # with arrow, list types are supported
     result = read_dataframe(test_ogr_types_list, use_arrow=True)
     assert "list_int64" in result.columns
     assert result["list_int64"][0].tolist() == [0, 1]
+
+
+def test_read_arrow_only_fids(naturalearth_lowres):
+    df = read_dataframe(
+        naturalearth_lowres,
+        columns=[],
+        read_geometry=False,
+        fid_as_index=True,
+        use_arrow=True,
+    )
+    assert df is not None
+    assert len(df.columns) == 0
+    assert len(df) == 177
 
 
 def test_read_arrow_raw(naturalearth_lowres):

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -52,7 +52,7 @@ def test_read_arrow_layer_without_geometry(test_fgdb_vsi):
     assert type(result) is pd.DataFrame
 
 
-def test_read_arrow_no_geometry(naturalearth_lowres):
+def test_read_arrow_ignore_geometry(naturalearth_lowres):
     result = read_dataframe(naturalearth_lowres, use_arrow=True, read_geometry=False)
     assert type(result) is pd.DataFrame
 
@@ -67,19 +67,6 @@ def test_read_arrow_nested_types(test_ogr_types_list):
     result = read_dataframe(test_ogr_types_list, use_arrow=True)
     assert "list_int64" in result.columns
     assert result["list_int64"][0].tolist() == [0, 1]
-
-
-def test_read_arrow_only_fids(naturalearth_lowres):
-    df = read_dataframe(
-        naturalearth_lowres,
-        columns=[],
-        read_geometry=False,
-        fid_as_index=True,
-        use_arrow=True,
-    )
-    assert df is not None
-    assert len(df.columns) == 0
-    assert len(df) == 177
 
 
 def test_read_arrow_raw(naturalearth_lowres):

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 import pytest
 
@@ -60,6 +61,16 @@ def test_read_arrow_ignore_geometry(naturalearth_lowres):
         columns=["geometry"]
     )
     assert_frame_equal(result, expected)
+
+
+def test_read_arrow_ignore_geometry_no_columns(naturalearth_lowres):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("'read_geometry' False cannot be combined with 'columns'=[]"),
+    ):
+        _ = read_dataframe(
+            naturalearth_lowres, use_arrow=True, read_geometry=False, columns=[]
+        )
 
 
 def test_read_arrow_nested_types(test_ogr_types_list):

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -47,11 +47,6 @@ def test_read_arrow_columns(naturalearth_lowres):
     assert result.columns.tolist() == ["continent", "geometry"]
 
 
-def test_read_arrow_layer_without_geometry(test_fgdb_vsi):
-    result = read_dataframe(test_fgdb_vsi, layer="basetable", use_arrow=True)
-    assert type(result) is pd.DataFrame
-
-
 def test_read_arrow_ignore_geometry(naturalearth_lowres):
     result = read_dataframe(naturalearth_lowres, use_arrow=True, read_geometry=False)
     assert type(result) is pd.DataFrame

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -75,6 +75,27 @@ def test_read_dataframe_vsi(naturalearth_lowres_vsi):
     assert len(df) == 177
 
 
+@pytest.mark.parametrize("use_arrow", [True, False])
+@pytest.mark.parametrize(
+    "columns, fid_as_index, exp_len", [(None, False, 2), ([], True, 2), ([], False, 0)]
+)
+def test_read_layer_without_geometry(
+    test_fgdb_vsi, columns, fid_as_index, use_arrow, exp_len
+):
+    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
+        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
+
+    result = read_dataframe(
+        test_fgdb_vsi,
+        layer="basetable",
+        columns=columns,
+        fid_as_index=fid_as_index,
+        use_arrow=use_arrow,
+    )
+    assert type(result) is pd.DataFrame
+    assert len(result) == exp_len
+
+
 @pytest.mark.parametrize(
     "naturalearth_lowres, expected_ext",
     [(".gpkg", ".gpkg"), (".shp", ".shp")],

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -75,16 +75,25 @@ def test_read_dataframe_vsi(naturalearth_lowres_vsi):
     assert len(df) == 177
 
 
-@pytest.mark.parametrize("use_arrow", [True, False])
+@pytest.mark.parametrize(
+    "use_arrow",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not has_pyarrow or __gdal_version__ < (3, 6, 0),
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+        False,
+    ],
+)
 @pytest.mark.parametrize(
     "columns, fid_as_index, exp_len", [(None, False, 2), ([], True, 2), ([], False, 0)]
 )
 def test_read_layer_without_geometry(
     test_fgdb_vsi, columns, fid_as_index, use_arrow, exp_len
 ):
-    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
-        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
-
     result = read_dataframe(
         test_fgdb_vsi,
         layer="basetable",
@@ -114,11 +123,20 @@ def test_read_no_geometry(naturalearth_lowres_all_ext):
     assert not isinstance(df, gp.GeoDataFrame)
 
 
-@pytest.mark.parametrize("use_arrow", [True, False])
+@pytest.mark.parametrize(
+    "use_arrow",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not has_pyarrow or __gdal_version__ < (3, 6, 0),
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+        False,
+    ],
+)
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
-    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
-        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
-
     with pytest.raises(
         ValueError,
         match=(
@@ -212,11 +230,20 @@ def test_read_fid_as_index(naturalearth_lowres_all_ext):
         assert_index_equal(df.index, pd.Index([2, 3], name="fid"))
 
 
-@pytest.mark.parametrize("use_arrow", [True, False])
+@pytest.mark.parametrize(
+    "use_arrow",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not has_pyarrow or __gdal_version__ < (3, 6, 0),
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+        False,
+    ],
+)
 def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
-    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
-        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
-
     df = read_dataframe(
         naturalearth_lowres,
         columns=[],

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -120,7 +120,11 @@ def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
         pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
 
     with pytest.raises(
-        ValueError, match="reading no columns, no geometry and no fids is not supported"
+        ValueError,
+        match=(
+            "at least one of read_geometry or return_fids must be True or columns must "
+            "be None or non-empty"
+        ),
     ):
         _ = read_dataframe(
             naturalearth_lowres,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -93,6 +93,20 @@ def test_read_no_geometry(naturalearth_lowres_all_ext):
     assert not isinstance(df, gp.GeoDataFrame)
 
 
+@pytest.mark.parametrize("use_arrow", [True, False])
+def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
+    with pytest.raises(
+        ValueError, match="reading no columns, no geometry and no fids is not supported"
+    ):
+        _ = read_dataframe(
+            naturalearth_lowres,
+            columns=[],
+            read_geometry=False,
+            fid_as_index=False,
+            use_arrow=use_arrow,
+        )
+
+
 def test_read_force_2d(test_fgdb_vsi):
     with pytest.warns(
         UserWarning, match=r"Measured \(M\) geometry types are not supported"
@@ -157,13 +171,31 @@ def test_read_fid_as_index(naturalearth_lowres_all_ext):
     df = read_dataframe(naturalearth_lowres_all_ext, fid_as_index=False, **kwargs)
     assert_index_equal(df.index, pd.RangeIndex(0, 2))
 
-    df = read_dataframe(naturalearth_lowres_all_ext, fid_as_index=True, **kwargs)
+    df = read_dataframe(
+        naturalearth_lowres_all_ext,
+        fid_as_index=True,
+        **kwargs,
+    )
     if naturalearth_lowres_all_ext.suffix in [".gpkg"]:
         # File format where fid starts at 1
         assert_index_equal(df.index, pd.Index([3, 4], name="fid"))
     else:
         # File format where fid starts at 0
         assert_index_equal(df.index, pd.Index([2, 3], name="fid"))
+
+
+@pytest.mark.parametrize("use_arrow", [True, False])
+def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
+    df = read_dataframe(
+        naturalearth_lowres,
+        columns=[],
+        read_geometry=False,
+        fid_as_index=True,
+        use_arrow=use_arrow,
+    )
+    assert df is not None
+    assert len(df) == 177
+    assert len(df.columns) == 0
 
 
 @pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -95,6 +95,9 @@ def test_read_no_geometry(naturalearth_lowres_all_ext):
 
 @pytest.mark.parametrize("use_arrow", [True, False])
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
+    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
+        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
+
     with pytest.raises(
         ValueError, match="reading no columns, no geometry and no fids is not supported"
     ):
@@ -186,6 +189,9 @@ def test_read_fid_as_index(naturalearth_lowres_all_ext):
 
 @pytest.mark.parametrize("use_arrow", [True, False])
 def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
+    if use_arrow and (not has_pyarrow or __gdal_version__ < (3, 6, 0)):
+        pytest.skip("Arrow tests require pyarrow and GDAL>=3.6")
+
     df = read_dataframe(
         naturalearth_lowres,
         columns=[],

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import re
 import sys
 
 import numpy as np
@@ -86,21 +87,21 @@ def test_vsi_read_layers(naturalearth_lowres_vsi):
     assert geometry.shape == (177,)
 
 
-def test_read_no_geometry(naturalearth_lowres):
+def test_read_ignore_geometry(naturalearth_lowres):
     geometry = read(naturalearth_lowres, read_geometry=False)[2]
 
     assert geometry is None
 
 
-def test_read_columns(naturalearth_lowres):
-    # read no columns or geometry
-    meta, _, geometry, fields = read(
-        naturalearth_lowres, columns=[], read_geometry=False
-    )
-    assert geometry is None
-    assert len(fields) == 0
-    array_equal(meta["fields"], np.empty(shape=(0, 4), dtype="object"))
+def test_read_ignore_geometry_no_columns(naturalearth_lowres):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("'read_geometry' False cannot be combined with 'columns'=[]"),
+    ):
+        _ = read(naturalearth_lowres, read_geometry=False, columns=[])
 
+
+def test_read_columns(naturalearth_lowres):
     columns = ["NAME", "NAME_LONG"]
     meta, _, geometry, fields = read(
         naturalearth_lowres, columns=columns, read_geometry=False

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -94,7 +94,11 @@ def test_read_no_geometry(naturalearth_lowres):
 
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres):
     with pytest.raises(
-        ValueError, match="reading no columns, no geometry and no fids is not supported"
+        ValueError,
+        match=(
+            "at least one of read_geometry or return_fids must be True or columns must "
+            "be None or non-empty"
+        ),
     ):
         _ = read(
             naturalearth_lowres, columns=[], read_geometry=False, return_fids=False


### PR DESCRIPTION
Necessary changes and tests to ensure following behaviour for both `use_arrow=True` and `use_arrow=False`:
* if `columns=[]`, `read_geometry=False` and `return_fid/fid_as_index=False`, a ValueError is raised
* if `columns=[]`, `read_geometry=False` and `return_fid/fid_as_index=True`, the index is read and returned
* if none of the above, but `fid_as_index=False` and the result ends up having no geometry nor attribute columns (eg. because the input file doesn't have a geometry column and `columns=[]`), an empty DataFrame is returned.

closes #263 