### PR TITLE
ENH: Add support for skip_features, max_features for read_arrow

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install pyarrow
         # GDAL>=3.6 required to use Arrow API
-        if: matrix.container != 'osgeo/gdal:ubuntu-small-3.5.3'
+        if: matrix.container != 'osgeo/gdal:ubuntu-small-3.5.3' && matrix.container != 'osgeo/gdal:ubuntu-small-3.4.3'
         run: |
           python3 -m pip install pyarrow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,15 @@
     performance impacts for some data sources that would otherwise return an
     unknown count (count is used in `read_info`, `read`, `read_dataframe`) (#271).
 
+-   using `skip_features` greater than the number of features available in a data
+    layer now returns empty arrays for `read` and an empty DataFrame for
+    `read_dataframe` instead of raising a `ValueError`
+-   enabled `skip_features` and `max_features` for `read_arrow` and
+    `read_dataframe(path, use_arrow=True)`. Note that this incurs overhead
+    because all features up to the next batch size above `max_features` (or size
+    of data layer) will be read prior to slicing out the requested range of
+    features.
+
 ### Bug fixes
 
 -   Fix int32 overflow when reading int64 columns (#260)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,12 @@
 
 -   using `skip_features` greater than the number of features available in a data
     layer now returns empty arrays for `read` and an empty DataFrame for
-    `read_dataframe` instead of raising a `ValueError`
+    `read_dataframe` instead of raising a `ValueError` (#282).
 -   enabled `skip_features` and `max_features` for `read_arrow` and
     `read_dataframe(path, use_arrow=True)`. Note that this incurs overhead
     because all features up to the next batch size above `max_features` (or size
     of data layer) will be read prior to slicing out the requested range of
-    features.
+    features (#282).
 
 ### Bug fixes
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -166,6 +166,14 @@ processes:
 >>> read_dataframe('ne_10m_admin_0_countries.shp', skip_features=10, max_features=10)
 ```
 
+NOTE: if `use_arrow` is `True`, `skip_features` and `max_features` will incur
+additional overhead because all features up to the next batch size above
+`max_features` (or size of data layer) will be read prior to slicing out the
+requested range of features. If `max_features` is less than the maximum Arrow
+batch size (65,536 features) only `max_features` will be read. All features
+up to `skip_features` are read from the data source and later discarded because
+the Arrow interface does not support randomly seeking a starting feature.
+
 ## Filter records by attribute value
 
 You can use the `where` parameter to define a GDAL-compatible SQL WHERE query against

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -172,7 +172,9 @@ additional overhead because all features up to the next batch size above
 requested range of features. If `max_features` is less than the maximum Arrow
 batch size (65,536 features) only `max_features` will be read. All features
 up to `skip_features` are read from the data source and later discarded because
-the Arrow interface does not support randomly seeking a starting feature.
+the Arrow interface does not support randomly seeking a starting feature. This
+overhead is in comparison to reading via Arrow without these parameters, which
+is generally much faster than not using Arrow.
 
 ## Filter records by attribute value
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -606,9 +606,8 @@ cdef validate_feature_range(OGRLayerH ogr_layer, int skip_features=0, int max_fe
         warnings.warn(f"Layer '{name}' does not have any features to read")
         return 0, 0
 
-    # validate skip_features, max_features
     if skip_features < 0 or skip_features >= feature_count:
-        raise ValueError(f"'skip_features' must be between 0 and {feature_count-1}")
+        skip_features = feature_count
 
     if max_features < 0:
         raise ValueError("'max_features' must be >= 0")
@@ -793,6 +792,10 @@ cdef get_features(
     ]
 
     field_data_view = [field_data[field_index][:] for field_index in range(n_fields)]
+
+    if num_features == 0:
+        return fid_data, geometries, field_data
+
     i = 0
     while True:
         try:
@@ -1578,7 +1581,7 @@ def ogr_write(
 
     if num_fields == 0 and geometry is None:
         raise ValueError("You must provide at least a geometry column or a field")
-    
+
     if num_fields > 0:
         num_records = len(field_data[0])
         for i in range(1, len(field_data)):

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -69,7 +69,8 @@ def read_dataframe(
         be ignored and 2D geometries to be returned
     skip_features : int, optional (default: 0)
         Number of features to skip from the beginning of the file before returning
-        features.  Must be less than the total number of features in the file.
+        features.  If greater than available number of features, an empty
+        DataFrame will be returned.
     max_features : int, optional (default: None)
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -72,8 +72,7 @@ def read_dataframe(
         features.  If greater than available number of features, an empty
         DataFrame will be returned.
     max_features : int, optional (default: None)
-        Number of features to read from the file.  Must be less than the total
-        number of features in the file minus skip_features (if used).
+        Number of features to read from the file.
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values.  Uses a
         restricted form of SQL WHERE clause, defined here:

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -84,7 +84,8 @@ def read(
         be ignored and 2D geometries to be returned
     skip_features : int, optional (default: 0)
         Number of features to skip from the beginning of the file before returning
-        features.  Must be less than the total number of features in the file.
+        features.   If greater than available number of features, empty arrays
+        will be returned.
     max_features : int, optional (default: None)
         Number of features to read from the file.  Must be less than the total
         number of features in the file minus skip_features (if used).

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -269,7 +269,7 @@ def read_arrow(
                     batches.append(batch)
 
                     count += len(batch)
-                    if count > max_features:
+                    if count >= (skip_features + max_features):
                         break
 
                 except StopIteration:

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -87,8 +87,7 @@ def read(
         features.   If greater than available number of features, empty arrays
         will be returned.
     max_features : int, optional (default: None)
-        Number of features to read from the file.  Must be less than the total
-        number of features in the file minus skip_features (if used).
+        Number of features to read from the file.
     where : str, optional (default: None)
         Where clause to filter features in layer by attribute values.  Uses a
         restricted form of SQL WHERE clause, defined here:

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -45,6 +45,27 @@ def test_read_arrow_max_features(naturalearth_lowres, max_features, expected):
     assert len(table) == expected
 
 
+@pytest.mark.parametrize(
+    "skip_features, max_features, expected",
+    [
+        (0, 0, 0),
+        (10, 0, 0),
+        (200, 0, 0),
+        (1, 200, 176),
+        (176, 10, 1),
+        (100, 100, 77),
+        (100, 100000, 77),
+    ],
+)
+def test_read_arrow_skip_features_max_features(
+    naturalearth_lowres, skip_features, max_features, expected
+):
+    table = read_arrow(
+        naturalearth_lowres, skip_features=skip_features, max_features=max_features
+    )[1]
+    assert len(table) == expected
+
+
 def test_read_arrow_fid(naturalearth_lowres_all_ext):
     kwargs = {"use_arrow": True, "where": "fid >= 2 AND fid <= 3"}
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -241,6 +241,30 @@ def test_read_fids_force_2d(test_fgdb_vsi):
         assert not df.iloc[0].geometry.has_z
 
 
+@pytest.mark.parametrize(
+    "use_arrow",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not has_pyarrow or __gdal_version__ < (3, 6, 0),
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("skip_features, expected", [(10, 167), (200, 0)])
+def test_read_skip_features(
+    naturalearth_lowres_all_ext, use_arrow, skip_features, expected
+):
+    df = read_dataframe(
+        naturalearth_lowres_all_ext, skip_features=skip_features, use_arrow=use_arrow
+    )
+    assert len(df) == expected
+    assert isinstance(df, gp.GeoDataFrame)
+
+
 def test_read_non_existent_file():
     # ensure consistent error type / message from GDAL
     with pytest.raises(DataSourceError, match="No such file or directory"):
@@ -368,10 +392,10 @@ def test_read_sql_skip_max(naturalearth_lowres_all_ext):
     assert len(df) == 1
 
     sql = "SELECT * FROM naturalearth_lowres LIMIT 1"
-    with pytest.raises(ValueError, match="'skip_features' must be between 0 and 0"):
-        _ = read_dataframe(
-            naturalearth_lowres_all_ext, sql=sql, skip_features=1, sql_dialect="OGRSQL"
-        )
+    df = read_dataframe(
+        naturalearth_lowres_all_ext, sql=sql, skip_features=1, sql_dialect="OGRSQL"
+    )
+    assert len(df) == 0
 
 
 @pytest.mark.skipif(not has_geos, reason="Spatial SQL operations require GEOS")

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -115,16 +115,22 @@ def test_read_columns(naturalearth_lowres):
     array_equal(meta["fields"], columns[:2])
 
 
-def test_read_skip_features(naturalearth_lowres):
-    expected_geometry, expected_fields = read(naturalearth_lowres)[2:]
-    geometry, fields = read(naturalearth_lowres, skip_features=10)[2:]
+@pytest.mark.parametrize("skip_features", [10, 200])
+def test_read_skip_features(naturalearth_lowres_all_ext, skip_features):
+    expected_geometry, expected_fields = read(naturalearth_lowres_all_ext)[2:]
+    geometry, fields = read(naturalearth_lowres_all_ext, skip_features=skip_features)[
+        2:
+    ]
 
-    assert len(geometry) == len(expected_geometry) - 10
-    assert len(fields[0]) == len(expected_fields[0]) - 10
+    # skipping more features than available in layer returns empty arrays
+    expected_count = max(len(expected_geometry) - skip_features, 0)
 
-    assert np.array_equal(geometry, expected_geometry[10:])
+    assert len(geometry) == expected_count
+    assert len(fields[0]) == expected_count
+
+    assert np.array_equal(geometry, expected_geometry[skip_features:])
     # Last field has more variable data
-    assert np.array_equal(fields[-1], expected_fields[-1][10:])
+    assert np.array_equal(fields[-1], expected_fields[-1][skip_features:])
 
 
 def test_read_max_features(naturalearth_lowres):


### PR DESCRIPTION
Progress toward feature parity between Arrow and non-Arrow read interfaces.

This adds support for `skip_features` and `max_features` to `read_arrow`, which enables these to be passed through via `read_dataframe(path, use_arrow=True, skip_features=10, max_features=2)` so that the behavior is the same with and without `use_arrow`.

I added a note to the introduction to describe the overhead involved:`use_arrow` is `True`, `skip_features` and `max_features` will incur additional overhead because all features up to the next batch size above `max_features` (or size of data layer) will be read prior to slicing out the requested range of features. If `max_features` is less than the maximum Arrow batch size (65,536 features) only `max_features` will be read. All features up to `skip_features` are read from the data source and later discarded because the Arrow interface does not support randomly seeking a starting feature.

This overhead is relative to reading via Arrow; based on my limited tests so far, it is still generally a lot faster to use Arrow even with these parameters than without Arrow.



This also drops a validation requirement that `skip_features` be less than the number of features available to read (originally we raised a `ValueError`).  Since using a `.slice` on a pyarrow Table with a value larger than the size of the original table happily returns an empty table, it made sense to take this approach throughout: if you ask for more features than available, you get back empty arrays / pyarrow Tables / (Geo)DataFrames.