### PR TITLE
TST: drop older GDAL, require shapely for tests, consolidate arrow test parametrize

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -20,13 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - "osgeo/gdal:ubuntu-small-latest" # >= python 3.10.6
-          - "osgeo/gdal:ubuntu-small-3.6.2" # python 3.10.6
+          - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.10.6
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.2" # python 3.10.12
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.3" # python 3.10.6
           - "osgeo/gdal:ubuntu-small-3.5.3" # python 3.8.10
-          - "osgeo/gdal:ubuntu-small-3.4.3" # python 3.8.10
-          - "osgeo/gdal:ubuntu-small-3.3.3" # python 3.8.10
-          - "osgeo/gdal:ubuntu-small-3.2.3" # python 3.8.5
-          - "osgeo/gdal:ubuntu-small-3.1.3" # python 3.8.2
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -41,7 +41,8 @@ jobs:
           python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
 
       - name: Install pyarrow
-        if: matrix.container == 'osgeo/gdal:ubuntu-small-latest'
+        # GDAL>=3.6 required to use Arrow API
+        if: matrix.container != 'osgeo/gdal:ubuntu-small-3.5.3'
         run: |
           python3 -m pip install pyarrow
 

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -22,7 +22,7 @@ jobs:
         container:
           - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.10.6
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.2" # python 3.10.12
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.3" # python 3.10.6
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6
           - "osgeo/gdal:ubuntu-small-3.5.3" # python 3.8.10
 
     container:

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -24,6 +24,7 @@ jobs:
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.2" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6
           - "osgeo/gdal:ubuntu-small-3.5.3" # python 3.8.10
+          - "osgeo/gdal:ubuntu-small-3.4.3" # python 3.8.10
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [build-sdist]
     runs-on: ubuntu-latest
     container:
-      image: "osgeo/gdal:ubuntu-small-3.4.0" # python 3.8.10
+      image: "ghcr.io/osgeo/gdal:ubuntu-small-3.6.3" # python 3.10.6
 
     steps:
       - name: Download sdist from artifacts
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --no-cache-dir wheelhouse/artifact/*.tar.gz
-          python3 -m pip install --no-cache-dir pytest pandas pyproj shapely
+          python3 -m pip install --no-cache-dir pytest pandas pyproj shapely>=2
           python3 -m pip install --no-cache-dir --no-deps geopandas
           python3 -m pip list
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 -   Automatically detect supported driver by extension for all available
     write drivers and addition of `detect_write_driver` (#270)
 
+### Other changes
+
+-   test suite requires Shapely >= 2.0
+
 ### Bug fixes
 
 -   Fix int32 overflow when reading int64 columns (#260)

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.1.x - 3.6.x.
+Supports Python 3.8 - 3.11 and GDAL 3.5.x - 3.6.x.
 
-Reading to GeoDataFrames requires `geopandas>=0.8` with `pygeos`
-or `geopandas>=0.12` with `shapely>=2`.
+Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 
 Additionally, installing `pyarrow` in combination with GDAL 3.6+ enables
 a further speed-up when specifying `use_arrow=True`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.5.x - 3.6.x.
+Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.7.x.
 
 Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 

--- a/ci/environment-libgdal3.5.1.yml
+++ b/ci/environment-libgdal3.5.1.yml
@@ -5,5 +5,5 @@ dependencies:
   - numpy
   - libgdal==3.5.1
   - pytest
-  - pygeos
+  - shapely>=2
   - geopandas-base

--- a/ci/environment-libgdal3.5.1.yml
+++ b/ci/environment-libgdal3.5.1.yml
@@ -5,5 +5,8 @@ dependencies:
   - numpy
   - libgdal==3.5.1
   - pytest
-  - shapely>=2
   - geopandas-base
+  - pip
+  - pip:
+      # install Shapely >= 2.0 using pip because it is not available on conda-forge for above libgdal
+      - shapely>=2

--- a/ci/environment-minimal.yml
+++ b/ci/environment-minimal.yml
@@ -5,4 +5,4 @@ dependencies:
   - numpy
   - libgdal
   - pytest
-
+  - shapely>=2

--- a/ci/environment-minimal.yml
+++ b/ci/environment-minimal.yml
@@ -5,4 +5,3 @@ dependencies:
   - numpy
   - libgdal
   - pytest
-  - shapely>=2

--- a/ci/requirements-wheel-test.txt
+++ b/ci/requirements-wheel-test.txt
@@ -2,7 +2,7 @@ pytest
 # dependencies of geopandas (installed separately with --no-deps to avoid fiona)
 pandas
 pyproj
-shapely
+shapely>=2
 packaging
 # optional test dependencies
 pyarrow

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -2,10 +2,9 @@
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.1.x - 3.6.x
+Supports Python 3.8 - 3.11 and GDAL 3.5.x - 3.6.x
 
-Reading to GeoDataFrames requires requires `geopandas>=0.8` with `pygeos`
-or `geopandas>=0.12` with `shapely>=2`.
+Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 
 Additionally, installing `pyarrow` in combination with GDAL 3.6+ enables
 a further speed-up when specifying `use_arrow=True`.
@@ -84,6 +83,7 @@ and uses `Black` and `Flake8` to ensure consistent formatting.
 
 It is recommended to install `pre-commit` and register its hooks so the formatting is
 automatically verified when you commit code.
+
 ```
 pre-commit install
 ```
@@ -149,6 +149,7 @@ It is also possible to install the necessary dependencies using conda.
 
 After cloning the environment, you can create a conda environment with the necessary
 dependencies like this:
+
 ```
 conda env create -f environment-dev.yml
 ```

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.5.x - 3.6.x
+Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.7.x
 
 Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -335,7 +335,7 @@ You can write a `GeoDataFrame` `df` to a file as follows:
 By default, the appropriate driver is inferred from the extension of the filename:
 
 -   `.fgb`: [FlatGeobuf](https://gdal.org/drivers/vector/flatgeobuf.html)
--   `.geojson`, `.json`: [GeoJSON](https://gdal.org/drivers/vector/geojson.html)
+-   `.geojson`: [GeoJSON](https://gdal.org/drivers/vector/geojson.html)
 -   `.geojsonl`, `.geojsons`: [GeoJSONSeq](https://gdal.org/drivers/vector/geojsonseq.html)
 -   `.gpkg`: [GPKG](https://gdal.org/drivers/vector/gpkg.html)
 -   `.shp`: [ESRI Shapefile](https://gdal.org/drivers/vector/shapefile.html)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,9 +4,9 @@ channels:
 dependencies:
   - numpy
   - geopandas-base
-  - libgdal ==3.6.2
+  - libgdal==3.6.2
   - pyarrow
-  - shapely
+  - shapely>=2
   # Specific for dev
   - cython
   - pre-commit

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - numpy
   - geopandas-base
-  - libgdal
+  - libgdal==3.6.2
   - pyarrow
   - shapely>=2
   # Specific for dev

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - numpy
   - geopandas-base
-  - libgdal==3.6.2
+  - libgdal
   - pyarrow
   - shapely>=2
   # Specific for dev

--- a/pyogrio/_compat.py
+++ b/pyogrio/_compat.py
@@ -1,0 +1,28 @@
+from packaging.version import Version
+
+from pyogrio.core import __gdal_version__, __gdal_geos_version__
+
+# detect optional dependencies
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = None
+
+try:
+    import shapely
+except ImportError:
+    shapely = None
+
+try:
+    import geopandas
+except ImportError:
+    geopandas = None
+
+
+HAS_ARROW_API = __gdal_version__ >= (3, 6, 0) and pyarrow is not None
+
+HAS_GEOPANDAS = geopandas is not None
+
+HAS_GDAL_GEOS = __gdal_geos_version__ is not None
+
+HAS_SHAPELY = shapely is not None and Version(shapely.__version__) >= Version("2.0.0")

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -88,7 +88,8 @@ def detect_write_driver(path):
     elif len(drivers) > 1:
         raise ValueError(
             f"Could not infer driver from path: {path}; multiple drivers are "
-            "available for that extension.  Please specify driver explicitly"
+            f"available for that extension: {', '.join(drivers)}.  Please "
+            "specify driver explicitly."
         )
 
     return drivers[0]

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -1,4 +1,6 @@
 import numpy as np
+
+from pyogrio._compat import HAS_GEOPANDAS
 from pyogrio.raw import (
     DRIVERS_NO_MIXED_SINGLE_MULTI,
     DRIVERS_NO_MIXED_DIMENSIONS,
@@ -144,13 +146,12 @@ def read_dataframe(
     .. _spatialite: https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """
-    try:
-        import pandas as pd
-        import geopandas as gp
-        from geopandas.array import from_wkb
-
-    except ImportError:
+    if not HAS_GEOPANDAS:
         raise ImportError("geopandas is required to use pyogrio.read_dataframe()")
+
+    import pandas as pd
+    import geopandas as gp
+    from geopandas.array import from_wkb
 
     path_or_buffer = _stringify_path(path_or_buffer)
 
@@ -306,15 +307,13 @@ def write_dataframe(
         option).
     """
     # TODO: add examples to the docstring (e.g. OGR kwargs)
-    try:
-        from geopandas.array import to_wkb
-        import pandas as pd
 
-        # if geopandas is available so is pyproj
-        from pyproj.enums import WktVersion
+    if not HAS_GEOPANDAS:
+        raise ImportError("geopandas is required to use pyogrio.write_dataframe()")
 
-    except ImportError:
-        raise ImportError("geopandas is required to use pyogrio.read_dataframe()")
+    from geopandas.array import to_wkb
+    import pandas as pd
+    from pyproj.enums import WktVersion  # if geopandas is available so is pyproj
 
     path = str(path)
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -1,6 +1,7 @@
 import warnings
 
 from pyogrio._env import GDALEnv
+from pyogrio._compat import HAS_ARROW_API
 from pyogrio.core import detect_write_driver
 from pyogrio.errors import DataSourceError
 from pyogrio.util import get_vsi_path, vsi_path, _preprocess_options_key_value
@@ -266,10 +267,8 @@ def open_arrow(
             "geometry_name": "<name of geometry column in arrow table>",
         }
     """
-    try:
-        import pyarrow  # noqa
-    except ImportError:
-        raise RuntimeError("the 'pyarrow' package is required to read using arrow")
+    if not HAS_ARROW_API:
+        raise RuntimeError("pyarrow and GDAL>= 3.6 required to read using arrow")
 
     path, buffer = get_vsi_path(path_or_buffer)
 

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -4,22 +4,12 @@ from zipfile import ZipFile, ZIP_DEFLATED
 import pytest
 
 from pyogrio import (
-    __gdal_version__,
     __gdal_version_string__,
-    __gdal_geos_version__,
     __version__,
     list_drivers,
 )
+from pyogrio._compat import HAS_ARROW_API, HAS_GDAL_GEOS, HAS_SHAPELY
 from pyogrio.raw import read, write
-
-try:
-    import pyarrow
-except ImportError:
-    pyarrow = None
-
-
-HAS_ARROW = __gdal_version__ >= (3, 6, 0) and pyarrow is not None
-HAS_GEOS = __gdal_geos_version__ is not None
 
 
 _data_dir = Path(__file__).parent.resolve() / "fixtures"
@@ -50,6 +40,18 @@ def pytest_report_header(config):
         f"GDAL {__gdal_version_string__}\n"
         f"Supported drivers: {drivers}"
     )
+
+
+# marks to skip tests if optional dependecies are not present
+requires_arrow_api = pytest.mark.skipif(
+    not HAS_ARROW_API, reason="GDAL>=3.6 and pyarrow required"
+)
+
+requires_gdal_geos = pytest.mark.skipif(
+    not HAS_GDAL_GEOS, reason="GDAL compiled with GEOS required"
+)
+
+requires_shapely = pytest.mark.skipif(not HAS_SHAPELY, reason="Shapely >= 2.0 required")
 
 
 def prepare_testfile(testfile_path, dst_dir, ext):

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -3,8 +3,23 @@ from zipfile import ZipFile, ZIP_DEFLATED
 
 import pytest
 
-from pyogrio import __gdal_version_string__, __version__, list_drivers
+from pyogrio import (
+    __gdal_version__,
+    __gdal_version_string__,
+    __gdal_geos_version__,
+    __version__,
+    list_drivers,
+)
 from pyogrio.raw import read, write
+
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = None
+
+
+HAS_ARROW = __gdal_version__ >= (3, 6, 0) and pyarrow is not None
+HAS_GEOS = __gdal_geos_version__ is not None
 
 
 _data_dir = Path(__file__).parent.resolve() / "fixtures"
@@ -112,3 +127,18 @@ def test_ogr_types_list():
 @pytest.fixture(scope="session")
 def test_datetime():
     return _data_dir / "test_datetime.geojson"
+
+
+use_arrow = pytest.mark.parametrize(
+    "use_arrow",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not HAS_ARROW,
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+    ],
+)

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -127,18 +127,3 @@ def test_ogr_types_list():
 @pytest.fixture(scope="session")
 def test_datetime():
     return _data_dir / "test_datetime.geojson"
-
-
-use_arrow = pytest.mark.parametrize(
-    "use_arrow",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not HAS_ARROW,
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-    ],
-)

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -31,7 +31,6 @@ DRIVERS = {
     ".geojsonl": "GeoJSONSeq",
     ".geojsons": "GeoJSONSeq",
     ".gpkg": "GPKG",
-    ".json": "GeoJSON",
     ".shp": "ESRI Shapefile",
 }
 

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -2,23 +2,22 @@ import math
 
 import pytest
 
-from pyogrio import __gdal_version__, read_dataframe
+from pyogrio import read_dataframe
 from pyogrio.raw import open_arrow, read_arrow
+from pyogrio.tests.conftest import requires_arrow_api
 
 try:
     import pandas as pd
     from pandas.testing import assert_frame_equal, assert_index_equal
     from geopandas.testing import assert_geodataframe_equal
+
+    import pyarrow
 except ImportError:
     pass
 
-
+# skip all tests in this file if Arrow API or GeoPandas are unavailable
+pytestmark = requires_arrow_api
 pytest.importorskip("geopandas")
-pyarrow = pytest.importorskip("pyarrow")
-
-pytestmark = pytest.mark.skipif(
-    __gdal_version__ < (3, 6, 0), reason="Arrow tests require GDAL>=3.6"
-)
 
 
 def test_read_arrow(naturalearth_lowres_all_ext):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -37,13 +37,15 @@ except ImportError:
 pytest.importorskip("geopandas")
 
 
-use_arrow = pytest.mark.parametrize(
-    "use_arrow",
-    [
+@pytest.fixture(
+    scope="session",
+    params=[
         False,
         pytest.param(True, marks=requires_arrow_api),
     ],
 )
+def use_arrow(request):
+    return request.param
 
 
 def spatialite_available(path):
@@ -76,7 +78,6 @@ def test_read_dataframe_vsi(naturalearth_lowres_vsi):
     assert len(df) == 177
 
 
-@use_arrow
 @pytest.mark.parametrize(
     "columns, fid_as_index, exp_len", [(None, False, 2), ([], True, 2), ([], False, 0)]
 )
@@ -112,7 +113,6 @@ def test_read_no_geometry(naturalearth_lowres_all_ext):
     assert not isinstance(df, gp.GeoDataFrame)
 
 
-@use_arrow
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
     with pytest.raises(
         ValueError,
@@ -207,7 +207,6 @@ def test_read_fid_as_index(naturalearth_lowres_all_ext):
         assert_index_equal(df.index, pd.Index([2, 3], name="fid"))
 
 
-@use_arrow
 def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
     df = read_dataframe(
         naturalearth_lowres,
@@ -1077,7 +1076,6 @@ def test_read_multisurface(data_dir):
     assert df.geometry.type.tolist() == ["MultiPolygon"]
 
 
-@use_arrow
 def test_read_dataset_kwargs(data_dir, use_arrow):
     filename = data_dir / "test_nested.geojson"
 
@@ -1109,7 +1107,6 @@ def test_read_dataset_kwargs(data_dir, use_arrow):
     assert_geodataframe_equal(df, expected)
 
 
-@use_arrow
 def test_read_invalid_dataset_kwargs(naturalearth_lowres, use_arrow):
     with pytest.warns(RuntimeWarning, match="does not support open option INVALID"):
         read_dataframe(naturalearth_lowres, use_arrow=use_arrow, INVALID="YES")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -501,7 +501,7 @@ def test_write_dataframe(tmp_path, naturalearth_lowres, ext):
 
     # Coordinates are not precisely equal when written to JSON
     # dtypes do not necessarily round-trip precisely through JSON
-    is_json = ext in [".json", ".geojson", ".geojsonl"]
+    is_json = ext in [".geojson", ".geojsonl"]
     # In .geojsonl the vertices are reordered, so normalize
     is_jsons = ext == ".geojsonl"
 
@@ -541,7 +541,7 @@ def test_write_dataframe_no_geom(tmp_path, naturalearth_lowres, ext):
     assert isinstance(result_df, pd.DataFrame)
 
     # some dtypes do not round-trip precisely through these file types
-    check_dtype = ext not in [".json", ".geojson", ".geojsonl", ".xlsx"]
+    check_dtype = ext not in [".geojson", ".geojsonl", ".xlsx"]
 
     if ext in [".gpkg", ".shp", ".xlsx"]:
         # These file types return a DataFrame when read.

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -5,7 +5,6 @@ from packaging.version import Version
 
 import numpy as np
 import pytest
-import shapely
 
 from pyogrio import list_layers, read_info, __gdal_version__
 from pyogrio.errors import DataLayerError, DataSourceError, FeatureError, GeometryError
@@ -14,7 +13,12 @@ from pyogrio.raw import (
     DRIVERS_NO_MIXED_DIMENSIONS,
     DRIVERS_NO_MIXED_SINGLE_MULTI,
 )
-from pyogrio.tests.conftest import ALL_EXTS, DRIVERS, HAS_ARROW, HAS_GEOS
+from pyogrio.tests.conftest import (
+    ALL_EXTS,
+    DRIVERS,
+    requires_arrow_api,
+    requires_gdal_geos,
+)
 
 try:
     import pandas as pd
@@ -23,6 +27,8 @@ try:
     import geopandas as gp
     from geopandas.array import from_wkt
     from geopandas.testing import assert_geodataframe_equal
+
+    import shapely  # if geopandas is present, shapely is expected to be present
 
 except ImportError:
     pass
@@ -35,13 +41,7 @@ use_arrow = pytest.mark.parametrize(
     "use_arrow",
     [
         False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not HAS_ARROW,
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
+        pytest.param(True, marks=requires_arrow_api),
     ],
 )
 
@@ -429,7 +429,7 @@ def test_read_sql_skip_max(naturalearth_lowres_all_ext):
         )
 
 
-@pytest.mark.skipif(not HAS_GEOS, reason="Spatial SQL operations require GEOS")
+@requires_gdal_geos
 @pytest.mark.parametrize(
     "naturalearth_lowres",
     [ext for ext in ALL_EXTS if ext != ".gpkg"],
@@ -454,7 +454,7 @@ def test_read_sql_dialect_sqlite_nogpkg(naturalearth_lowres):
     assert df.iloc[0].geometry.area > area_canada
 
 
-@pytest.mark.skipif(not HAS_GEOS, reason="Spatial SQL operations require GEOS")
+@requires_gdal_geos
 @pytest.mark.parametrize(
     "naturalearth_lowres", [".gpkg"], indirect=["naturalearth_lowres"]
 )

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -14,7 +14,7 @@ from pyogrio.raw import (
     DRIVERS_NO_MIXED_DIMENSIONS,
     DRIVERS_NO_MIXED_SINGLE_MULTI,
 )
-from pyogrio.tests.conftest import ALL_EXTS, DRIVERS, HAS_GEOS, use_arrow
+from pyogrio.tests.conftest import ALL_EXTS, DRIVERS, HAS_ARROW, HAS_GEOS
 
 try:
     import pandas as pd
@@ -29,6 +29,21 @@ except ImportError:
 
 
 pytest.importorskip("geopandas")
+
+
+use_arrow = pytest.mark.parametrize(
+    "use_arrow",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not HAS_ARROW,
+                reason="Arrow tests require pyarrow and GDAL>=3.6",
+            ),
+        ),
+    ],
+)
 
 
 def spatialite_available(path):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -5,15 +5,16 @@ from packaging.version import Version
 
 import numpy as np
 import pytest
+import shapely
 
-from pyogrio import list_layers, read_info, __gdal_version__, __gdal_geos_version__
+from pyogrio import list_layers, read_info, __gdal_version__
 from pyogrio.errors import DataLayerError, DataSourceError, FeatureError, GeometryError
 from pyogrio.geopandas import read_dataframe, write_dataframe
 from pyogrio.raw import (
     DRIVERS_NO_MIXED_DIMENSIONS,
     DRIVERS_NO_MIXED_SINGLE_MULTI,
 )
-from pyogrio.tests.conftest import ALL_EXTS, DRIVERS
+from pyogrio.tests.conftest import ALL_EXTS, DRIVERS, HAS_GEOS, use_arrow
 
 try:
     import pandas as pd
@@ -23,25 +24,11 @@ try:
     from geopandas.array import from_wkt
     from geopandas.testing import assert_geodataframe_equal
 
-    from shapely.geometry import Point
-except ImportError:
-    pass
-
-has_pyarrow = False
-try:
-    import pyarrow  # noqa
-
-    has_pyarrow = True
 except ImportError:
     pass
 
 
 pytest.importorskip("geopandas")
-
-
-# Note: this will also be false for GDAL < 3.4 when GEOS may be present but we
-# cannot verify it
-has_geos = __gdal_geos_version__ is not None
 
 
 def spatialite_available(path):
@@ -74,19 +61,7 @@ def test_read_dataframe_vsi(naturalearth_lowres_vsi):
     assert len(df) == 177
 
 
-@pytest.mark.parametrize(
-    "use_arrow",
-    [
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not has_pyarrow or __gdal_version__ < (3, 6, 0),
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-        False,
-    ],
-)
+@use_arrow
 @pytest.mark.parametrize(
     "columns, fid_as_index, exp_len", [(None, False, 2), ([], True, 2), ([], False, 0)]
 )
@@ -122,19 +97,7 @@ def test_read_no_geometry(naturalearth_lowres_all_ext):
     assert not isinstance(df, gp.GeoDataFrame)
 
 
-@pytest.mark.parametrize(
-    "use_arrow",
-    [
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not has_pyarrow or __gdal_version__ < (3, 6, 0),
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-        False,
-    ],
-)
+@use_arrow
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres, use_arrow):
     with pytest.raises(
         ValueError,
@@ -229,19 +192,7 @@ def test_read_fid_as_index(naturalearth_lowres_all_ext):
         assert_index_equal(df.index, pd.Index([2, 3], name="fid"))
 
 
-@pytest.mark.parametrize(
-    "use_arrow",
-    [
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not has_pyarrow or __gdal_version__ < (3, 6, 0),
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-        False,
-    ],
-)
+@use_arrow
 def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
     df = read_dataframe(
         naturalearth_lowres,
@@ -463,7 +414,7 @@ def test_read_sql_skip_max(naturalearth_lowres_all_ext):
         )
 
 
-@pytest.mark.skipif(not has_geos, reason="Spatial SQL operations require GEOS")
+@pytest.mark.skipif(not HAS_GEOS, reason="Spatial SQL operations require GEOS")
 @pytest.mark.parametrize(
     "naturalearth_lowres",
     [ext for ext in ALL_EXTS if ext != ".gpkg"],
@@ -488,7 +439,7 @@ def test_read_sql_dialect_sqlite_nogpkg(naturalearth_lowres):
     assert df.iloc[0].geometry.area > area_canada
 
 
-@pytest.mark.skipif(not has_geos, reason="Spatial SQL operations require GEOS")
+@pytest.mark.skipif(not HAS_GEOS, reason="Spatial SQL operations require GEOS")
 @pytest.mark.parametrize(
     "naturalearth_lowres", [".gpkg"], indirect=["naturalearth_lowres"]
 )
@@ -851,22 +802,15 @@ def test_write_dataframe_layer_geom_type_invalid(tmp_path, naturalearth_lowres):
 
 @pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".shp"])
 def test_write_dataframe_truly_mixed(tmp_path, ext):
-    from shapely.geometry import (
-        box,
-        LineString,
-        MultiLineString,
-        MultiPoint,
-        MultiPolygon,
-        Point,
-    )
-
     geometry = [
-        Point(0, 0),
-        LineString([(0, 0), (1, 1)]),
-        box(0, 0, 1, 1),
-        MultiPoint([Point(1, 1), Point(2, 2)]),
-        MultiLineString([LineString([(1, 1), (2, 2)]), LineString([(2, 2), (3, 3)])]),
-        MultiPolygon([box(1, 1, 2, 2), box(2, 2, 3, 3)]),
+        shapely.Point(0, 0),
+        shapely.LineString([(0, 0), (1, 1)]),
+        shapely.box(0, 0, 1, 1),
+        shapely.MultiPoint([shapely.Point(1, 1), shapely.Point(2, 2)]),
+        shapely.MultiLineString(
+            [shapely.LineString([(1, 1), (2, 2)]), shapely.LineString([(2, 2), (3, 3)])]
+        ),
+        shapely.MultiPolygon([shapely.box(1, 1, 2, 2), shapely.box(2, 2, 3, 3)]),
     ]
 
     df = gp.GeoDataFrame(
@@ -890,11 +834,14 @@ def test_write_dataframe_truly_mixed(tmp_path, ext):
 def test_write_dataframe_truly_mixed_invalid(tmp_path):
     # Shapefile doesn't support generic "Geometry" / "Unknown" type
     # for mixed geometries
-    from shapely.geometry import Point, LineString, box
 
     df = gp.GeoDataFrame(
         {"col": [1.0, 2.0, 3.0]},
-        geometry=[Point(0, 0), LineString([(0, 0), (1, 1)]), box(0, 0, 1, 1)],
+        geometry=[
+            shapely.Point(0, 0),
+            shapely.LineString([(0, 0), (1, 1)]),
+            shapely.box(0, 0, 1, 1),
+        ],
         crs="EPSG:4326",
     )
 
@@ -910,7 +857,12 @@ def test_write_dataframe_truly_mixed_invalid(tmp_path):
 @pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".fgb"])
 @pytest.mark.parametrize(
     "geoms",
-    [[None, Point(1, 1)], [Point(1, 1), None], [None, Point(1, 1, 2)], [None, None]],
+    [
+        [None, shapely.Point(1, 1)],
+        [shapely.Point(1, 1), None],
+        [None, shapely.Point(1, 1, 2)],
+        [None, None],
+    ],
 )
 def test_write_dataframe_infer_geometry_with_nulls(tmp_path, geoms, ext):
     filename = tmp_path / f"test{ext}"
@@ -945,10 +897,8 @@ def test_custom_crs_io(tmpdir, naturalearth_lowres_all_ext):
 
 
 def test_write_read_mixed_column_values(tmp_path):
-    from shapely.geometry import Point
-
     mixed_values = ["test", 1.0, 1, datetime.now(), None, np.nan]
-    geoms = [Point(0, 0) for _ in mixed_values]
+    geoms = [shapely.Point(0, 0) for _ in mixed_values]
     test_gdf = gp.GeoDataFrame(
         {"geometry": geoms, "mixed": mixed_values}, crs="epsg:31370"
     )
@@ -964,10 +914,8 @@ def test_write_read_mixed_column_values(tmp_path):
 
 
 def test_write_read_null(tmp_path):
-    from shapely.geometry import Point
-
     output_path = tmp_path / "test_write_nan.gpkg"
-    geom = Point(0, 0)
+    geom = shapely.Point(0, 0)
     test_data = {
         "geometry": [geom, geom, geom],
         "float64": [1.0, None, np.nan],
@@ -1114,19 +1062,7 @@ def test_read_multisurface(data_dir):
     assert df.geometry.type.tolist() == ["MultiPolygon"]
 
 
-@pytest.mark.parametrize(
-    "use_arrow",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not has_pyarrow or __gdal_version__ < (3, 6, 0),
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-    ],
-)
+@use_arrow
 def test_read_dataset_kwargs(data_dir, use_arrow):
     filename = data_dir / "test_nested.geojson"
 
@@ -1138,7 +1074,7 @@ def test_read_dataset_kwargs(data_dir, use_arrow):
             "top_level": ["A"],
             "intermediate_level": ['{ "bottom_level": "B" }'],
         },
-        geometry=[Point(0, 0)],
+        geometry=[shapely.Point(0, 0)],
         crs="EPSG:4326",
     )
 
@@ -1151,26 +1087,14 @@ def test_read_dataset_kwargs(data_dir, use_arrow):
             "top_level": ["A"],
             "intermediate_level_bottom_level": ["B"],
         },
-        geometry=[Point(0, 0)],
+        geometry=[shapely.Point(0, 0)],
         crs="EPSG:4326",
     )
 
     assert_geodataframe_equal(df, expected)
 
 
-@pytest.mark.parametrize(
-    "use_arrow",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not has_pyarrow or __gdal_version__ < (3, 6, 0),
-                reason="Arrow tests require pyarrow and GDAL>=3.6",
-            ),
-        ),
-    ],
-)
+@use_arrow
 def test_read_invalid_dataset_kwargs(naturalearth_lowres, use_arrow):
     with pytest.warns(RuntimeWarning, match="does not support open option INVALID"):
         read_dataframe(naturalearth_lowres, use_arrow=use_arrow, INVALID="YES")
@@ -1185,7 +1109,9 @@ def test_write_nullable_dtypes(tmp_path):
         "col4": pd.Series([True, False, None], dtype="boolean"),
         "col5": pd.Series(["a", None, "b"], dtype="string"),
     }
-    input_gdf = gp.GeoDataFrame(test_data, geometry=[Point(0, 0)] * 3, crs="epsg:31370")
+    input_gdf = gp.GeoDataFrame(
+        test_data, geometry=[shapely.Point(0, 0)] * 3, crs="epsg:31370"
+    )
     write_dataframe(input_gdf, path)
     output_gdf = read_dataframe(path)
     # We read it back as default (non-nullable) numpy dtypes, so we cast

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -17,7 +17,12 @@ from pyogrio import (
 from pyogrio._compat import HAS_SHAPELY
 from pyogrio.raw import read, write
 from pyogrio.errors import DataSourceError, DataLayerError, FeatureError
-from pyogrio.tests.conftest import prepare_testfile, DRIVERS, DRIVER_EXT
+from pyogrio.tests.conftest import (
+    DRIVERS,
+    DRIVER_EXT,
+    prepare_testfile,
+    requires_arrow_api,
+)
 
 
 def test_read(naturalearth_lowres):
@@ -835,9 +840,11 @@ def test_write_float_nan_null(tmp_path, dtype):
     assert '{ "col": NaN }' in content
 
 
-@pytest.mark.skipif("Arrow" not in list_drivers(), reason="GDAL not built with Arrow")
+@requires_arrow_api
+@pytest.mark.skipif(
+    "Arrow" not in list_drivers(), reason="Arrow driver is not available"
+)
 def test_write_float_nan_null_arrow(tmp_path):
-    pyarrow = pytest.importorskip("pyarrow")
     import pyarrow.feather
 
     # Point(0, 0)

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -6,6 +6,7 @@ import sys
 import numpy as np
 from numpy import array_equal
 import pytest
+import shapely
 
 from pyogrio import (
     list_layers,
@@ -583,17 +584,10 @@ def assert_equal_result(result1, result2):
     assert np.array_equal(meta1["fields"], meta2["fields"])
     assert np.array_equal(index1, index2)
     # a plain `assert np.array_equal(geometry1, geometry2)` doesn't work because
-    # the WKB values are not exactly equal, therefore parsing with pygeos to compare
+    # the WKB values are not exactly equal, therefore parsing with shapely to compare
     # with tolerance
-    try:
-        from shapely import from_wkb, equals_exact
-    except ImportError:
-        try:
-            from pygeos import from_wkb, equals_exact
-        except ImportError:
-            pytest.skip("Test requires pygeos or shapely>=2")
-    assert equals_exact(
-        from_wkb(geometry1), from_wkb(geometry2), tolerance=0.00001
+    assert shapely.equals_exact(
+        shapely.from_wkb(geometry1), shapely.from_wkb(geometry2), tolerance=0.00001
     ).all()
     assert all([np.array_equal(f1, f2) for f1, f2 in zip(field_data1, field_data2)])
 

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ setup(
     install_requires=["certifi", "numpy"],
     extras_require={
         "dev": ["Cython"],
-        "test": ["pytest", "pytest-cov"],
+        "test": ["pytest", "pytest-cov", "shapely>=2"],
         "benchmark": ["pytest-benchmark"],
         "geopandas": ["geopandas"],
     },

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ setup(
     install_requires=["certifi", "numpy"],
     extras_require={
         "dev": ["Cython"],
-        "test": ["pytest", "pytest-cov", "shapely>=2"],
+        "test": ["pytest", "pytest-cov"],
         "benchmark": ["pytest-benchmark"],
         "geopandas": ["geopandas"],
     },


### PR DESCRIPTION
This raises the minimum supported version of GDAL to 3.5.* (note: no compatibility change, just dropping old versions from CI).

This updates the CI matrix to use newer Docker images from ghcr.io (current home of GDAL images).

This adds `_compat.py` to check the state of optional dependencies and GDAL features like Arrow API or GEOS.  This will give us a place in later PRs to set variables to use Arrow by default.

This drops shim to use PyGEOS; otherwise the conditional presence of it was cluttering up tests esp. those around #285.  While GeoPandas support should continue to work with PyGEOS instead of Shapely 2.0, we no longer test that specifically and no longer list that as a compatible setup.  The tests assume that if GeoPandas is present that Shapely >= 2.0 is present.

This adds a new parametrize `@use_arrow` which will provide a boolean value of at least `False` and will include `True` if arrow support is enabled.  This should make it easier to mark additional tests to test with and without arrow support.

This adds new pytest marks to make skipping tests a little easier:
- `requires_arrow_api`: skip tests if pyarrow is absent or GDAL < 3.6
- `requires_gdal_geos`: skip tests if GDAL was not compiled with GEOS
- `requires_shapely`: skip tests if Shapely >= 2.0 is absent

This drops direct tests that use `.json` extension without specifying driver, because recent versions of GDAL added [another driver](https://gdal.org/drivers/vector/jsonfg.html) for that extension and we raise errors when there are multiple.  Since this comes from GDAL rather than an intentional breaking change on our end, I didn't note this in the changelog (should we?).
