### PR TITLE
CI: Run nightly tests on installed version of pyogrio

### DIFF
--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Test
         run: |
-          pytest --color=yes tests/
+          pytest --color=yes pyogrio/tests/

--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -51,4 +51,3 @@ jobs:
       - name: Test
         run: |
           pytest -v -r s pyogrio/tests
-        shell: micromamba-shell {0}

--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Test
         run: |
-          pytest --color=yes pyogrio/tests/
+          pytest -v -r s pyogrio/tests

--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -1,0 +1,53 @@
+name: Conda Tests Installed
+
+on:
+  pull_request:
+    branches: [ main, v0.** ]
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  TestsOnInstalled:    
+    name: ${{ matrix.checkout_ref }} - python ${{ matrix.python }} - ${{ matrix.os }}
+    timeout-minutes: 30
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python: ["3.11"]
+        include:
+          - checkout_ref: "v0.6.0"
+            # nomkl: openblas instead of mkl saves 600 MB. Linux OK, but 50% slower on Windows and OSX!
+            install_extra_args: >-
+              geopandas-base
+              nomkl
+              pyarrow
+              pyogrio=0.6.0
+              pytest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.checkout_ref }}
+          sparse-checkout: |
+            tests
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: "1.5.1-0"
+          environment-name: tests-conda-installed-env
+          create-args: >-
+            python=${{ matrix.python }}
+            ${{ matrix.install_extra_args }}
+
+      - name: Test
+        run: |
+          pytest --color=yes tests/

--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ref: ${{ matrix.checkout_ref }}
           sparse-checkout: |
-            tests
+            pyogrio/tests
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:

--- a/.github/workflows/tests-conda-installed.yml
+++ b/.github/workflows/tests-conda-installed.yml
@@ -51,3 +51,4 @@ jobs:
       - name: Test
         run: |
           pytest -v -r s pyogrio/tests
+        shell: micromamba-shell {0}


### PR DESCRIPTION
Just an idea to do this... but it can help to detect issues as early as possible when dependencies make breaking changes and/or have regression bugs that influence pyogrio.