### PR TITLE
ENH Remove warning on no features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
     columns, geometry, or fids (#280)
 -   Automatically detect supported driver by extension for all available
     write drivers and addition of `detect_write_driver` (#270)
--   Removed warning when no features are read from the data source.
+-   Removed warning when no features are read from the data source (#299).
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
     columns, geometry, or fids (#280)
 -   Automatically detect supported driver by extension for all available
     write drivers and addition of `detect_write_driver` (#270)
+-   Removed warning when no features are read from the data source.
 
 ### Other changes
 
@@ -45,7 +46,7 @@
     -   the `features` property in the result will now be -1 if calculating the
         feature count is an expensive operation for this driver. You can force it to be
         calculated using the `force_feature_count` parameter.
-    -   for boolean values in the `capabilities` property, the values will now be 
+    -   for boolean values in the `capabilities` property, the values will now be
         booleans instead of 1 or 0.
 
 ## 0.6.0 (2023-04-27)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -632,7 +632,6 @@ cdef validate_feature_range(OGRLayerH ogr_layer, int skip_features=0, int max_fe
     num_features = max_features
 
     if feature_count == 0:
-        name = OGR_L_GetName(ogr_layer)
         return 0, 0
 
     if skip_features < 0 or skip_features >= feature_count:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -633,7 +633,6 @@ cdef validate_feature_range(OGRLayerH ogr_layer, int skip_features=0, int max_fe
 
     if feature_count == 0:
         name = OGR_L_GetName(ogr_layer)
-        warnings.warn(f"Layer '{name}' does not have any features to read")
         return 0, 0
 
     if skip_features < 0 or skip_features >= feature_count:

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -213,10 +213,9 @@ def test_read_bounds_bbox_invalid(naturalearth_lowres, bbox):
 
 def test_read_bounds_bbox(naturalearth_lowres_all_ext):
     # should return no features
-    with pytest.warns(UserWarning, match="does not have any features to read"):
-        fids, bounds = read_bounds(
-            naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001)
-        )
+    fids, bounds = read_bounds(
+        naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001)
+    )
 
     assert fids.shape == (0,)
     assert bounds.shape == (4, 0)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -220,7 +220,6 @@ def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
     assert len(df.columns) == 0
 
 
-@pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 def test_read_where(naturalearth_lowres_all_ext):
     # empty filter should return full set of records
     df = read_dataframe(naturalearth_lowres_all_ext, where="")
@@ -250,7 +249,6 @@ def test_read_where(naturalearth_lowres_all_ext):
     assert len(df) == 0
 
 
-@pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 def test_read_where_invalid(naturalearth_lowres_all_ext):
     with pytest.raises(ValueError, match="Invalid SQL"):
         read_dataframe(naturalearth_lowres_all_ext, where="invalid")
@@ -264,9 +262,8 @@ def test_read_bbox_invalid(naturalearth_lowres_all_ext, bbox):
 
 def test_read_bbox(naturalearth_lowres_all_ext):
     # should return no features
-    with pytest.warns(UserWarning, match="does not have any features to read"):
-        df = read_dataframe(naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001))
-        assert len(df) == 0
+    df = read_dataframe(naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001))
+    assert len(df) == 0
 
     df = read_dataframe(naturalearth_lowres_all_ext, bbox=(-85, 8, -80, 10))
     assert len(df) == 2
@@ -318,7 +315,6 @@ def test_read_non_existent_file():
         read_dataframe("zip:///non-existent.zip")
 
 
-@pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 def test_read_sql(naturalearth_lowres_all_ext):
     # The geometry column cannot be specified when using the
     # default OGRSQL dialect but is returned nonetheless, so 4 columns.
@@ -572,7 +568,6 @@ def test_write_dataframe_no_geom(tmp_path, naturalearth_lowres, ext):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*Layer .* does not have any features to read")
 @pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext not in ".geojsonl"])
 def test_write_empty_dataframe(tmp_path, ext):
     expected = gp.GeoDataFrame(geometry=[], crs=4326)

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -181,9 +181,8 @@ def test_read_where(naturalearth_lowres):
     assert max(fields[0]) < 100000000
 
     # should match no items
-    with pytest.warns(UserWarning, match="does not have any features to read"):
-        geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'INVALID'")[2:]
-        assert len(geometry) == 0
+    geometry, fields = read(naturalearth_lowres, where="iso_a3 = 'INVALID'")[2:]
+    assert len(geometry) == 0
 
 
 def test_read_where_invalid(naturalearth_lowres):
@@ -199,10 +198,9 @@ def test_read_bbox_invalid(naturalearth_lowres, bbox):
 
 def test_read_bbox(naturalearth_lowres_all_ext):
     # should return no features
-    with pytest.warns(UserWarning, match="does not have any features to read"):
-        geometry, fields = read(
-            naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001)
-        )[2:]
+    geometry, fields = read(naturalearth_lowres_all_ext, bbox=(0, 0, 0.00001, 0.00001))[
+        2:
+    ]
 
     assert len(geometry) == 0
 


### PR DESCRIPTION
Resolves #294 

Removes the `UserWarning` warning previously raised when no features were read from the data source.