### PR TITLE
FIX: Disallow negative skip_features

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -650,17 +650,15 @@ cdef validate_feature_range(OGRLayerH ogr_layer, int skip_features=0, int max_fe
     skip_features : number of features to skip from beginning of available range
     max_features : maximum number of features to read from available range
     """
+
     feature_count = get_feature_count(ogr_layer, 1)
     num_features = max_features
 
     if feature_count == 0:
         return 0, 0
 
-    if skip_features < 0 or skip_features >= feature_count:
+    if skip_features >= feature_count:
         skip_features = feature_count
-
-    if max_features < 0:
-        raise ValueError("'max_features' must be >= 0")
 
     elif max_features == 0:
         num_features = feature_count - skip_features
@@ -1094,6 +1092,12 @@ def ogr_read(
     if bbox and mask:
         raise ValueError("cannot set both 'bbox' and 'mask'")
 
+    if skip_features < 0:
+        raise ValueError("'skip_features' must be >= 0")
+
+    if max_features < 0:
+        raise ValueError("'max_features' must be >= 0")
+
     try:
         dataset_options = dict_to_options(dataset_kwargs)
         ogr_dataset = ogr_open(path_c, 0, dataset_options)
@@ -1261,6 +1265,9 @@ def ogr_open_arrow(
                 "specifying 'skip_features' is not supported for Arrow for GDAL<3.8.0"
             )
 
+    if skip_features < 0:
+        raise ValueError("'skip_features' must be >= 0")
+
     if max_features:
         raise ValueError(
             "specifying 'max_features' is not supported for Arrow"
@@ -1422,6 +1429,12 @@ def ogr_read_bounds(
 
     if bbox and mask:
         raise ValueError("cannot set both 'bbox' and 'mask'")
+
+    if skip_features < 0:
+        raise ValueError("'skip_features' must be >= 0")
+
+    if max_features < 0:
+        raise ValueError("'max_features' must be >= 0")
 
     path_b = path.encode('utf-8')
     path_c = path_b

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -250,6 +250,12 @@ def read_arrow(
     """
     from pyarrow import Table
 
+    if skip_features < 0:
+        raise ValueError("'skip_features' must be >= 0")
+
+    if max_features is not None and max_features < 0:
+        raise ValueError("'max_features' must be >= 0")
+
     # limit batch size to max_features if set
     if "batch_size" in kwargs:
         batch_size = kwargs.pop("batch_size")

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -39,12 +39,22 @@ def test_read_arrow_skip_features(naturalearth_lowres, skip_features, expected):
     assert len(table) == expected
 
 
+def test_read_arrow_negative_skip_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'skip_features' must be >= 0"):
+        read_arrow(naturalearth_lowres, skip_features=-1)
+
+
 @pytest.mark.parametrize(
     "max_features, expected", [(0, 0), (10, 10), (200, 177), (100000, 177)]
 )
 def test_read_arrow_max_features(naturalearth_lowres, max_features, expected):
     table = read_arrow(naturalearth_lowres, max_features=max_features)[1]
     assert len(table) == expected
+
+
+def test_read_arrow_negative_max_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'max_features' must be >= 0"):
+        read_arrow(naturalearth_lowres, max_features=-1)
 
 
 @pytest.mark.parametrize(

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -191,12 +191,22 @@ def test_read_bounds_max_features(naturalearth_lowres):
     assert bounds.shape == (4, 2)
 
 
+def test_read_bounds_negative_max_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'max_features' must be >= 0"):
+        read_bounds(naturalearth_lowres, max_features=-1)
+
+
 def test_read_bounds_skip_features(naturalearth_lowres):
     expected_bounds = read_bounds(naturalearth_lowres, max_features=11)[1][:, 10]
     fids, bounds = read_bounds(naturalearth_lowres, skip_features=10)
     assert bounds.shape == (4, 167)
     assert allclose(bounds[:, 0], expected_bounds)
     assert fids[0] == 10
+
+
+def test_read_bounds_negative_skip_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'skip_features' must be >= 0"):
+        read_bounds(naturalearth_lowres, skip_features=-1)
 
 
 def test_read_bounds_where_invalid(naturalearth_lowres_all_ext):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -490,7 +490,7 @@ def test_read_max_features(naturalearth_lowres_all_ext, use_arrow, max_features)
     )
 
 
-def testt_read_negative_max_features(naturalearth_lowres, use_arrow):
+def test_read_negative_max_features(naturalearth_lowres, use_arrow):
     with pytest.raises(ValueError, match="'max_features' must be >= 0"):
         read_dataframe(naturalearth_lowres, max_features=-1, use_arrow=use_arrow)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -429,15 +429,70 @@ def test_read_fids_force_2d(test_fgdb_vsi):
         assert not df.iloc[0].geometry.has_z
 
 
-@pytest.mark.parametrize("skip_features, expected", [(10, 167), (200, 0)])
-def test_read_skip_features(
-    naturalearth_lowres_all_ext, use_arrow, skip_features, expected
-):
+@pytest.mark.parametrize("skip_features", [10, 200])
+def test_read_skip_features(naturalearth_lowres_all_ext, use_arrow, skip_features):
+    ext = naturalearth_lowres_all_ext.suffix
+    expected = (
+        read_dataframe(naturalearth_lowres_all_ext)
+        .iloc[skip_features:]
+        .reset_index(drop=True)
+    )
+
     df = read_dataframe(
         naturalearth_lowres_all_ext, skip_features=skip_features, use_arrow=use_arrow
     )
-    assert len(df) == expected
-    assert isinstance(df, gp.GeoDataFrame)
+    assert len(df) == len(expected)
+
+    # Coordinates are not precisely equal when written to JSON
+    # dtypes do not necessarily round-trip precisely through JSON
+    is_json = ext in [".geojson", ".geojsonl"]
+    # In .geojsonl the vertices are reordered, so normalize
+    is_jsons = ext == ".geojsonl"
+
+    assert_geodataframe_equal(
+        df,
+        expected,
+        check_less_precise=is_json,
+        check_index_type=False,
+        check_dtype=not is_json,
+        normalize=is_jsons,
+    )
+
+
+def test_read_negative_skip_features(naturalearth_lowres, use_arrow):
+    with pytest.raises(ValueError, match="'skip_features' must be >= 0"):
+        read_dataframe(naturalearth_lowres, skip_features=-1, use_arrow=use_arrow)
+
+
+@pytest.mark.parametrize("max_features", [10, 100])
+def test_read_max_features(naturalearth_lowres_all_ext, use_arrow, max_features):
+    ext = naturalearth_lowres_all_ext.suffix
+    expected = read_dataframe(naturalearth_lowres_all_ext).iloc[:max_features]
+    df = read_dataframe(
+        naturalearth_lowres_all_ext, max_features=max_features, use_arrow=use_arrow
+    )
+
+    assert len(df) == len(expected)
+
+    # Coordinates are not precisely equal when written to JSON
+    # dtypes do not necessarily round-trip precisely through JSON
+    is_json = ext in [".geojson", ".geojsonl"]
+    # In .geojsonl the vertices are reordered, so normalize
+    is_jsons = ext == ".geojsonl"
+
+    assert_geodataframe_equal(
+        df,
+        expected,
+        check_less_precise=is_json,
+        check_index_type=False,
+        check_dtype=not is_json,
+        normalize=is_jsons,
+    )
+
+
+def testt_read_negative_max_features(naturalearth_lowres, use_arrow):
+    with pytest.raises(ValueError, match="'max_features' must be >= 0"):
+        read_dataframe(naturalearth_lowres, max_features=-1, use_arrow=use_arrow)
 
 
 def test_read_non_existent_file(use_arrow):

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -152,6 +152,11 @@ def test_read_skip_features(naturalearth_lowres_all_ext, skip_features):
     assert np.array_equal(fields[-1], expected_fields[-1][skip_features:])
 
 
+def test_read_negative_skip_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'skip_features' must be >= 0"):
+        read(naturalearth_lowres, skip_features=-1)
+
+
 def test_read_max_features(naturalearth_lowres):
     expected_geometry, expected_fields = read(naturalearth_lowres)[2:]
     geometry, fields = read(naturalearth_lowres, max_features=2)[2:]
@@ -161,6 +166,11 @@ def test_read_max_features(naturalearth_lowres):
 
     assert np.array_equal(geometry, expected_geometry[:2])
     assert np.array_equal(fields[-1], expected_fields[-1][:2])
+
+
+def test_read_negative_max_features(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'max_features' must be >= 0"):
+        read(naturalearth_lowres, max_features=-1)
 
 
 def test_read_where(naturalearth_lowres):


### PR DESCRIPTION
This sidesteps making a decision around implementing support for negative `skip_features` in #309 for now and simply disallows that, which would have been equivalent to the behavior prior to #282.  We can add support for negative slicing at a different time, if we so choose.

This raises a specific `ValueError` and expands tests to match.  I also added checks for negative `max_features` and associated tests.