### PR TITLE
DOC: mention option of prefixing a path with the driver in ogr_open exception 

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -161,6 +161,11 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         raise DataSourceError("Failed to open dataset (mode={}): {}".format(mode, path_c.decode("utf-8"))) from None
 
     except CPLE_BaseError as exc:
+        if str(exc).endswith("not recognized as a supported file format."):
+            raise DataSourceError(
+                f"{str(exc)} It might help to specify the correct driver explicitly by "
+                "prefixing the file path with `<DRIVER>:`"
+            )
         raise DataSourceError(str(exc))
 
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -164,7 +164,7 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         if str(exc).endswith("not recognized as a supported file format."):
             raise DataSourceError(
                 f"{str(exc)} It might help to specify the correct driver explicitly by "
-                "prefixing the file path with `<DRIVER>:`"
+                "prefixing the file path with '<DRIVER>:', e.g. 'GPKG:path'."
             )
         raise DataSourceError(str(exc))
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -166,7 +166,7 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         if str(exc).endswith("not recognized as a supported file format."):
             raise DataSourceError(
                 f"{str(exc)} It might help to specify the correct driver explicitly by "
-                "prefixing the file path with '<DRIVER>:', e.g. 'GPKG:path'."
+                "prefixing the file path with '<DRIVER>:', e.g. 'CSV:path'."
             ) from None
         raise DataSourceError(str(exc)) from None
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -158,15 +158,17 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         return ogr_dataset
 
     except NullPointerError:
-        raise DataSourceError("Failed to open dataset (mode={}): {}".format(mode, path_c.decode("utf-8"))) from None
+        raise DataSourceError(
+            "Failed to open dataset (mode={}): {}".format(mode, path_c.decode("utf-8"))
+        ) from None
 
     except CPLE_BaseError as exc:
         if str(exc).endswith("not recognized as a supported file format."):
             raise DataSourceError(
                 f"{str(exc)} It might help to specify the correct driver explicitly by "
                 "prefixing the file path with '<DRIVER>:', e.g. 'GPKG:path'."
-            )
-        raise DataSourceError(str(exc))
+            ) from None
+        raise DataSourceError(str(exc)) from None
 
 
 cdef OGRLayerH get_ogr_layer(GDALDatasetH ogr_dataset, layer) except NULL:

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -80,16 +80,18 @@ def detect_write_driver(path):
     if len(drivers) == 0:
         raise ValueError(
             f"Could not infer driver from path: {path}; please specify driver "
-            "explicitly, e.g. by prefixing the file path with `<DRIVER>:`"
+            "explicitly, e.g. by prefixing the file path with '<DRIVER>:', "
+            "e.g. 'GPKG:path'."
         )
 
     # if there are multiple drivers detected, user needs to specify the correct
     # one manually
     elif len(drivers) > 1:
         raise ValueError(
-            f"Could not infer driver from path: {path}; multiple drivers are "
-            f"available for that extension: {', '.join(drivers)}.  Please specify "
-            "driver explicitly, e.g. by prefixing the file path with `<DRIVER>:`"
+            f"Could not infer driver from path: {path}; multiple drivers are available "
+            f"for that extension: {', '.join(drivers)}. Please specify driver "
+            "explicitly, e.g. by prefixing the file path with '<DRIVER>:', "
+            "e.g. 'GPKG:path'."
         )
 
     return drivers[0]

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -80,7 +80,7 @@ def detect_write_driver(path):
     if len(drivers) == 0:
         raise ValueError(
             f"Could not infer driver from path: {path}; please specify driver "
-            "explicitly"
+            "explicitly, e.g. by prefixing the file path with `<DRIVER>:`"
         )
 
     # if there are multiple drivers detected, user needs to specify the correct
@@ -88,8 +88,8 @@ def detect_write_driver(path):
     elif len(drivers) > 1:
         raise ValueError(
             f"Could not infer driver from path: {path}; multiple drivers are "
-            f"available for that extension: {', '.join(drivers)}.  Please "
-            "specify driver explicitly."
+            f"available for that extension: {', '.join(drivers)}.  Please specify "
+            "driver explicitly, e.g. by prefixing the file path with `<DRIVER>:`"
         )
 
     return drivers[0]

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -80,18 +80,16 @@ def detect_write_driver(path):
     if len(drivers) == 0:
         raise ValueError(
             f"Could not infer driver from path: {path}; please specify driver "
-            "explicitly, e.g. by prefixing the file path with '<DRIVER>:', "
-            "e.g. 'GPKG:path'."
+            "explicitly"
         )
 
     # if there are multiple drivers detected, user needs to specify the correct
     # one manually
     elif len(drivers) > 1:
         raise ValueError(
-            f"Could not infer driver from path: {path}; multiple drivers are available "
-            f"for that extension: {', '.join(drivers)}. Please specify driver "
-            "explicitly, e.g. by prefixing the file path with '<DRIVER>:', "
-            "e.g. 'GPKG:path'."
+            f"Could not infer driver from path: {path}; multiple drivers are "
+            f"available for that extension: {', '.join(drivers)}.  Please "
+            "specify driver explicitly."
         )
 
     return drivers[0]

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -906,6 +906,25 @@ def test_read_datetime_millisecond(test_datetime):
     assert field[1] == np.datetime64("2020-01-01 10:00:00.000")
 
 
+@pytest.mark.parametrize("prefix_driver", [True, False])
+def test_read_unsupported_ext(tmp_path, prefix_driver):
+    test_unsupported_path = tmp_path / "test.unsupported"
+    with open(test_unsupported_path, "w") as file:
+        file.write("column1,column2\n")
+        file.write("data1,data2")
+
+    if prefix_driver:
+        _, _, _, field_data = read(f"CSV:{test_unsupported_path}")
+        assert len(field_data) == 2
+        assert field_data[0] == "data1"
+
+    else:
+        with pytest.raises(
+            DataSourceError, match=".* by prefixing the file path with '<DRIVER>:'.*"
+        ):
+            read(test_unsupported_path)
+
+
 @pytest.mark.parametrize("ext", ["gpkg", "geojson"])
 def test_read_write_null_geometry(tmp_path, ext):
     # Point(0, 0), null

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -906,23 +906,27 @@ def test_read_datetime_millisecond(test_datetime):
     assert field[1] == np.datetime64("2020-01-01 10:00:00.000")
 
 
-@pytest.mark.parametrize("prefix_driver", [True, False])
-def test_read_unsupported_ext(tmp_path, prefix_driver):
+def test_read_unsupported_ext(tmp_path):
     test_unsupported_path = tmp_path / "test.unsupported"
     with open(test_unsupported_path, "w") as file:
         file.write("column1,column2\n")
         file.write("data1,data2")
 
-    if prefix_driver:
-        _, _, _, field_data = read(f"CSV:{test_unsupported_path}")
-        assert len(field_data) == 2
-        assert field_data[0] == "data1"
+    with pytest.raises(
+        DataSourceError, match=".* by prefixing the file path with '<DRIVER>:'.*"
+    ):
+        read(test_unsupported_path)
 
-    else:
-        with pytest.raises(
-            DataSourceError, match=".* by prefixing the file path with '<DRIVER>:'.*"
-        ):
-            read(test_unsupported_path)
+
+def test_read_unsupported_ext_with_prefix(tmp_path):
+    test_unsupported_path = tmp_path / "test.unsupported"
+    with open(test_unsupported_path, "w") as file:
+        file.write("column1,column2\n")
+        file.write("data1,data2")
+
+    _, _, _, field_data = read(f"CSV:{test_unsupported_path}")
+    assert len(field_data) == 2
+    assert field_data[0] == "data1"
 
 
 @pytest.mark.parametrize("ext", ["gpkg", "geojson"])


### PR DESCRIPTION
As most drivers seem to support this, it might be practical to suggest this option when a file cannot be opened?

For writing, the driver detection doesn't support this at the moment, and gdal doesn't seem to support this either for writing... so where it is probably easier to just keep using the `driver` parameter.

reference #310