### PR TITLE
Avoid usage of packaging in non-test code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.1 (2023-10-26)
+
+- Fix unspecified dependency on ``packaging`` (#318).
+
 ## 0.7.0 (2023-10-25)
 
 ### Improvements

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -1,4 +1,3 @@
-from packaging.version import Version
 import re
 import sys
 from urllib.parse import urlparse
@@ -188,7 +187,7 @@ def _mask_to_wkb(mask):
     try:
         import shapely
 
-        if Version(shapely.__version__) < Version("2.0.0"):
+        if int(shapely.__version__.split(".")[0]) < 2:
             shapely = None
     except ImportError:
         shapely = None


### PR DESCRIPTION
See https://github.com/geopandas/pyogrio/issues/316#issuecomment-1780574589, this avoids adding it as an actual dependency.