### PR TITLE
Add packaging as an install dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
--   Add `packaging` as a dependency.
+-   Add `packaging` as a dependency (#320).
 
 ## 0.7.1 (2023-10-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.7.2 (2023-10-27)
+
+### Bug fixes
+
+-   Add `packaging` as a dependency.
+
 ## 0.7.1 (2023-10-26)
 
 ### Bug fixes

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -2,6 +2,8 @@ import re
 import sys
 from urllib.parse import urlparse
 
+from packaging.version import Version
+
 from pyogrio._env import GDALEnv
 
 with GDALEnv():
@@ -187,7 +189,7 @@ def _mask_to_wkb(mask):
     try:
         import shapely
 
-        if int(shapely.__version__.split(".")[0]) < 2:
+        if Version(shapely.__version__) < Version("2.0.0"):
             shapely = None
     except ImportError:
         shapely = None

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ setup(
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
     python_requires=">=3.8",
-    install_requires=["certifi", "numpy"],
+    install_requires=["certifi", "numpy", "packaging"],
     extras_require={
         "dev": ["Cython"],
         "test": ["pytest", "pytest-cov"],


### PR DESCRIPTION
Reverses #318

Tested binary wheel in a brand new virtual environment, and it installed `packaging` and appeared to work correctly.