### PR TITLE
CI: add gdal 3.8.1 tests + update gdal 3.7.2 to 3.7.3

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -21,7 +21,8 @@ jobs:
       matrix:
         container:
           - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.10.6
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.2" # python 3.10.12
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.8.1" # python 3.10.12
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.3" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6
           - "osgeo/gdal:ubuntu-small-3.5.3" # python 3.8.10
           - "osgeo/gdal:ubuntu-small-3.4.3" # python 3.8.10

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ substantial change. Please see [CHANGES](CHANGES.md).
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.7.x.
+Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.8.x.
 
 Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.7.x
+Supports Python 3.8 - 3.11 and GDAL 3.4.x - 3.8.x
 
 Reading to GeoDataFrames requires `geopandas>=0.12` with `shapely>=2`.
 


### PR DESCRIPTION
- Update to GDAL 3.7.3 as I'd like to be able to test a backport to this version in GDAL regarding sql statements + arrow
- Add GDAL 3.8.1 container to have latest released version of GDAL tested