### PR TITLE
CI: use setup-micromamba action

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           # environment with lower versions of optional dependencies
           - python: "3.10"
-            extra: |
+            extra: >-
               pandas=1.5
               geopandas=0.12
           # minimal environment without optional dependencies


### PR DESCRIPTION
`provision-with-micromamba` has been deprecated for some time. `setup-micromamba` is the new action to be used.