### PR TITLE
TST: update error message in tests for GDAL 3.9

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -163,7 +163,7 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         ) from None
 
     except CPLE_BaseError as exc:
-        if str(exc).endswith("not recognized as a supported file format."):
+        if str(exc).endswith("a supported file format."):
             raise DataSourceError(
                 f"{str(exc)} It might help to specify the correct driver explicitly by "
                 "prefixing the file path with '<DRIVER>:', e.g. 'CSV:path'."

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -889,7 +889,7 @@ def test_write_read_empty_dataframe_unsupported(tmp_path, ext):
 
     assert filename.exists()
     with pytest.raises(
-        Exception, match=".* not recognized as a supported file format."
+        Exception, match=".* not recognized as( being in)? a supported file format."
     ):
         _ = read_dataframe(filename)
 


### PR DESCRIPTION
Addressing test failures with GDAL main caused by https://github.com/OSGeo/gdal/pull/9114. 

(to be honest, being a non-native speaker, but "_as being_ in a file format" sounds very strange to my ears)