### PR TITLE
DOC: Correct key name in pyogrio.read_info() docstring 

### DIFF
--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -244,7 +244,7 @@ def read_info(
                 "fields": <ndarray of field names>,
                 "dtypes": <ndarray of field dtypes>,
                 "encoding": "<encoding>",
-                "geometry": "<geometry type>",
+                "geometry_type": "<geometry type>",
                 "features": <feature count or -1>,
                 "total_bounds": <tuple with total bounds or None>,
                 "driver": "<driver>",


### PR DESCRIPTION
Corrected key "geometry" to "geometry_type" in docstring for pyogrio.io.read_info() method. #357 