### PR TITLE
BUG: fix encoding issues on windows for some formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 ### Improvements
 
-- `read_arrow` and `open_arrow` now provide [GeoArrow-compliant extension metadata](https://geoarrow.org/extension-types.html), including the CRS, when using GDAL 3.8 or higher.
+-   `read_arrow` and `open_arrow` now provide 
+    [GeoArrow-compliant extension metadata](https://geoarrow.org/extension-types.html),
+    including the CRS, when using GDAL 3.8 or higher (#366).
 
 ### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
 
 -   Fix error in `write_dataframe` if input has a date column and
     non-consecutive index values (#325).
--   Fix encoding issues on windows for some formats (e.g. ".csv") (#361).
+-   Fix encoding issues on windows for some formats (e.g. ".csv") and always write ESRI
+    Shapefiles using UTF-8 by default on all platforms (#361).
 -   Raise exception in `read_arrow` or `read_dataframe(..., use_arrow=True)` if
     a boolean column is detected due to error in GDAL reading boolean values (#335)
     this has been fixed in GDAL >= 3.8.3.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 -   Fix error in `write_dataframe` if input has a date column and
     non-consecutive index values (#325).
--   Fix encoding issues on windows for some formats, e.g. ".csv" (#361).
+-   Fix encoding issues on windows for some formats (e.g. ".csv") (#361).
 -   Raise exception in `read_arrow` or `read_dataframe(..., use_arrow=True)` if
     a boolean column is detected due to error in GDAL reading boolean values (#335)
     this has been fixed in GDAL >= 3.8.3.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 -   Fix error in `write_dataframe` if input has a date column and
     non-consecutive index values (#325).
+-   Fix encoding issues on windows for some formats, e.g. ".csv" (#361).
 -   Raise exception in `read_arrow` or `read_dataframe(..., use_arrow=True)` if
     a boolean column is detected due to error in GDAL reading boolean values (#335)
     this has been fixed in GDAL >= 3.8.3.

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -476,7 +476,7 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
     str or None
     """
 
-    if ogr_layer is not NULL and OGR_L_TestCapability(ogr_layer, OLCStringsAsUTF8):
+    if OGR_L_TestCapability(ogr_layer, OLCStringsAsUTF8):
         return 'UTF-8'
 
     driver = get_driver(ogr_dataset)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1953,12 +1953,7 @@ def ogr_write(
     # Now the dataset and layer have been created, we can properly determine the
     # encoding. It is derived from the user, from the dataset capabilities / type,
     # or from the system locale
-    encoding = (
-        encoding
-        or detect_encoding(ogr_dataset, ogr_layer)
-        or locale.getpreferredencoding()
-    )
-
+    
     ### Create the fields
     field_types = None
     if num_fields > 0:
@@ -2006,6 +2001,12 @@ def ogr_write(
 
     ### Create the features
     ogr_featuredef = OGR_L_GetLayerDefn(ogr_layer)
+
+    encoding = (
+        encoding
+        or detect_encoding(ogr_dataset, ogr_layer)
+        or locale.getpreferredencoding()
+    )
 
     supports_transactions = OGR_L_TestCapability(ogr_layer, OLCTransactions)
     if supports_transactions:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -504,6 +504,9 @@ cdef get_encoding_for_driver(str driver):
         # per https://help.openstreetmap.org/questions/2172/what-encoding-does-openstreetmap-use
         return "UTF-8"
 
+    if driver == "XLSX":
+        return "UTF-8"
+
     return None
 
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2002,15 +2002,15 @@ def ogr_write(
     ### Create the features
     ogr_featuredef = OGR_L_GetLayerDefn(ogr_layer)
 
+    supports_transactions = OGR_L_TestCapability(ogr_layer, OLCTransactions)
+    if supports_transactions:
+        start_transaction(ogr_dataset, 0)
+
     encoding = (
         encoding
         or detect_encoding(ogr_dataset, ogr_layer)
         or locale.getpreferredencoding()
     )
-
-    supports_transactions = OGR_L_TestCapability(ogr_layer, OLCTransactions)
-    if supports_transactions:
-        start_transaction(ogr_dataset, 0)
 
     for i in range(num_records):
         try:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -463,8 +463,9 @@ cdef get_metadata(GDALMajorObjectH obj):
 
 cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
     """Attempt to detect the encoding of the dataset or layer.
-    If it supports UTF-8, use that.
-    If it is a shapefile, it must otherwise be ISO-8859-1.
+    If the dataset supports/is in UTF-8, returns UTF-8.
+    If it is a non-UTF-8 shapefile, returns ISO-8859-1.
+    Otherwise the system locale preferred encoding is returned.
 
     Parameters
     ----------
@@ -480,7 +481,7 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
         return 'UTF-8'
 
     driver = get_driver(ogr_dataset)
-    return get_encoding_for_driver(driver)
+    return get_encoding_for_driver(driver) or locale.getpreferredencoding()
 
 
 cdef get_encoding_for_driver(str driver):
@@ -1161,11 +1162,7 @@ def ogr_read(
 
         # Encoding is derived from the user, from the dataset capabilities / type,
         # or from the system locale
-        encoding = (
-            encoding
-            or detect_encoding(ogr_dataset, ogr_layer)
-            or locale.getpreferredencoding()
-        )
+        encoding = encoding or detect_encoding(ogr_dataset, ogr_layer)
 
         fields = get_fields(ogr_layer, encoding)
 
@@ -1352,11 +1349,7 @@ def ogr_open_arrow(
 
         # Encoding is derived from the user, from the dataset capabilities / type,
         # or from the system locale
-        encoding = (
-            encoding
-            or detect_encoding(ogr_dataset, ogr_layer)
-            or locale.getpreferredencoding()
-        )
+        encoding = encoding or detect_encoding(ogr_dataset, ogr_layer)
 
         fields = get_fields(ogr_layer, encoding, use_arrow=True)
 
@@ -1548,11 +1541,7 @@ def ogr_read_info(
 
         # Encoding is derived from the user, from the dataset capabilities / type,
         # or from the system locale
-        encoding = (
-            encoding
-            or detect_encoding(ogr_dataset, ogr_layer)
-            or locale.getpreferredencoding()
-        )
+        encoding = encoding or detect_encoding(ogr_dataset, ogr_layer)
 
         fields = get_fields(ogr_layer, encoding)
 
@@ -1958,11 +1947,7 @@ def ogr_write(
     # Now the dataset and layer have been created, we can properly determine the
     # encoding. It is derived from the user, from the dataset capabilities / type,
     # or from the system locale
-    encoding = (
-        encoding
-        or detect_encoding(ogr_dataset, ogr_layer)
-        or locale.getpreferredencoding()
-    )
+    encoding = encoding or detect_encoding(ogr_dataset, ogr_layer)
 
     ### Create the fields
     field_types = None

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -505,6 +505,11 @@ cdef get_encoding_for_driver(str driver):
         return "UTF-8"
 
     if driver == "XLSX":
+        # OLCStringsAsUTF8 isn't advertised (yet).
+        return "UTF-8"
+
+    if driver == "GeoJSONSeq":
+        # In old gdal versions, OLCStringsAsUTF8 wasn't advertised yet.
         return "UTF-8"
 
     return None

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1906,8 +1906,13 @@ def ogr_write(
         gdal_tz_offsets = {}
 
     ### Setup up dataset and layer
-    if not encoding:
-        encoding = locale.getpreferredencoding()
+    # Encoding is derived from the user, from the dataset capabilities / type,
+    # or from the system locale
+    encoding = (
+        encoding
+        or detect_encoding(ogr_dataset, ogr_layer)
+        or locale.getpreferredencoding()
+    )
 
     layer_created = create_ogr_dataset_layer(
         path, layer, driver, crs, geometry_type, encoding,
@@ -2032,7 +2037,7 @@ def ogr_write(
                             field_value = str(field_value)
 
                         try:
-                            value_b = field_value.encode("UTF-8")
+                            value_b = field_value.encode(encoding)
                             OGR_F_SetFieldString(ogr_feature, field_idx, value_b)
 
                         except AttributeError:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -478,16 +478,22 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
     str or None
     """
 
-    # Layers/drivers for which string attribute values should be supplied in UTF-8 and
-    # will always be returned in UTF-8, regardless of the encoding used to write the
-    # files, return True. Layers/drivers for which the data will be written and read
-    # as-such without recoding to and from UTF-8 is needed return False.
     if OGR_L_TestCapability(ogr_layer, OLCStringsAsUTF8):
-        return 'UTF-8'
+        # OGR_L_TestCapability returns True for OLCStringsAsUTF8 if GDAL hides encoding
+        # complexities for this layer/driver type. In this case all string attribute
+        # values have to be supplied in UTF-8 and values will be returned in UTF-8.
+        # The encoding used to read/write under the hood depends on the driver used.
+        # For layers/drivers where False is returned, the string values are written and
+        # read without recoding. Hence, it is up to you to supply the data in the
+        # appropriate encoding.
+        return "UTF-8"
 
     driver = get_driver(ogr_dataset)
-    if driver == 'ESRI Shapefile':
-        return 'ISO-8859-1'
+    if driver == "ESRI Shapefile":
+        # Typically, OGR_L_TestCapability returns True for OLCStringsAsUTF8 for ESRI
+        # Shapefile so this won't be reached. However, for old versions of GDAL and/or
+        # if libraries are missing, this fallback could be needed.
+        return "ISO-8859-1"
 
     if driver == "OSM":
         # always set OSM data to UTF-8

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -469,7 +469,7 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
     Parameters
     ----------
     ogr_dataset : pointer to open OGR dataset
-    ogr_layer : NULL or pointer to open OGR layer
+    ogr_layer : pointer to open OGR layer
 
     Returns
     -------
@@ -2040,7 +2040,6 @@ def ogr_write(
                     OGR_F_SetFieldNull(ogr_feature, field_idx)
 
                 elif field_type == OFTString:
-                    # TODO: encode string using approach from _get_internal_encoding which checks layer capabilities
                     if (
                         field_value is None
                         or (isinstance(field_value, float) and isnan(field_value))
@@ -2052,7 +2051,7 @@ def ogr_write(
                             field_value = str(field_value)
 
                         try:
-                            value_b = field_value.encode("UTF-8")
+                            value_b = field_value.encode(encoding)
                             OGR_F_SetFieldString(ogr_feature, field_idx, value_b)
 
                         except AttributeError:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1959,7 +1959,7 @@ def ogr_write(
         for i in range(num_fields):
             field_type, field_subtype, width, precision = field_types[i]
 
-            name_b = fields[i].encode(encoding)
+            name_b = fields[i].encode("UTF-8")
             try:
                 ogr_fielddef = exc_wrap_pointer(OGR_Fld_Create(name_b, field_type))
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -504,9 +504,11 @@ cdef get_encoding_for_driver(str driver):
         # per https://help.openstreetmap.org/questions/2172/what-encoding-does-openstreetmap-use
         return "UTF-8"
 
+    """
     if driver == "XLSX":
         # OLCStringsAsUTF8 isn't advertised (yet).
         return "UTF-8"
+    """
 
     if driver == "GeoJSONSeq":
         # In old gdal versions, OLCStringsAsUTF8 wasn't advertised yet.

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1738,7 +1738,7 @@ cdef create_ogr_dataset_layer(
     ----------
     encoding : str
         Only used if `driver` is "ESRI Shapefile". If not None, it overrules the default
-        shapefile encoding.
+        shapefile encoding, which is "UTF-8" in pyogrio.
 
     Returns
     -------
@@ -1832,7 +1832,7 @@ cdef create_ogr_dataset_layer(
             # Fiona only sets encoding for shapefiles; other drivers do not support
             # encoding as an option.
             if encoding is None:
-                encoding = get_encoding_for_driver(driver)
+                encoding = "UTF-8"
             encoding_b = encoding.upper().encode('UTF-8')
             encoding_c = encoding_b
             layer_options = CSLSetNameValue(layer_options, "ENCODING", encoding_c)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -485,7 +485,8 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
         # The encoding used to read/write under the hood depends on the driver used.
         # For layers/drivers where False is returned, the string values are written and
         # read without recoding. Hence, it is up to you to supply the data in the
-        # appropriate encoding.
+        # appropriate encoding. More info:
+        # https://gdal.org/development/rfc/rfc23_ogr_unicode.html#oftstring-oftstringlist-fields
         return "UTF-8"
 
     driver = get_driver(ogr_dataset)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -476,10 +476,12 @@ cdef detect_encoding(OGRDataSourceH ogr_dataset, OGRLayerH ogr_layer):
     str or None
     """
 
+    driver = get_driver(ogr_dataset)
     if OGR_L_TestCapability(ogr_layer, OLCStringsAsUTF8):
+        warnings.warn(f"layer of driver {driver} has OLCStringsAsUTF8 capability")
         return 'UTF-8'
 
-    driver = get_driver(ogr_dataset)
+    warnings.warn(f"layer of driver {driver} has NO OLCStringsAsUTF8 capability")
     return get_encoding_for_driver(driver)
 
 
@@ -1947,6 +1949,7 @@ def ogr_write(
         &ogr_dataset, &ogr_layer,
     )
 
+    warnings.warn(f"in ogr_write: {locale.getpreferredencoding()=}")
     # Now the dataset and layer have been created, we can properly determine the
     # encoding. It is derived from the user, from the dataset capabilities / type,
     # or from the system locale

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -62,6 +62,25 @@ def spatialite_available(path):
         return False
 
 
+def test_read_csv(tmp_path):
+    # Write csv test file. Depending on the os this will be written in a different
+    # encoding: for linux and macos this is utf-8, for windows it is cp1252.
+    csv_path = tmp_path / "test.csv"
+    with open(csv_path, "w") as csv:
+        csv.write("name,city\n")
+        csv.write("Wilhelm Röntgen,Zürich")
+
+    # Read csv. The data should be read with the same default encoding as the csv file
+    # was written in, but should have been converted to utf-8 in the dataframe returned.
+    # Hence, the asserts below, with strings in utf-8, be OK.
+    df = read_dataframe(csv_path)
+
+    assert len(df) == 1
+    assert df.columns.tolist() == ["name", "city"]
+    assert df.city.tolist() == ["Zürich"]
+    assert df.name.tolist() == ["Wilhelm Röntgen"]
+
+
 def test_read_dataframe(naturalearth_lowres_all_ext):
     df = read_dataframe(naturalearth_lowres_all_ext)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -78,7 +78,7 @@ def test_read_csv_encoding(tmp_path):
     assert len(df) == 1
     assert df.columns.tolist() == ["näme", "city"]
     assert df.city.tolist() == ["Zürich"]
-    assert df.name.tolist() == ["Wilhelm Röntgen"]
+    assert df.näme.tolist() == ["Wilhelm Röntgen"]
 
 
 def test_read_dataframe(naturalearth_lowres_all_ext):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,6 +1,5 @@
 import contextlib
 from datetime import datetime
-import filecmp
 import os
 import numpy as np
 import pytest
@@ -819,7 +818,11 @@ def test_write_csv_encoding(tmp_path):
 
     # If the files written are binary identical, they were written using the same
     # encoding.
-    assert filecmp.cmp(csv_path, csv_pyogrio_path, shallow=False)
+    with open(csv_path, "r") as csv:
+        csv_str = csv.read()
+    with open(csv_pyogrio_path, "r") as csv_pyogrio:
+        csv_pyogrio_str = csv_pyogrio.read()
+    assert csv_str == csv_pyogrio_str
 
 
 @pytest.mark.parametrize("ext", ALL_EXTS)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,6 +1,8 @@
 import contextlib
 from datetime import datetime
+import locale
 import os
+import warnings
 import numpy as np
 import pytest
 
@@ -805,7 +807,8 @@ def test_write_csv_encoding(tmp_path):
     """Test if write_dataframe uses the default encoding correctly."""
     # Write csv test file. Depending on the os this will be written in a different
     # encoding: for linux and macos this is utf-8, for windows it is cp1252.
-    csv_path = tmp_path / "test.csv"
+    csv_path = tmp_path / "testg.csv"
+
     with open(csv_path, "w") as csv:
         csv.write("name,city\n")
         csv.write("Wilhelm Röntgen,Zürich\n")
@@ -875,6 +878,11 @@ def test_write_dataframe_no_geom(tmp_path, naturalearth_lowres, ext):
     # A shapefile without geometry column results in only a .dbf file.
     if ext == ".shp":
         output_path = output_path.with_suffix(".dbf")
+    elif ext == ".xlsx":
+        warnings.warn(
+            f"in test_write_dataframe_no_geom, with {ext=}, "
+            f"locale: {locale.getpreferredencoding()=}"
+        )
 
     # Determine driver
     driver = DRIVERS[ext] if ext != ".xlsx" else "XLSX"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,8 +1,6 @@
 import contextlib
 from datetime import datetime
-import locale
 import os
-import warnings
 import numpy as np
 import pytest
 
@@ -878,11 +876,6 @@ def test_write_dataframe_no_geom(tmp_path, naturalearth_lowres, ext):
     # A shapefile without geometry column results in only a .dbf file.
     if ext == ".shp":
         output_path = output_path.with_suffix(".dbf")
-    elif ext == ".xlsx":
-        warnings.warn(
-            f"in test_write_dataframe_no_geom, with {ext=}, "
-            f"locale: {locale.getpreferredencoding()=}"
-        )
 
     # Determine driver
     driver = DRIVERS[ext] if ext != ".xlsx" else "XLSX"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -67,7 +67,7 @@ def test_read_csv_encoding(tmp_path):
     # encoding: for linux and macos this is utf-8, for windows it is cp1252.
     csv_path = tmp_path / "test.csv"
     with open(csv_path, "w") as csv:
-        csv.write("name,city\n")
+        csv.write("näme,city\n")
         csv.write("Wilhelm Röntgen,Zürich\n")
 
     # Read csv. The data should be read with the same default encoding as the csv file
@@ -76,7 +76,7 @@ def test_read_csv_encoding(tmp_path):
     df = read_dataframe(csv_path)
 
     assert len(df) == 1
-    assert df.columns.tolist() == ["name", "city"]
+    assert df.columns.tolist() == ["näme", "city"]
     assert df.city.tolist() == ["Zürich"]
     assert df.name.tolist() == ["Wilhelm Röntgen"]
 
@@ -808,12 +808,12 @@ def test_write_csv_encoding(tmp_path):
     csv_path = tmp_path / "testg.csv"
 
     with open(csv_path, "w") as csv:
-        csv.write("name,city\n")
+        csv.write("näme,city\n")
         csv.write("Wilhelm Röntgen,Zürich\n")
 
     # Write csv test file with the same data using write_dataframe. It should use the
     # same encoding as above.
-    df = pd.DataFrame({"name": ["Wilhelm Röntgen"], "city": ["Zürich"]})
+    df = pd.DataFrame({"näme": ["Wilhelm Röntgen"], "city": ["Zürich"]})
     csv_pyogrio_path = tmp_path / "test_pyogrio.csv"
     write_dataframe(df, csv_pyogrio_path)
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -414,18 +414,23 @@ def test_read_return_only_fids(naturalearth_lowres):
     assert len(field_data) == 0
 
 
-def test_write_shp(tmpdir, naturalearth_lowres):
+@pytest.mark.parametrize("encoding", [None, "ISO-8859-1"])
+def test_write_shp(tmpdir, naturalearth_lowres, encoding):
     meta, _, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.shp")
+    meta["encoding"] = encoding
     write(filename, geometry, field_data, **meta)
 
     assert os.path.exists(filename)
     for ext in (".dbf", ".prj"):
         assert os.path.exists(filename.replace(".shp", ext))
 
-    # Make sure the file was written in UTF-8
-    assert read_info(filename)["encoding"] == "UTF-8"
+    # We write shapefiles in UTF-8 by default on all platforms
+    expected_encoding = encoding if encoding is not None else "UTF-8"
+    with open(filename.replace(".shp", ".cpg")) as cpg_file:
+        result_encoding = cpg_file.read()
+        assert result_encoding == expected_encoding
 
 
 def test_write_gpkg(tmpdir, naturalearth_lowres):

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -414,7 +414,7 @@ def test_read_return_only_fids(naturalearth_lowres):
     assert len(field_data) == 0
 
 
-def test_write(tmpdir, naturalearth_lowres):
+def test_write_shp(tmpdir, naturalearth_lowres):
     meta, _, geometry, field_data = read(naturalearth_lowres)
 
     filename = os.path.join(str(tmpdir), "test.shp")
@@ -423,6 +423,9 @@ def test_write(tmpdir, naturalearth_lowres):
     assert os.path.exists(filename)
     for ext in (".dbf", ".prj"):
         assert os.path.exists(filename.replace(".shp", ext))
+
+    # Make sure the file was written in UTF-8
+    assert read_info(filename)["encoding"] == "UTF-8"
 
 
 def test_write_gpkg(tmpdir, naturalearth_lowres):


### PR DESCRIPTION
I noticed in some [geofileops tests](https://github.com/geofileops/geofileops/actions/runs/8110958569/job/22169297289?pr=505) that using pyogrio to write/read dataframes to ".csv" files gives encoding issues.

This PR fixes those.

Odd detail: I only saw this behaviour on the github CI windows systems: locally I couldn't reproduce. Apparently:
- when running tests on my local windows `locale.getprefferedencoding()` returns "UTF-8", even though when I run `locale.getprefferedencoding()` in a seperate script it returns the typical one for windows: "cp1252".
- in the tests on the github windows machines, `locale.getprefferedencoding()` returns "cp1252".