### PR TITLE
Read with GeoArrow metadata for GDAL >= 3.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## 0.7.3 (???)
+## 0.8.0 (???)
+
+### Improvements
+
+- `read_arrow` and `open_arrow` now provide [GeoArrow-compliant extension metadata](https://geoarrow.org/extension-types.html), including the CRS, when using GDAL 3.8 or higher.
 
 ### Bug fixes
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -783,7 +783,7 @@ cdef process_fields(
             data[i] = bin_value[:ret_length]
 
         elif field_type == OFTDateTime or field_type == OFTDate:
-            
+
             if datetime_as_string:
                 # defer datetime parsing to user/ pandas layer
                 # Update to OGR_F_GetFieldAsISO8601DateTime when GDAL 3.7+ only
@@ -851,7 +851,7 @@ cdef get_features(
 
     field_data = [
         np.empty(shape=(num_features, ),
-        dtype = ("object" if datetime_as_string and 
+        dtype = ("object" if datetime_as_string and
                     fields[field_index,3].startswith("datetime") else fields[field_index,3])
         ) for field_index in range(n_fields)
     ]
@@ -950,8 +950,8 @@ cdef get_features_by_fid(
     field_ogr_types = fields[:,1]
     field_data = [
         np.empty(shape=(count, ),
-        dtype=("object" if datetime_as_string and fields[field_index,3].startswith("datetime") 
-            else fields[field_index,3])) 
+        dtype=("object" if datetime_as_string and fields[field_index,3].startswith("datetime")
+            else fields[field_index,3]))
         for field_index in range(n_fields)
     ]
 
@@ -1379,6 +1379,14 @@ def ogr_open_arrow(
                 options,
                 "MAX_FEATURES_IN_BATCH",
                 str(batch_size).encode('UTF-8')
+            )
+
+        # Default to geoarrow metadata encoding
+        IF CTE_GDAL_VERSION >= (3, 8, 0):
+            options = CSLSetNameValue(
+                options,
+                "GEOMETRY_METADATA_ENCODING",
+                "GEOARROW".encode('UTF-8')
             )
 
         # make sure layer is read from beginning

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import math
 import os
 
@@ -184,6 +185,19 @@ def test_open_arrow_max_features_unsupported(naturalearth_lowres, max_features):
             reader,
         ):
             pass
+
+
+@pytest.mark.skipif(
+    __gdal_version__ < (3, 8, 0),
+    reason="returns geoarrow metadata only for GDAL>=3.8.0",
+)
+def test_read_arrow_geoarrow_metadata(naturalearth_lowres):
+    _meta, table = read_arrow(naturalearth_lowres)
+    field = table.schema.field("wkb_geometry")
+    assert field.metadata[b"ARROW:extension:name"] == b"geoarrow.wkb"
+    parsed_meta = json.loads(field.metadata[b"ARROW:extension:metadata"])
+    assert parsed_meta["crs"]["id"]["authority"] == "EPSG"
+    assert parsed_meta["crs"]["id"]["code"] == 4326
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Resolves half of https://github.com/geopandas/pyogrio/issues/345. @jorisvandenbossche mentioned in https://github.com/geopandas/pyogrio/issues/345#issuecomment-1909638656 that he'd suggest making the change to geoarrow metadata. I'd also propose that we make this the default.

A test is added to verify that the metadata on the geometry field is set. The name should be `geoarrow.wkb` and the extension metadata should include a CRS field with PROJJSON, which I assert is EPSG:4326 for this test dataset.

@brendan-ward would you still prefer having a flag for the user to set this? Ref https://github.com/geopandas/pyogrio/issues/345#issuecomment-1908878875