### PR TITLE
BUG: undefined variable in timezone logic

### DIFF
--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -50,7 +50,7 @@ def _try_parse_datetime(ser):
         try:
             res = pd.to_datetime(ser, **datetime_kwargs)
         except Exception:
-            pass
+            res = ser
     # if object dtype, try parse as utc instead
     if res.dtype == "object":
         try:


### PR DESCRIPTION
I don't know how I missed this in #253, but there's a logical error if an exception is thrown in this block.

I'm not quite sure how to test this - I only noticed the error in my geopandas dev environment where I had pyogrio 0.7.2 with pandas dev - so I was getting the exception fixedby #348 (not part of 0.7.2), not a future error due to  mixed time zones - which is what this try except was originally for.