### PR TITLE
BLD: remove numpy as build depedency (only required run dependency)

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -19,7 +19,6 @@ from libc.math cimport isnan
 
 cimport cython
 import numpy as np
-cimport numpy as np
 
 from pyogrio._ogr cimport *
 from pyogrio._err cimport *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [build-system]
-# numpy and Cython are required to execute setup.py to build Cython extensions
 requires = [
     "setuptools",
     "wheel",
     "Cython>=0.29",
-    "oldest-supported-numpy",
     "versioneer[toml]==0.28",
     # tomli is used by versioneer
     "tomli; python_version < '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,13 @@ import versioneer
 # import Cython if available
 try:
     from Cython.Build import cythonize
-    from Cython.Distutils import build_ext as _build_ext
+    from Cython.Distutils import build_ext
 except ImportError:
     cythonize = None
 
 
 MIN_PYTHON_VERSION = (3, 8, 0)
 MIN_GDAL_VERSION = (2, 4, 0)
-
-build_ext = None
 
 
 if sys.version_info < MIN_PYTHON_VERSION:
@@ -171,20 +169,6 @@ else:
         compiler_directives={"language_level": "3"},
         compile_time_env=compile_time_env,
     )
-
-    # Get numpy include directory without importing numpy at top level here
-    # from: https://stackoverflow.com/a/42163080
-    class build_ext(_build_ext):
-        def run(self):
-            try:
-                import numpy
-
-                self.include_dirs.append(numpy.get_include())
-                # Call original build_ext command
-                _build_ext.run(self)
-
-            except ImportError:
-                pass
 
     if os.environ.get("PYOGRIO_PACKAGE_DATA"):
         gdal_data = os.environ.get("GDAL_DATA")


### PR DESCRIPTION
Currently, we do have _build_ dependency on numpy (listed in pyproject.toml's `build-system.requires`), but in practice I don't think we are actually using anything from numpy's C API, as far as I can see. 

Having numpy as a build dependency adds some complexity, especially with ABI compatibility of buildtime vs runtime version of numpy (in the past you needed to build with an older version, now with numpy 2.0 we need to build with the latest to ensure to be compatible with both numpy 1.x and 2.0). If we don't actually need numpy at compile time, removing that makes this a lot simpler and we don't have to worry about those issues.

