### PR TITLE
DO NOT MERGE: Refactor dataframe where tests, reduce IF conditional compilation blocks

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -66,4 +66,4 @@ jobs:
 
       - name: Test
         run: |
-          pytest -v --color=yes -r s pyogrio/tests
+          pytest -v -s --color=yes -r s pyogrio/tests/test_geopandas_io.py

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        # os: [ubuntu-latest, macos-latest, windows-2019]
+        os: ["macos-latest"]
         python: ["3.10", "3.11", "3.12"]
         env: ["latest"]
         include:
@@ -31,15 +32,15 @@ jobs:
             extra: >-
               pandas=1.5
               geopandas=0.12
-          # minimal environment without optional dependencies
-          - os: "ubuntu-latest"
-            python: "3.9"
-            env: "minimal"
-          # environment for older Windows libgdal to make sure gdal_i.lib is
-          # properly detected
-          - os: "windows-2019"
-            python: "3.10"
-            env: "libgdal3.5.1"
+          # # minimal environment without optional dependencies
+          # - os: "ubuntu-latest"
+          #   python: "3.9"
+          #   env: "minimal"
+          # # environment for older Windows libgdal to make sure gdal_i.lib is
+          # # properly detected
+          # - os: "windows-2019"
+          #   python: "3.10"
+          #   env: "libgdal3.5.1"
 
     steps:
       - name: Checkout repo
@@ -66,4 +67,4 @@ jobs:
 
       - name: Test
         run: |
-          pytest -v -s --color=yes -r s pyogrio/tests/test_geopandas_io.py
+          pytest -v -s --color=yes -r s pyogrio/tests/test_geopandas_io.py::test_read_where_range

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -62,7 +62,7 @@ jobs:
           echo "GDAL_VERSION=$(gdalinfo --version | cut -c 6-10)" >> $GITHUB_ENV
 
       - name: Install pyogrio
-        run: pip install -e .
+        run: pip install -e . -v
 
       - name: Test
         run: |

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1112,6 +1112,8 @@ def ogr_read(
     cdef int feature_count = 0
     cdef double xmin, ymin, xmax, ymax
 
+    print(f"ogr_open_arrow: {path}")
+
     path_b = path.encode('utf-8')
     path_c = path_b
 
@@ -1247,7 +1249,7 @@ def ogr_read(
             dataset_options = NULL
 
         if ogr_dataset != NULL:
-            if sql is not None:
+            if sql is not None and ogr_layer != NULL:
                 GDALDatasetReleaseResultSet(ogr_dataset, ogr_layer)
 
             GDALClose(ogr_dataset)
@@ -1455,7 +1457,7 @@ def ogr_open_arrow(
         yield meta, reader
 
     finally:
-        print("in ogr_open_arrow block")
+        print("in ogr_open_arrow finally block")
         if reader is not None:
             print("closing reader")
             # Mark reader as closed to prevent reading batches
@@ -1474,13 +1476,13 @@ def ogr_open_arrow(
             dataset_options = NULL
 
         if ogr_dataset != NULL:
-            if sql is not None:
+            if sql is not None and ogr_layer != NULL:
                 GDALDatasetReleaseResultSet(ogr_dataset, ogr_layer)
 
             GDALClose(ogr_dataset)
             ogr_dataset = NULL
 
-        print("done with ogr_open_arrow block")
+        print("done with ogr_open_arrow finally block")
 
 def ogr_read_bounds(
     str path,

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -196,6 +196,7 @@ cdef extern from "arrow_bridge.h":
 
     struct ArrowArrayStream:
         int (*get_schema)(ArrowArrayStream* stream, ArrowSchema* out)
+        void (*release)(ArrowArrayStream*) noexcept nogil
 
 
 cdef extern from "ogr_api.h":

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -202,6 +202,8 @@ cdef extern from "ogr_api.h":
     int             OGRGetDriverCount()
     OGRSFDriverH    OGRGetDriver(int)
 
+    bint            OGRGetGEOSVersion(int *pnMajor, int *pnMinor, int *pnPatch)
+
     OGRDataSourceH  OGR_Dr_Open(OGRSFDriverH driver, const char *path, int bupdate)
     const char*     OGR_Dr_GetName(OGRSFDriverH driver)
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -42,21 +42,13 @@ def get_gdal_version_string():
     return get_string(version)
 
 
-IF CTE_GDAL_VERSION >= (3, 4, 0):
-
-    cdef extern from "ogr_api.h":
-        bint OGRGetGEOSVersion(int *pnMajor, int *pnMinor, int *pnPatch)
-
-
 def get_gdal_geos_version():
     cdef int major, minor, revision
 
-    IF CTE_GDAL_VERSION >= (3, 4, 0):
-        if not OGRGetGEOSVersion(&major, &minor, &revision):
-            return None
-        return (major, minor, revision)
-    ELSE:
+    if not OGRGetGEOSVersion(&major, &minor, &revision):
         return None
+
+    return (major, minor, revision)
 
 
 def set_gdal_config_options(dict options):

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -260,9 +260,12 @@ def read_arrow(
 
     gdal_version = get_gdal_version()
 
+    # also checking skip_features here because of special handling for GDAL < 3.8.0
+    # otherwise it is properly checked in ogr_open_arrow instead
     if skip_features < 0:
         raise ValueError("'skip_features' must be >= 0")
 
+    # max_features support is shimmed here so it must be validated here
     if max_features is not None and max_features < 0:
         raise ValueError("'max_features' must be >= 0")
 
@@ -401,6 +404,12 @@ def open_arrow(
     """
     if not HAS_ARROW_API:
         raise RuntimeError("pyarrow and GDAL>= 3.6 required to read using arrow")
+
+    gdal_version = get_gdal_version()
+    if skip_features and gdal_version < (3, 8, 0):
+        raise ValueError(
+            "specifying 'skip_features' is not supported for open_arrow for GDAL<3.8.0"
+        )
 
     path, buffer = get_vsi_path(path_or_buffer)
 

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -171,7 +171,7 @@ def test_open_arrow_skip_features_unsupported(naturalearth_lowres, skip_features
     GDAL < 3.8.0"""
     with pytest.raises(
         ValueError,
-        match="specifying 'skip_features' is not supported for Arrow for GDAL<3.8.0",
+        match="specifying 'skip_features' is not supported for open_arrow for GDAL<3.8.0",
     ):
         with open_arrow(naturalearth_lowres, skip_features=skip_features) as (
             meta,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -343,6 +343,9 @@ def test_read_where_in(naturalearth_lowres_all_ext, use_arrow):
 
 
 def test_read_where_range(naturalearth_lowres_all_ext, use_arrow):
+    if naturalearth_lowres_all_ext.suffix not in {".geojsonl", ".gpkg"}:
+        pytest.skip("only test gpkg")
+
     # should return items within range
     df = read_dataframe(
         naturalearth_lowres_all_ext,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -317,11 +317,13 @@ def test_read_fid_as_index_only(naturalearth_lowres, use_arrow):
     assert len(df.columns) == 0
 
 
-def test_read_where(naturalearth_lowres_all_ext, use_arrow):
+def test_read_where_empty(naturalearth_lowres_all_ext, use_arrow):
     # empty filter should return full set of records
     df = read_dataframe(naturalearth_lowres_all_ext, use_arrow=use_arrow, where="")
     assert len(df) == 177
 
+
+def test_read_where_equals(naturalearth_lowres_all_ext, use_arrow):
     # should return singular item
     df = read_dataframe(
         naturalearth_lowres_all_ext, use_arrow=use_arrow, where="iso_a3 = 'CAN'"
@@ -329,6 +331,8 @@ def test_read_where(naturalearth_lowres_all_ext, use_arrow):
     assert len(df) == 1
     assert df.iloc[0].iso_a3 == "CAN"
 
+
+def test_read_where_in(naturalearth_lowres_all_ext, use_arrow):
     df = read_dataframe(
         naturalearth_lowres_all_ext,
         use_arrow=use_arrow,
@@ -337,6 +341,8 @@ def test_read_where(naturalearth_lowres_all_ext, use_arrow):
     assert len(df) == 3
     assert len(set(df.iso_a3.unique()).difference(["CAN", "USA", "MEX"])) == 0
 
+
+def test_read_where_range(naturalearth_lowres_all_ext, use_arrow):
     # should return items within range
     df = read_dataframe(
         naturalearth_lowres_all_ext,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -343,6 +343,9 @@ def test_read_where_in(naturalearth_lowres_all_ext, use_arrow):
 
 
 def test_read_where_range(naturalearth_lowres_all_ext, use_arrow):
+    if naturalearth_lowres_all_ext.suffix != ".gpkg":
+        pytest.skip("only test gpkg")
+
     # should return items within range
     df = read_dataframe(
         naturalearth_lowres_all_ext,

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -344,7 +344,7 @@ def test_read_where_in(naturalearth_lowres_all_ext, use_arrow):
 
 def test_read_where_range(naturalearth_lowres_all_ext, use_arrow):
     if naturalearth_lowres_all_ext.suffix not in {".geojsonl", ".gpkg"}:
-        pytest.skip("only test gpkg")
+        pytest.skip("only test geojsonl or gpkg")
 
     # should return items within range
     df = read_dataframe(

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -343,9 +343,6 @@ def test_read_where_in(naturalearth_lowres_all_ext, use_arrow):
 
 
 def test_read_where_range(naturalearth_lowres_all_ext, use_arrow):
-    if naturalearth_lowres_all_ext.suffix != ".gpkg":
-        pytest.skip("only test gpkg")
-
     # should return items within range
     df = read_dataframe(
         naturalearth_lowres_all_ext,


### PR DESCRIPTION
Split up dataframe read with `where` test to try and probe at #384 

Also tries to remove `IF` blocks marked as deprecated by Cython, except for those still needed for GDAL version specific functions.