### PR TITLE
FIX: Only raise GDAL <3.8.3 bool I/O exception for FlatGeobuf / GPKG 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,8 @@
 -   Fix encoding issues on windows for some formats (e.g. ".csv") and always write ESRI
     Shapefiles using UTF-8 by default on all platforms (#361).
 -   Raise exception in `read_arrow` or `read_dataframe(..., use_arrow=True)` if
-    a boolean column is detected due to error in GDAL reading boolean values (#335)
-    this has been fixed in GDAL >= 3.8.3.
+    a boolean column is detected due to error in GDAL reading boolean values for
+    FlatGeobuf / GPKG drivers (#335, #387); this has been fixed in GDAL >= 3.8.3.
 
 ### Packaging
 

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -330,16 +330,6 @@ def read_arrow(
         else:
             table = reader.read_all()
 
-    # raise error if schema has bool values and GDAL <3.8.3
-    # due to https://github.com/OSGeo/gdal/issues/8998
-    if gdal_version < (3, 8, 3) and any(
-        [col_type == "bool" for col_type in table.schema.types]
-    ):
-        raise RuntimeError(
-            "GDAL < 3.8.3 does not correctly read boolean data values using the "
-            "Arrow API.  Do not use read_arrow() / use_arrow=True for this dataset."
-        )
-
     return meta, table
 
 

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 from pyogrio import __gdal_version__, read_dataframe
 from pyogrio.raw import open_arrow, read_arrow, write
-from pyogrio.tests.conftest import requires_arrow_api
+from pyogrio.tests.conftest import ALL_EXTS, requires_arrow_api
 
 try:
     import pandas as pd
@@ -232,8 +232,9 @@ def test_enable_with_environment_variable(test_ogr_types_list):
 @pytest.mark.skipif(
     __gdal_version__ < (3, 8, 3), reason="Arrow bool value bug fixed in GDAL >= 3.8.3"
 )
-def test_arrow_bool_roundtrip(tmpdir):
-    filename = os.path.join(str(tmpdir), "test.gpkg")
+@pytest.mark.parametrize("ext", ALL_EXTS)
+def test_arrow_bool_roundtrip(tmpdir, ext):
+    filename = os.path.join(str(tmpdir), f"test{ext}")
 
     # Point(0, 0)
     geometry = np.array(
@@ -242,6 +243,22 @@ def test_arrow_bool_roundtrip(tmpdir):
     bool_col = np.array([True, False, True, False, True])
     field_data = [bool_col]
     fields = ["bool_col"]
+
+    kwargs = {}
+
+    if ext == ".fgb":
+        # For .fgb, spatial_index=False to avoid the rows being reordered
+        kwargs["spatial_index"] = False
+
+    write(
+        filename,
+        geometry,
+        field_data,
+        fields,
+        geometry_type="Point",
+        crs="EPSG:4326",
+        **kwargs,
+    )
 
     write(
         filename, geometry, field_data, fields, geometry_type="Point", crs="EPSG:4326"
@@ -254,8 +271,9 @@ def test_arrow_bool_roundtrip(tmpdir):
 @pytest.mark.skipif(
     __gdal_version__ >= (3, 8, 3), reason="Arrow bool value bug fixed in GDAL >= 3.8.3"
 )
-def test_arrow_bool_exception(tmpdir):
-    filename = os.path.join(str(tmpdir), "test.gpkg")
+@pytest.mark.parametrize("ext", ALL_EXTS)
+def test_arrow_bool_exception(tmpdir, ext):
+    filename = os.path.join(str(tmpdir), f"test{ext}")
 
     # Point(0, 0)
     geometry = np.array(
@@ -269,9 +287,20 @@ def test_arrow_bool_exception(tmpdir):
         filename, geometry, field_data, fields, geometry_type="Point", crs="EPSG:4326"
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="GDAL < 3.8.3 does not correctly read boolean data values using "
-        "the Arrow API",
-    ):
-        read_arrow(filename)
+    if ext in {".fgb", ".gpkg"}:
+        # only raise exception for GPKG / FGB
+        with pytest.raises(
+            RuntimeError,
+            match="GDAL < 3.8.3 does not correctly read boolean data values using "
+            "the Arrow API",
+        ):
+            with open_arrow(filename):
+                pass
+
+        # do not raise exception if no bool columns are read
+        with open_arrow(filename, columns=[]):
+            pass
+
+    else:
+        with open_arrow(filename):
+            pass


### PR DESCRIPTION
Resolves #350

Moves the test for bool cols into the Cython tier where we can also check the driver and ignored fields, so that we only raise the exception when reading FlatGeobuf/GPKG if also reading a bool col