### PR TITLE
PERF: optimize geometry type checking in write_dataframe

### DIFF
--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -495,9 +495,7 @@ def write_dataframe(
         # If there is data, infer layer geometry type + promote_to_multi
         if not df.empty:
             # None/Empty geometries sometimes report as Z incorrectly, so ignore them
-            has_z_arr = geometry[
-                (geometry != np.array(None)) & (~geometry.is_empty)
-            ].has_z
+            has_z_arr = geometry[geometry.notna() & (~geometry.is_empty)].has_z
             has_z = has_z_arr.any()
             all_z = has_z_arr.all()
 


### PR DESCRIPTION
I was checking the performance of `write_dataframe` and noticed there was a significant part spent in `__ne__` of the geometry array, which can be optimized by using a built-in method for checking missing values instead of using `!= None` (for a larger dataset this can take more than a second, while the `notna()` call is in the milliseconds)