### PR TITLE
ENH: refactor handling of reading from in-memory dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
     option for `read`, `read_dataframe`, and `open_arrow`, and correctly encode
     Shapefile field names and text values to the user-provided `encoding` for
     `write` and `write_dataframe` (#384).
+-   Fixed bug preventing reading from bytes or file-like in `read_arrow` /
+    `open_arrow` (#407).
 
 ### Packaging
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -137,30 +137,6 @@ def ogr_list_drivers():
     return drivers
 
 
-def buffer_to_virtual_file(bytesbuf, ext=''):
-    """Maps a bytes buffer to a virtual file.
-    `ext` is empty or begins with a period and contains at most one period.
-
-    This (and remove_virtual_file) is originally copied from the Fiona project
-    (https://github.com/Toblerity/Fiona/blob/c388e9adcf9d33e3bb04bf92b2ff210bbce452d9/fiona/ogrext.pyx#L1863-L1879)
-    """
-
-    vsi_filename = f"/vsimem/{uuid4().hex + ext}"
-
-    vsi_handle = VSIFileFromMemBuffer(vsi_filename.encode("UTF-8"), <unsigned char *>bytesbuf, len(bytesbuf), 0)
-
-    if vsi_handle == NULL:
-        raise OSError('failed to map buffer to file')
-    if VSIFCloseL(vsi_handle) != 0:
-        raise OSError('failed to close mapped file handle')
-
-    return vsi_filename
-
-
-def remove_virtual_file(vsi_filename):
-    return VSIUnlink(vsi_filename.encode("UTF-8"))
-
-
 cdef void set_proj_search_path(str path):
     """Set PROJ library data file search path for use in GDAL."""
     cdef char **paths = NULL

--- a/pyogrio/_vsi.pxd
+++ b/pyogrio/_vsi.pxd
@@ -1,0 +1,4 @@
+cdef str get_ogr_vsimem_write_path(object path_or_fp, str driver)
+cdef str read_buffer_to_vsimem(bytes bytes_buffer)
+cdef read_vsimem_to_buffer(str path, object out_buffer)
+cdef delete_vsimem_file(str path)

--- a/pyogrio/_vsi.pyx
+++ b/pyogrio/_vsi.pyx
@@ -48,7 +48,7 @@ cdef str get_ogr_vsimem_write_path(object path_or_fp, str driver):
 
 
 cdef str read_buffer_to_vsimem(bytes bytes_buffer):
-    """ Read the bytes into an in-memory dataset
+    """ Wrap the bytes (zero-copy) into an in-memory dataset
 
     If the first 4 bytes indicate the bytes are a zip file, the returned path
     will be prefixed with /vsizip/ and suffixed with .zip to enable proper
@@ -71,7 +71,6 @@ cdef str read_buffer_to_vsimem(bytes bytes_buffer):
     # NOTE: GDAL does not copy the contents of bytes_buffer; it must remain
     # in scope through the duration of using this file
     vsi_handle = VSIFileFromMemBuffer(path.encode("UTF-8"), <unsigned char *>bytes_buffer, num_bytes, 0)
-    vsi_buffer = NULL
 
     if vsi_handle == NULL:
         raise OSError("failed to read buffer into in-memory file")

--- a/pyogrio/_vsi.pyx
+++ b/pyogrio/_vsi.pyx
@@ -1,0 +1,141 @@
+from io import BytesIO
+from uuid import uuid4
+
+from libc.stdlib cimport malloc, free
+from libc.string cimport memcpy
+
+from pyogrio._ogr cimport *
+from pyogrio._ogr import _get_driver_metadata_item
+
+
+cdef str get_ogr_vsimem_write_path(object path_or_fp, str driver):
+    """ Return the original path or a /vsimem/ path
+
+    If passed a io.BytesIO object, this will return a /vsimem/ path that can be
+    used to create a new in-memory file with an extension inferred from the driver
+    if possible.  Path will be contained in an in-memory directory to contain
+    sibling files (though drivers that create sibling files are not supported for
+    in-memory files).
+
+    Caller is responsible for deleting the directory via delete_vsimem_file()
+
+    Parameters
+    ----------
+    path_or_fp : str or io.BytesIO object
+    driver : str
+    """
+
+    if not isinstance(path_or_fp, BytesIO):
+        return path_or_fp
+
+    # Create in-memory directory to contain auxiliary files
+    memfilename = uuid4().hex
+    VSIMkdir(f"/vsimem/{memfilename}".encode("UTF-8"), 0666)
+
+    # file extension is required for some drivers, set it based on driver metadata
+    ext = ""
+    recommended_ext = _get_driver_metadata_item(driver, "DMD_EXTENSIONS")
+    if recommended_ext is not None:
+        ext = "." + recommended_ext.split(" ")[0]
+
+    path = f"/vsimem/{memfilename}/{memfilename}{ext}"
+
+    # check for existing bytes
+    if path_or_fp.getbuffer().nbytes > 0:
+        raise NotImplementedError("writing to existing in-memory object is not supported")
+
+    return path
+
+
+cdef str read_buffer_to_vsimem(bytes bytes_buffer):
+    """ Read the bytes into an in-memory dataset
+
+    If the first 4 bytes indicate the bytes are a zip file, the returned path
+    will be prefixed with /vsizip/ and suffixed with .zip to enable proper
+    reading by GDAL.
+
+    Caller is responsible for deleting the in-memory file via delete_vsimem_file().
+
+    Parameters
+    ----------
+    bytes_buffer : bytes
+    """
+    cdef int num_bytes = len(bytes_buffer)
+
+    is_zipped = len(bytes_buffer) > 4 and bytes_buffer[:4].startswith(b"PK\x03\x04")
+    ext = ".zip" if is_zipped else ""
+
+    path = f"/vsimem/{uuid4().hex}{ext}"
+
+    # Create an in-memory object that references bytes_buffer
+    # NOTE: GDAL does not copy the contents of bytes_buffer; it must remain
+    # in scope through the duration of using this file
+    vsi_handle = VSIFileFromMemBuffer(path.encode("UTF-8"), <unsigned char *>bytes_buffer, num_bytes, 0)
+    vsi_buffer = NULL
+
+    if vsi_handle == NULL:
+        raise OSError("failed to read buffer into in-memory file")
+
+    if VSIFCloseL(vsi_handle) != 0:
+        raise OSError("failed to close in-memory file")
+
+    if is_zipped:
+        path = f"/vsizip/{path}"
+
+    return path
+
+
+cdef read_vsimem_to_buffer(str path, object out_buffer):
+    """Copy bytes from in-memory file to buffer
+
+    This will automatically unlink the in-memory file pointed to by path; caller
+    is still responsible for calling delete_vsimem_file() to cleanup any other
+    files contained in the in-memory directory.
+
+    Parameters:
+    -----------
+    path : str
+        path to in-memory file
+    buffer : BytesIO object
+    """
+
+    cdef unsigned char *vsi_buffer = NULL
+    cdef vsi_l_offset vsi_buffer_size = 0
+
+    try:
+        # Take ownership of the buffer to avoid a copy; GDAL will automatically
+        # unlink the memory file
+        vsi_buffer = VSIGetMemFileBuffer(path.encode("UTF-8"), &vsi_buffer_size, 1)
+        if vsi_buffer == NULL:
+            raise RuntimeError("could not read bytes from in-memory file")
+
+        # write bytes to buffer
+        out_buffer.write(<bytes>vsi_buffer[:vsi_buffer_size])
+        # rewind to beginning to allow caller to read
+        out_buffer.seek(0)
+
+    finally:
+        if vsi_buffer != NULL:
+            CPLFree(vsi_buffer)
+
+
+cdef delete_vsimem_file(str path):
+    """ Recursively delete in-memory path or directory containing path
+
+    This is used for final cleanup of an in-memory dataset, which may have been
+    created within a directory to contain sibling files.
+
+    Additional VSI handlers may be chained to the left of /vsimem/ in path and
+    will be ignored.
+
+    Parameters:
+    -----------
+    path : str
+        path to in-memory file
+    """
+
+    if "/vsimem/" not in path:
+        return
+
+    root = "/vsimem/" + path.split("/vsimem/")[1].split("/")[0]
+    VSIRmdirRecursive(root.encode("UTF-8"))

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -8,7 +8,7 @@ from pyogrio.errors import DataSourceError
 from pyogrio.util import (
     _mask_to_wkb,
     _preprocess_options_key_value,
-    get_vsi_path,
+    get_vsi_path_or_buffer,
     vsi_path,
 )
 
@@ -20,7 +20,6 @@ with GDALEnv():
         get_gdal_version_string,
         ogr_driver_supports_write,
         ogr_driver_supports_vsi,
-        remove_virtual_file,
     )
 
 
@@ -191,35 +190,28 @@ def read(
         https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html
 
     """
-    path, buffer = get_vsi_path(path_or_buffer)
 
     dataset_kwargs = _preprocess_options_key_value(kwargs) if kwargs else {}
 
-    try:
-        result = ogr_read(
-            path,
-            layer=layer,
-            encoding=encoding,
-            columns=columns,
-            read_geometry=read_geometry,
-            force_2d=force_2d,
-            skip_features=skip_features,
-            max_features=max_features or 0,
-            where=where,
-            bbox=bbox,
-            mask=_mask_to_wkb(mask),
-            fids=fids,
-            sql=sql,
-            sql_dialect=sql_dialect,
-            return_fids=return_fids,
-            dataset_kwargs=dataset_kwargs,
-            datetime_as_string=datetime_as_string,
-        )
-    finally:
-        if buffer is not None:
-            remove_virtual_file(path)
-
-    return result
+    return ogr_read(
+        get_vsi_path_or_buffer(path_or_buffer),
+        layer=layer,
+        encoding=encoding,
+        columns=columns,
+        read_geometry=read_geometry,
+        force_2d=force_2d,
+        skip_features=skip_features,
+        max_features=max_features or 0,
+        where=where,
+        bbox=bbox,
+        mask=_mask_to_wkb(mask),
+        fids=fids,
+        sql=sql,
+        sql_dialect=sql_dialect,
+        return_fids=return_fids,
+        dataset_kwargs=dataset_kwargs,
+        datetime_as_string=datetime_as_string,
+    )
 
 
 def read_arrow(
@@ -437,34 +429,28 @@ def open_arrow(
     if not HAS_ARROW_API:
         raise RuntimeError("GDAL>= 3.6 required to read using arrow")
 
-    path, buffer = get_vsi_path(path_or_buffer)
-
     dataset_kwargs = _preprocess_options_key_value(kwargs) if kwargs else {}
 
-    try:
-        return ogr_open_arrow(
-            path,
-            layer=layer,
-            encoding=encoding,
-            columns=columns,
-            read_geometry=read_geometry,
-            force_2d=force_2d,
-            skip_features=skip_features,
-            max_features=max_features or 0,
-            where=where,
-            bbox=bbox,
-            mask=_mask_to_wkb(mask),
-            fids=fids,
-            sql=sql,
-            sql_dialect=sql_dialect,
-            return_fids=return_fids,
-            dataset_kwargs=dataset_kwargs,
-            batch_size=batch_size,
-            use_pyarrow=use_pyarrow,
-        )
-    finally:
-        if buffer is not None:
-            remove_virtual_file(path)
+    return ogr_open_arrow(
+        get_vsi_path_or_buffer(path_or_buffer),
+        layer=layer,
+        encoding=encoding,
+        columns=columns,
+        read_geometry=read_geometry,
+        force_2d=force_2d,
+        skip_features=skip_features,
+        max_features=max_features or 0,
+        where=where,
+        bbox=bbox,
+        mask=_mask_to_wkb(mask),
+        fids=fids,
+        sql=sql,
+        sql_dialect=sql_dialect,
+        return_fids=return_fids,
+        dataset_kwargs=dataset_kwargs,
+        batch_size=batch_size,
+        use_pyarrow=use_pyarrow,
+    )
 
 
 def _parse_options_names(xml):

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -146,6 +146,37 @@ def test_datetime_tz():
     return _data_dir / "test_datetime_tz.geojson"
 
 
+@pytest.fixture(scope="function")
+def geojson_bytes(tmp_path):
+    """Extracts first 3 records from naturalearth_lowres and writes to GeoJSON,
+    returning bytes"""
+    meta, _, geometry, field_data = read(
+        _data_dir / Path("naturalearth_lowres/naturalearth_lowres.shp"), max_features=3
+    )
+
+    filename = tmp_path / "test.geojson"
+    write(filename, geometry, field_data, **meta)
+
+    with open(filename, "rb") as f:
+        bytes_buffer = f.read()
+
+    return bytes_buffer
+
+
+@pytest.fixture(scope="function")
+def geojson_filelike(tmp_path):
+    """Extracts first 3 records from naturalearth_lowres and writes to GeoJSON,
+    returning open file handle"""
+    meta, _, geometry, field_data = read(
+        _data_dir / Path("naturalearth_lowres/naturalearth_lowres.shp"), max_features=3
+    )
+
+    filename = tmp_path / "test.geojson"
+    write(filename, geometry, field_data, layer="test", **meta)
+
+    return open(filename, "rb")
+
+
 @pytest.fixture(
     scope="session",
     params=[

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -174,7 +174,8 @@ def geojson_filelike(tmp_path):
     filename = tmp_path / "test.geojson"
     write(filename, geometry, field_data, layer="test", **meta)
 
-    return open(filename, "rb")
+    with open(filename, "rb") as f:
+        yield f
 
 
 @pytest.fixture(

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -161,6 +161,7 @@ def test_read_arrow_vsi(naturalearth_lowres_vsi):
     assert len(table) == 177
 
 
+@requires_arrow_write_api
 @pytest.mark.filterwarnings("ignore:A geometry of type POLYGON is inserted")
 @pytest.mark.filterwarnings("ignore:File /vsimem:RuntimeWarning")
 @pytest.mark.parametrize("driver,ext", [("GeoJSON", "geojson"), ("GPKG", "gpkg")])

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -177,6 +177,20 @@ def test_list_layers(naturalearth_lowres, naturalearth_lowres_vsi, test_fgdb_vsi
         assert array_equal(fgdb_layers[6], ["test_areas", "MultiPolygon Z"])
 
 
+def test_list_layers_bytes(geojson_bytes):
+    layers = list_layers(geojson_bytes)
+
+    assert layers.shape == (1, 2)
+    assert layers[0, 0] == "test"
+
+
+def test_list_layers_filelike(geojson_filelike):
+    layers = list_layers(geojson_filelike)
+
+    assert layers.shape == (1, 2)
+    assert layers[0, 0] == "test"
+
+
 def test_read_bounds(naturalearth_lowres):
     fids, bounds = read_bounds(naturalearth_lowres)
     assert fids.shape == (177,)
@@ -184,6 +198,30 @@ def test_read_bounds(naturalearth_lowres):
 
     assert fids[0] == 0
     # Fiji; wraps antimeridian
+    assert allclose(bounds[:, 0], [-180.0, -18.28799, 180.0, -16.02088])
+
+
+def test_read_bounds_vsi(naturalearth_lowres_vsi):
+    fids, bounds = read_bounds(naturalearth_lowres_vsi[1])
+    assert fids.shape == (177,)
+    assert bounds.shape == (4, 177)
+
+    assert fids[0] == 0
+    # Fiji; wraps antimeridian
+    assert allclose(bounds[:, 0], [-180.0, -18.28799, 180.0, -16.02088])
+
+
+def test_read_bounds_bytes(geojson_bytes):
+    fids, bounds = read_bounds(geojson_bytes)
+    assert fids.shape == (3,)
+    assert bounds.shape == (4, 3)
+    assert allclose(bounds[:, 0], [-180.0, -18.28799, 180.0, -16.02088])
+
+
+def test_read_bounds_filelike(geojson_filelike):
+    fids, bounds = read_bounds(geojson_filelike)
+    assert fids.shape == (3,)
+    assert bounds.shape == (4, 3)
     assert allclose(bounds[:, 0], [-180.0, -18.28799, 180.0, -16.02088])
 
 
@@ -395,6 +433,27 @@ def test_read_info(naturalearth_lowres):
         assert meta["capabilities"]["fast_set_next_by_index"] is True
     else:
         raise ValueError(f"test not implemented for ext {naturalearth_lowres.suffix}")
+
+
+def test_read_info_vsi(naturalearth_lowres_vsi):
+    meta = read_info(naturalearth_lowres_vsi[1])
+
+    assert meta["fields"].shape == (5,)
+    assert meta["features"] == 177
+
+
+def test_read_info_bytes(geojson_bytes):
+    meta = read_info(geojson_bytes)
+
+    assert meta["fields"].shape == (5,)
+    assert meta["features"] == 3
+
+
+def test_read_info_filelike(geojson_filelike):
+    meta = read_info(geojson_filelike)
+
+    assert meta["fields"].shape == (5,)
+    assert meta["features"] == 3
 
 
 @pytest.mark.parametrize(

--- a/pyogrio/tests/test_path.py
+++ b/pyogrio/tests/test_path.py
@@ -7,7 +7,7 @@ import pytest
 
 import pyogrio
 import pyogrio.raw
-from pyogrio.util import vsi_path, get_vsi_path
+from pyogrio.util import vsi_path, get_vsi_path_or_buffer
 
 try:
     import geopandas  # NOQA
@@ -333,16 +333,24 @@ def test_uri_s3_dataframe(aws_env_setup):
     assert len(df) == 67
 
 
-def test_get_vsi_path_obj_to_string():
+def test_get_vsi_path_or_buffer_obj_to_string():
     path = Path("/tmp/test.gpkg")
-    assert get_vsi_path(path) == (str(path), None)
+    assert get_vsi_path_or_buffer(path) == str(path)
 
 
-def test_get_vsi_path_fixtures_to_string(tmpdir, tmp_path):
+def test_get_vsi_path_or_buffer_fixtures_to_string(tmpdir, tmp_path):
     # tmpdir uses a private class LocalPath in pytest so we have to test it using
     # the fixture instead of making an instance
     path = tmpdir / "test.gpkg"
-    assert get_vsi_path(path) == (str(path), None)
+    assert get_vsi_path_or_buffer(path) == str(path)
 
     path = tmp_path / "test.gpkg"
-    assert get_vsi_path(path) == (str(path), None)
+    assert get_vsi_path_or_buffer(path) == str(path)
+
+
+@pytest.mark.parametrize(
+    "raw_path", ["/vsimem/test.shp.zip", "/vsizip//vsimem/test.shp.zip"]
+)
+def test_vsimem_path_exception(raw_path):
+    with pytest.raises(ValueError, match=""):
+        vsi_path(raw_path)

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -5,44 +5,49 @@ from urllib.parse import urlparse
 
 from packaging.version import Version
 
-from pyogrio._env import GDALEnv
 
-with GDALEnv():
-    from pyogrio._ogr import buffer_to_virtual_file
+def get_vsi_path_or_buffer(path_or_buffer):
+    """Get vsi-prefixed path or bytes buffer depending on type of path_or_buffer
 
+    If path_or_buffer is a bytes object, it will be returned directly and will
+    be read into an in-memory dataset when passed to one of the Cython functions.
 
-def get_vsi_path(path_or_buffer):
+    If path_or_buffer is a file-like object with a read method, bytes will be
+    read from the file-like object and returned.
+
+    Otherwise, it will be converted to a string, and parsed to prefix with
+    appropriate GDAL /vsi*/ prefixes.
+
+    Parameters
+    ----------
+    path_or_buffer : str, pathlib.Path, bytes, or file-like
+
+    Returns
+    -------
+    str or bytes
+    """
+
     # force path objects to string to specifically ignore their read method
     if (
         isinstance(path_or_buffer, Path)
         # TODO: check for pytest LocalPath can be removed when all instances of tmpdir in fixtures are removed
         or "_pytest._py.path.LocalPath" in str(type(path_or_buffer))
     ):
-        path_or_buffer = str(path_or_buffer)
+        return vsi_path(str(path_or_buffer))
+
+    if isinstance(path_or_buffer, bytes):
+        return path_or_buffer
 
     if hasattr(path_or_buffer, "read"):
-        bytes_read = path_or_buffer.read()
+        bytes_buffer = path_or_buffer.read()
 
         # rewind buffer if possible so that subsequent operations do not need to rewind
         if hasattr(path_or_buffer, "seek"):
             path_or_buffer.seek(0)
 
-        path_or_buffer = bytes_read
+        return bytes_buffer
 
-    buffer = None
-    if isinstance(path_or_buffer, bytes):
-        buffer = path_or_buffer
-        ext = ""
-        is_zipped = path_or_buffer[:4].startswith(b"PK\x03\x04")
-        if is_zipped:
-            ext = ".zip"
-        path = buffer_to_virtual_file(path_or_buffer, ext=ext)
-        if is_zipped:
-            path = "/vsizip/" + path
-    else:
-        path = vsi_path(str(path_or_buffer))
-
-    return path, buffer
+    return vsi_path(str(path_or_buffer))
 
 
 def vsi_path(path: str) -> str:
@@ -50,6 +55,11 @@ def vsi_path(path: str) -> str:
     Ensure path is a local path or a GDAL-compatible vsi path.
 
     """
+
+    if "/vsimem/" in path:
+        raise ValueError(
+            "path cannot contain /vsimem/ directly; to use an in-memory dataset a bytes object must be passed instead"
+        )
 
     # path is already in GDAL format
     if path.startswith("/vsi"):

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ else:
             Extension("pyogrio._geometry", ["pyogrio/_geometry.pyx"], **ext_options),
             Extension("pyogrio._io", ["pyogrio/_io.pyx"], **ext_options),
             Extension("pyogrio._ogr", ["pyogrio/_ogr.pyx"], **ext_options),
+            Extension("pyogrio._vsi", ["pyogrio/_vsi.pyx"], **ext_options),
         ],
         compiler_directives={"language_level": "3"},
         compile_time_env=compile_time_env,


### PR DESCRIPTION
Resolves #401 

This moves all handling of creation / destruction of the in-memory dataset used for read operations to the Cython tier, and now passes in either a string or bytes to `read_info()`, `list_layers()`, `read_bounds()`, `read()`, `read_arrow()` functions.  I think this also sets us to for later refactors where we may pass file-like / filesystem-like objects directly down to Cython in order to use the GDAL virtual filesystem plugin.

To keep things organized, I split VSI related Cython functions into the new `_vsi.pyx` / `_vsi.pxd` files.

Because the bytes buffer is passed as a parameter, it remains in scope during the Cython function and we don't need to hold an extra handle on it like before. (the handle was required to prevent Python from deallocating it while GDAL still may use it to represent the in-memory dataset).

This expands the tests to verify that core functions still work correctly when passed bytes or file-like objects.  To avoid the various GPKG related errors when working with this type in memory, I instead added new test fixtures to create a GeoJSON file from the first 3 records of the naturalearth_lowres dataset.

This also adds a specific check that the incoming path does not already contain `/vsimem/`, since we have to handle that internally and cannot allow it to be passed in.