### PR TITLE
ENH: allow writing without geometry using Arrow

### DIFF
--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -788,7 +788,7 @@ def write_arrow(
         Otherwise needs to be specified explicitly.
     geometry_type : str
         The geometry type of the written layer. Currently, this needs to be
-        specified explicitly when creating a new layer.
+        specified explicitly when creating a new layer with geometries.
         Possible values are: "Unknown", "Point", "LineString", "Polygon",
         "MultiPoint", "MultiLineString", "MultiPolygon" or "GeometryCollection".
 
@@ -848,20 +848,20 @@ def write_arrow(
             "The 'promote_to_multi' option is not supported when writing using Arrow"
         )
 
-    if geometry_type is None:
-        raise ValueError("'geometry_type' keyword is required")
+    if geometry_name is not None:
+        if geometry_type is None:
+            raise ValueError("'geometry_type' keyword is required")
+        if crs is None:
+            # TODO: does GDAL infer CRS automatically from geometry metadata?
+            warnings.warn(
+                "'crs' was not provided.  The output dataset will not have "
+                "projection information defined and may not be usable in other "
+                "systems."
+            )
 
     dataset_metadata, layer_metadata = _validate_metadata(
         dataset_metadata, layer_metadata, metadata
     )
-
-    # TODO: does GDAL infer CRS automatically from geometry metadata?
-    if crs is None:
-        warnings.warn(
-            "'crs' was not provided.  The output dataset will not have "
-            "projection information defined and may not be usable in other "
-            "systems."
-        )
 
     # preprocess kwargs and split in dataset and layer creation options
     dataset_kwargs, layer_kwargs = _preprocess_options_kwargs(

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -657,6 +657,7 @@ def test_write_unsupported_geoarrow(tmpdir, naturalearth_lowres):
         )
 
 
+@requires_arrow_write_api
 def test_write_no_geom(tmpdir, naturalearth_lowres):
     _, table = read_arrow(naturalearth_lowres)
     table = table.drop_columns("wkb_geometry")

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -657,6 +657,21 @@ def test_write_unsupported_geoarrow(tmpdir, naturalearth_lowres):
         )
 
 
+def test_write_no_geom(tmpdir, naturalearth_lowres):
+    _, table = read_arrow(naturalearth_lowres)
+    table = table.drop_columns("wkb_geometry")
+
+    # Test
+    filename = str(tmpdir / "test.gpkg")
+    write_arrow(table, filename)
+    # Check result
+    assert os.path.exists(filename)
+    meta, result = read_arrow(filename)
+    assert meta["crs"] is None
+    assert meta["geometry_type"] is None
+    assert table.equals(result)
+
+
 @requires_arrow_write_api
 def test_write_geometry_type(tmpdir, naturalearth_lowres):
     meta, table = read_arrow(naturalearth_lowres)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -990,13 +990,6 @@ def test_write_dataframe_no_geom(
 
     FlatGeobuf (.fgb) doesn't seem to support this, and just writes an empty file.
     """
-    if use_arrow:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason="Arrow does not yet support writing dataframes without geometry",
-            )
-        )
     # Prepare test data
     input_df = read_dataframe(naturalearth_lowres, read_geometry=False)
     if write_geodf:


### PR DESCRIPTION
It seems that in the final version of the `ogr_write_arrow` actually already could write data without a geometry column, but I didn't test that anymore, and so all what is needed to allow this was to clean up our validation of the keywords.