### PR TITLE
Expose the Arrow read and write function top-level

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,13 +13,9 @@ GeoPandas integration
 .. autofunction:: pyogrio.read_dataframe
 .. autofunction:: pyogrio.write_dataframe
 
-Reading as Arrow data
----------------------
+Arrow integration
+-----------------
 
-.. autofunction:: pyogrio.raw.read_arrow
-.. autofunction:: pyogrio.raw.open_arrow
-
-Writing from Arrow data
----------------------
-
-.. autofunction:: pyogrio.raw.write_arrow
+.. autofunction:: pyogrio.read_arrow
+.. autofunction:: pyogrio.open_arrow
+.. autofunction:: pyogrio.write_arrow

--- a/pyogrio/__init__.py
+++ b/pyogrio/__init__.py
@@ -19,6 +19,7 @@ from pyogrio.core import (
     __gdal_version_string__,
     __gdal_geos_version__,
 )
+from pyogrio.raw import read_arrow, open_arrow, write_arrow
 from pyogrio.geopandas import read_dataframe, write_dataframe
 from pyogrio._version import get_versions
 
@@ -35,6 +36,9 @@ __all__ = [
     "set_gdal_config_options",
     "get_gdal_config_option",
     "get_gdal_data_path",
+    "read_arrow",
+    "open_arrow",
+    "write_arrow",
     "read_dataframe",
     "write_dataframe",
     "__gdal_version__",


### PR DESCRIPTION
Given that those are less low-level as the "raw" `read`/`write` functions, I think it would make sense to expose those top-level?