### PR TITLE
BUG: Fix hash url parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.8.1 (yyyy-mm-dd)
 
+### Bug fixes
+
 - Fix bug preventing reading from file paths containing hashes in `read_dataframe` (#412)
 
 ## 0.8.0 (2024-05-06)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.8.1 (yyyy-mm-dd)
+
+- Fix bug preventing reading from file paths containing hashes in `read_dataframe` (#412)
+
 ## 0.8.0 (2024-05-06)
 
 ### Improvements

--- a/pyogrio/tests/test_path.py
+++ b/pyogrio/tests/test_path.py
@@ -35,6 +35,7 @@ def change_cwd(path):
         ("/home/user/data.gpkg", "/home/user/data.gpkg"),
         (r"C:\User\Documents\data.gpkg", r"C:\User\Documents\data.gpkg"),
         ("file:///home/user/data.gpkg", "/home/user/data.gpkg"),
+        ("/home/folder # with hash/data.gpkg", "/home/folder # with hash/data.gpkg"),
         # cloud URIs
         ("https://testing/data.gpkg", "/vsicurl/https://testing/data.gpkg"),
         ("s3://testing/data.gpkg", "/vsis3/testing/data.gpkg"),

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -115,7 +115,7 @@ def _parse_uri(path: str):
     scheme : str
         URI scheme such as "https" or "zip+s3".
     """
-    parts = urlparse(path)
+    parts = urlparse(path, allow_fragments=False)
 
     # if the scheme is not one of GDAL's supported schemes, return raw path
     if parts.scheme and not all(p in SCHEMES for p in parts.scheme.split("+")):


### PR DESCRIPTION
This is an upstream equivalent of https://github.com/geopandas/geopandas/pull/3280 to fix https://github.com/geopandas/geopandas/issues/3279 which is an edge case to do with using urlparse in detecting file schemes.