### PR TITLE
BUG: fix write of kml lon/lat transpose

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@
 -   Fixed bug preventing reading from bytes or file-like in `read_arrow` /
     `open_arrow` (#407).
 -   Fixed bug transposing longitude and latitude when writing files with
-    co-ordinate transfomration to EPSG:4326 (#421).
+    coordinate transformation from EPSG:4326 (#421).
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@
     `write` and `write_dataframe` (#384).
 -   Fixed bug preventing reading from bytes or file-like in `read_arrow` /
     `open_arrow` (#407).
+-   Fixed bug transposing longitude and latitude when writing files with
+    co-ordinate transfomration to EPSG:4326 (#421).
 
 ### Packaging
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2134,8 +2134,8 @@ cdef create_ogr_dataset_layer(
         if crs is not None:
             try:
                 ogr_crs = create_crs(crs)
-                 # force geographic CRS to use lon, lat order and ignore axis order specified by CRS, in order
-                 # to correctly write KML and GeoJSON coordinates in correct order
+                # force geographic CRS to use lon, lat order and ignore axis order specified by CRS, in order
+                # to correctly write KML and GeoJSON coordinates in correct order
                 OSRSetAxisMappingStrategy(ogr_crs, OAMS_TRADITIONAL_GIS_ORDER)
 
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2740,6 +2740,3 @@ cdef create_fields_from_arrow_schema(
                 f"'{get_string(child.name)}' and type {get_string(child.format)}"
                 f"{gdal_msg}."
             )
-
-cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH srs):
-    OSRSetAxisMappingStrategy(srs, OAMS_TRADITIONAL_GIS_ORDER)

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2134,7 +2134,9 @@ cdef create_ogr_dataset_layer(
         if crs is not None:
             try:
                 ogr_crs = create_crs(crs)
-                osr_set_traditional_axis_mapping_strategy(ogr_crs)
+                 # force geographic CRS to use lon, lat order and ignore axis order specified by CRS, in order
+                 # to correctly write KML and GeoJSON coordinates in correct order
+                OSRSetAxisMappingStrategy(ogr_crs, OAMS_TRADITIONAL_GIS_ORDER)
 
 
             except Exception as exc:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2134,6 +2134,8 @@ cdef create_ogr_dataset_layer(
         if crs is not None:
             try:
                 ogr_crs = create_crs(crs)
+                osr_set_traditional_axis_mapping_strategy(ogr_crs)
+
 
             except Exception as exc:
                 if dataset_options != NULL:
@@ -2736,3 +2738,6 @@ cdef create_fields_from_arrow_schema(
                 f"'{get_string(child.name)}' and type {get_string(child.format)}"
                 f"{gdal_msg}."
             )
+
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH srs):
+    OSRSetAxisMappingStrategy(srs, OAMS_TRADITIONAL_GIS_ORDER)

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -196,7 +196,10 @@ cdef extern from "ogr_srs_api.h":
     const char*             OSRGetAuthorityName(OGRSpatialReferenceH srs, const char *key)
     const char*             OSRGetAuthorityCode(OGRSpatialReferenceH srs, const char *key)
     OGRErr                  OSRImportFromEPSG(OGRSpatialReferenceH srs, int code)
-
+    ctypedef enum OSRAxisMappingStrategy:
+        OAMS_TRADITIONAL_GIS_ORDER
+        
+    void                    OSRSetAxisMappingStrategy(OGRSpatialReferenceH hSRS, OSRAxisMappingStrategy)
     int                     OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *pszDef)
     void                    OSRSetPROJSearchPaths(const char *const *paths)
     OGRSpatialReferenceH    OSRNewSpatialReference(const char *wkt)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2071,7 +2071,8 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
 
 def test_write_kml_file_coordinates(tmp_path, use_arrow):
     # confirm reading with kml stores as lon/lat convention
-    gdf = gp.GeoDataFrame(
+    points = [Point(10, 20), Point(30, 40), Point(50, 60)]
+    gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")
         data={
             "label": ["A", "B", "C"],
             "geometry": [Point(10, 20), Point(30, 40), Point(50, 60)],

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2079,7 +2079,7 @@ def test_write_kml_file_coordinates(tmp_path, use_arrow):
     )
     gdf = gdf.set_crs(4326)
     output_path = tmp_path / "test.kml"
-    write_dataframe(gdf, output_path, layer="tmp_layer", driver="KML")
+    write_dataframe(gdf, output_path, layer="tmp_layer", driver="KML", use_arrow=use_arrow)
 
     gdf_in = read_dataframe(output_path)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2067,3 +2067,21 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
     )
     assert actual.columns[0] == mandarin
     assert actual[mandarin].values[0] == mandarin
+
+def test_write_kml_file_coordinates(tmp_path):
+    # confirm reading with kml stores as lon/lat convention
+    gdf = gp.GeoDataFrame(data={'label':['A', 'B', 'C'],
+                                'geometry': [Point(10, 20),
+                                             Point(30, 40),
+                                             Point(50, 60)],
+                                }
+                        )
+    gdf = gdf.set_crs(4326)
+    output_path = tmp_path / f"test.kml"
+    write_dataframe(gdf, output_path, layer='tmp_layer', driver="KML")
+
+    gdf_in = read_dataframe(output_path)
+
+    assert (gdf_in.geometry.values == [Point(10, 20), 
+                                       Point(30, 40), 
+                                       Point(50, 60)]).all()

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2070,7 +2070,7 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
 
 
 def test_write_kml_file_coordinates(tmp_path, use_arrow):
-    # confirm reading with kml stores as lon/lat convention
+    # confirm KML coordinates are written in lon, lat order even if CRS axis specifies otherwise
     points = [Point(10, 20), Point(30, 40), Point(50, 60)]
     gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")
         data={

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2084,6 +2084,6 @@ def test_write_kml_file_coordinates(tmp_path, use_arrow):
 
     gdf_in = read_dataframe(output_path, use_arrow=use_arrow)
 
-    assert (
+    assert np.array_equal(gdf_in.geometry.values, points)
         gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]
     ).all()

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2103,7 +2103,7 @@ def test_write_kml_file_coordinate_order(tmp_path, use_arrow):
 
 
 @pytest.mark.requires_arrow_write_api
-def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow=use_arrow):
+def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow):
     points = [Point(10, 20), Point(30, 40), Point(50, 60)]
     gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")
     output_path = tmp_path / "test.geojson"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2069,21 +2069,33 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
     assert actual[mandarin].values[0] == mandarin
 
 
-def test_write_kml_file_coordinates(tmp_path, use_arrow):
+def test_write_kml_file_coordinate_order(tmp_path, use_arrow):
     # confirm KML coordinates are written in lon, lat order even if CRS axis specifies otherwise
     points = [Point(10, 20), Point(30, 40), Point(50, 60)]
     gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")
-        data={
-            "label": ["A", "B", "C"],
-            "geometry": [Point(10, 20), Point(30, 40), Point(50, 60)],
-        }
-    )
-    gdf = gdf.set_crs(4326)
     output_path = tmp_path / "test.kml"
-    write_dataframe(gdf, output_path, layer="tmp_layer", driver="KML", use_arrow=use_arrow)
+    write_dataframe(
+        gdf, output_path, layer="tmp_layer", driver="KML", use_arrow=use_arrow
+    )
 
     gdf_in = read_dataframe(output_path, use_arrow=use_arrow)
 
     assert np.array_equal(gdf_in.geometry.values, points)
-        gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]
-    ).all()
+
+
+def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow=use_arrow):
+    points = [Point(10, 20), Point(30, 40), Point(50, 60)]
+    gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")
+    output_path = tmp_path / "test.geojson"
+    write_dataframe(
+        gdf,
+        output_path,
+        layer="tmp_layer",
+        driver="GeoJSON",
+        RFC7946=True,
+        use_arrow=use_arrow,
+    )
+
+    gdf_in = read_dataframe(output_path, use_arrow=use_arrow)
+
+    assert np.array_equal(gdf_in.geometry.values, points)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2084,6 +2084,7 @@ def test_write_kml_file_coordinate_order(tmp_path, use_arrow):
     assert np.array_equal(gdf_in.geometry.values, points)
 
 
+@pytest.mark.requires_arrow_write_api
 def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow=use_arrow):
     points = [Point(10, 20), Point(30, 40), Point(50, 60)]
     gdf = gp.GeoDataFrame(geometry=points, crs="EPSG:4326")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2083,6 +2083,24 @@ def test_write_kml_file_coordinate_order(tmp_path, use_arrow):
 
     assert np.array_equal(gdf_in.geometry.values, points)
 
+    # test appending to the existing file
+    points_append = [Point(70, 80), Point(90, 100), Point(110, 120)]
+    gdf_append = gp.GeoDataFrame(geometry=points_append, crs="EPSG:4326")
+
+    write_dataframe(
+        gdf_append,
+        output_path,
+        layer="tmp_layer",
+        driver="KML",
+        use_arrow=use_arrow,
+        append=True,
+    )
+    # force_2d used to only compare xy geometry as z-dimension is undesirably
+    # introduced when the kml file is over-written.
+    gdf_in_appended = read_dataframe(output_path, use_arrow=use_arrow, force_2d=True)
+
+    assert np.array_equal(gdf_in_appended.geometry.values, points + points_append)
+
 
 @pytest.mark.requires_arrow_write_api
 def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow=use_arrow):
@@ -2101,3 +2119,21 @@ def test_write_geojson_rfc7946_coordinates(tmp_path, use_arrow=use_arrow):
     gdf_in = read_dataframe(output_path, use_arrow=use_arrow)
 
     assert np.array_equal(gdf_in.geometry.values, points)
+
+    # test appending to the existing file
+
+    points_append = [Point(70, 80), Point(90, 100), Point(110, 120)]
+    gdf_append = gp.GeoDataFrame(geometry=points_append, crs="EPSG:4326")
+
+    write_dataframe(
+        gdf_append,
+        output_path,
+        layer="tmp_layer",
+        driver="GeoJSON",
+        RFC7946=True,
+        use_arrow=use_arrow,
+        append=True,
+    )
+
+    gdf_in_appended = read_dataframe(output_path, use_arrow=use_arrow)
+    assert np.array_equal(gdf_in_appended.geometry.values, points + points_append)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2081,7 +2081,7 @@ def test_write_kml_file_coordinates(tmp_path, use_arrow):
     output_path = tmp_path / "test.kml"
     write_dataframe(gdf, output_path, layer="tmp_layer", driver="KML", use_arrow=use_arrow)
 
-    gdf_in = read_dataframe(output_path)
+    gdf_in = read_dataframe(output_path, use_arrow=use_arrow)
 
     assert (
         gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2068,6 +2068,7 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
     assert actual.columns[0] == mandarin
     assert actual[mandarin].values[0] == mandarin
 
+
 def test_write_kml_file_coordinates(tmp_path):
     # confirm reading with kml stores as lon/lat convention
     gdf = gp.GeoDataFrame(
@@ -2078,7 +2079,7 @@ def test_write_kml_file_coordinates(tmp_path):
     )
     gdf = gdf.set_crs(4326)
     output_path = tmp_path / "test.kml"
-    write_dataframe(gdf, output_path, layer='tmp_layer', driver="KML")
+    write_dataframe(gdf, output_path, layer="tmp_layer", driver="KML")
 
     gdf_in = read_dataframe(output_path)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2069,6 +2069,7 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
     assert actual[mandarin].values[0] == mandarin
 
 
+@pytest.mark.requires_arrow_write_api
 def test_write_kml_file_coordinate_order(tmp_path, use_arrow):
     # confirm KML coordinates are written in lon, lat order even if CRS axis specifies otherwise
     points = [Point(10, 20), Point(30, 40), Point(50, 60)]

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2069,7 +2069,7 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
     assert actual[mandarin].values[0] == mandarin
 
 
-def test_write_kml_file_coordinates(tmp_path):
+def test_write_kml_file_coordinates(tmp_path, use_arrow):
     # confirm reading with kml stores as lon/lat convention
     gdf = gp.GeoDataFrame(
         data={

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2070,18 +2070,18 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
 
 def test_write_kml_file_coordinates(tmp_path):
     # confirm reading with kml stores as lon/lat convention
-    gdf = gp.GeoDataFrame(data={'label':['A', 'B', 'C'],
-                                'geometry': [Point(10, 20),
-                                             Point(30, 40),
-                                             Point(50, 60)],
-                                }
-                        )
++    gdf = gp.GeoDataFrame(
++        data={
++            "label": ["A", "B", "C"],
++            "geometry": [Point(10, 20), Point(30, 40), Point(50, 60)],
++        }
++    )
     gdf = gdf.set_crs(4326)
     output_path = tmp_path / "test.kml"
     write_dataframe(gdf, output_path, layer='tmp_layer', driver="KML")
 
     gdf_in = read_dataframe(output_path)
 
-    assert (gdf_in.geometry.values == [Point(10, 20), 
-                                       Point(30, 40), 
-                                       Point(50, 60)]).all()
++    assert (
++        gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]
++    ).all()

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2070,18 +2070,18 @@ def test_non_utf8_encoding_shapefile_sql(tmp_path, use_arrow):
 
 def test_write_kml_file_coordinates(tmp_path):
     # confirm reading with kml stores as lon/lat convention
-+    gdf = gp.GeoDataFrame(
-+        data={
-+            "label": ["A", "B", "C"],
-+            "geometry": [Point(10, 20), Point(30, 40), Point(50, 60)],
-+        }
-+    )
+    gdf = gp.GeoDataFrame(
+        data={
+            "label": ["A", "B", "C"],
+            "geometry": [Point(10, 20), Point(30, 40), Point(50, 60)],
+        }
+    )
     gdf = gdf.set_crs(4326)
     output_path = tmp_path / "test.kml"
     write_dataframe(gdf, output_path, layer='tmp_layer', driver="KML")
 
     gdf_in = read_dataframe(output_path)
 
-+    assert (
-+        gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]
-+    ).all()
+    assert (
+        gdf_in.geometry.values == [Point(10, 20), Point(30, 40), Point(50, 60)]
+    ).all()

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2077,7 +2077,7 @@ def test_write_kml_file_coordinates(tmp_path):
                                 }
                         )
     gdf = gdf.set_crs(4326)
-    output_path = tmp_path / f"test.kml"
+    output_path = tmp_path / "test.kml"
     write_dataframe(gdf, output_path, layer='tmp_layer', driver="KML")
 
     gdf_in = read_dataframe(output_path)


### PR DESCRIPTION
Closes #420

My cython is atrocious.

Followed what was done in fiona, qgis and gdal documentation to find this is probably what needs to be done. But I am probably doing it too broadly and may have unintended consequences in other filetypes.

~Still need to write tests.~

Need to investigate how this may impact other file types.