### PR TITLE
Fix #421 entry in changelog from v0.8.0 to 0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+-   Fixed bug transposing longitude and latitude when writing files with
+    coordinate transformation from EPSG:4326 (#421).
 -   Fix bug preventing reading from file paths containing hashes in `read_dataframe` (#412).
 
 ### Packaging
@@ -58,8 +60,6 @@
     `write` and `write_dataframe` (#384).
 -   Fixed bug preventing reading from bytes or file-like in `read_arrow` /
     `open_arrow` (#407).
--   Fixed bug transposing longitude and latitude when writing files with
-    coordinate transformation from EPSG:4326 (#421).
 
 ### Packaging
 


### PR DESCRIPTION
Apologies, I had incorrectly entered the fix for #421 under v0.8.0 in my PR. This PR fixes that in the changelog