### PR TITLE
BUG: Enable mask & bbox filter when geometry column not read

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 -   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
+-   BUG: Enable mask & bbox filter when geometry column not read (#431).
 
 ## 0.9.0 (2024-06-17)
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1274,7 +1274,7 @@ def ogr_read(
             idx = np.intersect1d(fields[:,2], columns, return_indices=True)[1]
             fields = fields[idx, :]
 
-        if not read_geometry:
+        if not read_geometry and bbox is None and mask is None:
             ignored_fields.append("OGR_GEOMETRY")
 
         # Instruct GDAL to ignore reading fields not

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -116,6 +116,31 @@ def test_read_no_geometry(naturalearth_lowres):
     assert geometry is None
 
 
+@pytest.mark.skipif(
+    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
+)
+def test_read_no_geometry__mask(naturalearth_lowres):
+    geometry, fields = read(
+        naturalearth_lowres,
+        read_geometry=False,
+        mask=shapely.Point(-105, 55),
+    )[2:]
+
+    assert np.array_equal(fields[3], ["CAN"])
+    assert geometry is None
+
+
+def test_read_no_geometry__bbox(naturalearth_lowres):
+    geometry, fields = read(
+        naturalearth_lowres,
+        read_geometry=False,
+        bbox=(-109.0, 55.0, -109.0, 55.0),
+    )[2:]
+
+    assert np.array_equal(fields[3], ["CAN"])
+    assert geometry is None
+
+
 def test_read_no_geometry_no_columns_no_fids(naturalearth_lowres):
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Without this change, when a `bbox` or `mask` is passed in and the geometry is ignored, the filter excludes all rows and an empty response is returned.