### PR TITLE
FIX: silence warning from write_dataframe with GeoSeries.notna()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.9.1 (yyyy-mm-dd)
+
+### Bug fixes
+
+-   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
+
 ## 0.9.0 (2024-06-17)
 
 ### Improvements

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -520,7 +520,10 @@ def write_dataframe(
         # If there is data, infer layer geometry type + promote_to_multi
         if not df.empty:
             # None/Empty geometries sometimes report as Z incorrectly, so ignore them
-            has_z_arr = geometry[geometry.notna() & (~geometry.is_empty)].has_z
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", r"GeoSeries\.notna", UserWarning)
+                geometry_notna = geometry.notna()
+            has_z_arr = geometry[geometry_notna & (~geometry.is_empty)].has_z
             has_z = has_z_arr.any()
             all_z = has_z_arr.all()
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2,6 +2,7 @@ import contextlib
 from datetime import datetime
 from io import BytesIO
 import locale
+import warnings
 
 import numpy as np
 import pytest
@@ -1060,6 +1061,21 @@ def test_write_empty_dataframe(tmp_path, ext, use_arrow):
     assert filename.exists()
     df = read_dataframe(filename)
     assert_geodataframe_equal(df, expected)
+
+
+def test_write_empty_geometry(tmp_path):
+    expected = gp.GeoDataFrame({"x": [0]}, geometry=from_wkt(["POINT EMPTY"]), crs=4326)
+    filename = tmp_path / "test.shp"
+
+    # Check that no warning is raised with GeoSeries.notna()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        write_dataframe(expected, filename)
+    assert filename.exists()
+
+    # TODO: fix reading POINT EMPTY
+    # df = read_dataframe(filename)
+    # assert_geodataframe_equal(df, expected)
 
 
 @pytest.mark.parametrize("ext", [".geojsonl", ".geojsons"])

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1065,7 +1065,7 @@ def test_write_empty_dataframe(tmp_path, ext, use_arrow):
 
 def test_write_empty_geometry(tmp_path):
     expected = gp.GeoDataFrame({"x": [0]}, geometry=from_wkt(["POINT EMPTY"]), crs=4326)
-    filename = tmp_path / "test.shp"
+    filename = tmp_path / "test.gpkg"
 
     # Check that no warning is raised with GeoSeries.notna()
     with warnings.catch_warnings():
@@ -1073,9 +1073,9 @@ def test_write_empty_geometry(tmp_path):
         write_dataframe(expected, filename)
     assert filename.exists()
 
-    # TODO: fix reading POINT EMPTY
-    # df = read_dataframe(filename)
-    # assert_geodataframe_equal(df, expected)
+    # Xref GH-436: round-tripping possible with GPKG but not others
+    df = read_dataframe(filename)
+    assert_geodataframe_equal(df, expected)
 
 
 @pytest.mark.parametrize("ext", [".geojsonl", ".geojsons"])


### PR DESCRIPTION
Closes #432

Add TODO note to sort-out reading `POINT EMPTY`, which I'll open in a separate issue...