### PR TITLE
CI: Use uv for faster pip installs, fix venv issues in latest GDAL

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -37,12 +37,16 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Python Dependencies
+      - name: Create virtual environment
         run: |
-          # use uv for much faster pip installs
           curl -LsSf https://astral.sh/uv/install.sh | sh
           . $HOME/.cargo/env
-          uv venv
+          uv venv .venv
+          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+      - name: Install Python Dependencies
+        run: |
           uv pip install pip wheel
           uv pip install -e .[dev,test,geopandas]
 

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -33,20 +33,24 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          apt-get update && apt-get install -y git python3-pip
+          apt-get update && apt-get install -y build-essential git python3-dev
 
       - uses: actions/checkout@v4
 
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install --no-cache-dir -U pip wheel
-          python3 -m pip install --no-cache-dir -e .[dev,test,geopandas]
+          # use uv for much faster pip installs
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          source $HOME/.cargo/env
+          uv venv
+          uv pip install pip wheel
+          uv pip install -e .[dev,test,geopandas]
 
       - name: Install pyarrow
         # GDAL>=3.6 required to use Arrow API
         if: matrix.container != 'osgeo/gdal:ubuntu-small-3.5.3' && matrix.container != 'osgeo/gdal:ubuntu-small-3.4.3'
         run: |
-          python3 -m pip install pyarrow
+          uv pip install pyarrow
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           # use uv for much faster pip installs
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          source $HOME/.cargo/env
+          . $HOME/.cargo/env
           uv venv
           uv pip install pip wheel
           uv pip install -e .[dev,test,geopandas]


### PR DESCRIPTION
This adds [uv](https://github.com/astral-sh/uv) for faster pip installs and uses a virtual environment that it manages to get around virtual environment errors on latest GDAL.

We were previously getting this from GDAL-latest, and the easiest way it seemed to work around this was to use a dedicated virtual environment:

```
Run python3 -m pip install --no-cache-dir -U pip wheel
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/geopandas/pyogrio/actions/runs/9754424367/job/26921308229?pr=438#step:5:7)68 for the detailed specification.
```