### PR TITLE
TST: Consolidate test marks that skip if shapely is not installed

### DIFF
--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -16,7 +16,7 @@ from pyogrio import (
 from pyogrio.core import detect_write_driver
 from pyogrio._compat import GDAL_GE_38
 from pyogrio.errors import DataSourceError, DataLayerError
-from pyogrio.tests.conftest import HAS_SHAPELY, prepare_testfile
+from pyogrio.tests.conftest import prepare_testfile, requires_shapely
 
 from pyogrio._env import GDALEnv
 
@@ -302,9 +302,7 @@ def test_read_bounds_bbox(naturalearth_lowres_all_ext):
     )
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 @pytest.mark.parametrize(
     "mask",
     [
@@ -318,9 +316,7 @@ def test_read_bounds_mask_invalid(naturalearth_lowres, mask):
         read_bounds(naturalearth_lowres, mask=mask)
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 def test_read_bounds_bbox_mask_invalid(naturalearth_lowres):
     with pytest.raises(ValueError, match="cannot set both 'bbox' and 'mask'"):
         read_bounds(
@@ -328,9 +324,7 @@ def test_read_bounds_bbox_mask_invalid(naturalearth_lowres):
         )
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 @pytest.mark.parametrize(
     "mask,expected",
     [

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -117,9 +117,7 @@ def test_read_no_geometry(naturalearth_lowres):
     assert geometry is None
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 def test_read_no_geometry__mask(naturalearth_lowres):
     geometry, fields = read(
         naturalearth_lowres,

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -26,6 +26,7 @@ from pyogrio.tests.conftest import (
     prepare_testfile,
     requires_pyarrow_api,
     requires_arrow_api,
+    requires_shapely,
 )
 
 try:
@@ -255,9 +256,7 @@ def test_read_bbox_where(naturalearth_lowres_all_ext):
     assert np.array_equal(fields[3], ["CAN"])
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 @pytest.mark.parametrize(
     "mask",
     [
@@ -271,17 +270,13 @@ def test_read_mask_invalid(naturalearth_lowres, mask):
         read(naturalearth_lowres, mask=mask)
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 def test_read_bbox_mask_invalid(naturalearth_lowres):
     with pytest.raises(ValueError, match="cannot set both 'bbox' and 'mask'"):
         read(naturalearth_lowres, bbox=(-85, 8, -80, 10), mask=shapely.Point(-105, 55))
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 @pytest.mark.parametrize(
     "mask,expected",
     [
@@ -316,9 +311,7 @@ def test_read_mask(naturalearth_lowres_all_ext, mask, expected):
     assert len(geometry) == len(expected)
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 def test_read_mask_sql(naturalearth_lowres_all_ext):
     fields = read(
         naturalearth_lowres_all_ext,
@@ -329,9 +322,7 @@ def test_read_mask_sql(naturalearth_lowres_all_ext):
     assert np.array_equal(fields[3], ["CAN"])
 
 
-@pytest.mark.skipif(
-    not HAS_SHAPELY, reason="Shapely is required for mask functionality"
-)
+@requires_shapely
 def test_read_mask_where(naturalearth_lowres_all_ext):
     fields = read(
         naturalearth_lowres_all_ext,


### PR DESCRIPTION
We were already using `requires_shapely` test mark for several tests, but not tests that used the `mask` parameter.