### PR TITLE
FIX: Raise NotImplementedError if user passes an open file handle to write

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 -   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
 -   Enable mask & bbox filter when geometry column not read (#431).
--   Raise NotImplmentedError when user attempts to write to an open file handle.
+-   Raise NotImplmentedError when user attempts to write to an open file handle (#442).
 
 ## 0.9.0 (2024-06-17)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@
 ### Bug fixes
 
 -   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
--   BUG: Enable mask & bbox filter when geometry column not read (#431).
+-   Enable mask & bbox filter when geometry column not read (#431).
+-   Raise NotImplmentedError when user attempts to write to an open file handle.
 
 ## 0.9.0 (2024-06-17)
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -360,7 +360,8 @@ def write_dataframe(
         in the output file.
     path : str or io.BytesIO
         path to output file on writeable file system or an io.BytesIO object to
-        allow writing to memory
+        allow writing to memory.  Will raise NotImplementedError if an open file
+        handle is passed; use BytesIO instead.
         NOTE: support for writing to memory is limited to specific drivers.
     layer : str, optional (default: None)
         layer name to create.  If writing to memory and layer name is not

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -537,8 +537,6 @@ def _get_write_path_driver(path, driver, append=False):
     (path, driver)
     """
 
-    print("type", type(path), hasattr(path, "write"), isinstance(path, Path))
-
     if isinstance(path, BytesIO):
         if driver is None:
             raise ValueError("driver must be provided to write to in-memory file")

--- a/pyogrio/raw.py
+++ b/pyogrio/raw.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 import warnings
 
 from pyogrio._env import GDALEnv
@@ -522,7 +523,8 @@ def _get_write_path_driver(path, driver, append=False):
     ----------
     path : str or io.BytesIO
         path to output file on writeable file system or an io.BytesIO object to
-        allow writing to memory
+        allow writing to memory.  Will raise NotImplementedError if an open file
+        handle is passed.
     driver : str, optional (default: None)
         The OGR format driver used to write the vector file. By default attempts
         to infer driver from path.  Must be provided to write to a file-like
@@ -534,6 +536,8 @@ def _get_write_path_driver(path, driver, append=False):
     -------
     (path, driver)
     """
+
+    print("type", type(path), hasattr(path, "write"), isinstance(path, Path))
 
     if isinstance(path, BytesIO):
         if driver is None:
@@ -553,6 +557,11 @@ def _get_write_path_driver(path, driver, append=False):
 
         if append:
             raise NotImplementedError("append is not supported for in-memory files")
+
+    elif hasattr(path, "write") and not isinstance(path, Path):
+        raise NotImplementedError(
+            "writing to an open file handle is not yet supported; instead, write to a BytesIO instance and then read bytes from that to write to the file handle"
+        )
 
     else:
         path = vsi_path(str(path))
@@ -605,7 +614,8 @@ def write(
     ----------
     path : str or io.BytesIO
         path to output file on writeable file system or an io.BytesIO object to
-        allow writing to memory
+        allow writing to memory.  Will raise NotImplementedError if an open file
+        handle is passed; use BytesIO instead.
         NOTE: support for writing to memory is limited to specific drivers.
     geometry : ndarray of WKB encoded geometries or None
         If None, geometries will not be written to output file

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -946,6 +946,7 @@ def test_write_memory_existing_unsupported(naturalearth_lowres):
         )
 
 
+@requires_arrow_write_api
 def test_write_open_file_handle(tmp_path, naturalearth_lowres):
     """Verify that writing to an open file handle is not currently supported"""
 

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -5,6 +5,7 @@ import math
 import os
 from packaging.version import Version
 import sys
+from zipfile import ZipFile
 
 import pytest
 import numpy as np
@@ -943,6 +944,44 @@ def test_write_memory_existing_unsupported(naturalearth_lowres):
             geometry_type=meta["geometry_type"],
             geometry_name=meta["geometry_name"] or "wkb_geometry",
         )
+
+
+def test_write_open_file_handle(tmp_path, naturalearth_lowres):
+    """Verify that writing to an open file handle is not currently supported"""
+
+    meta, table = read_arrow(naturalearth_lowres, max_features=1)
+    meta["geometry_type"] = "MultiPolygon"
+
+    # verify it fails for regular file handle
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with open(tmp_path / "test.geojson", "wb") as f:
+            write_arrow(
+                table,
+                f,
+                driver="GeoJSON",
+                layer="test",
+                crs=meta["crs"],
+                geometry_type=meta["geometry_type"],
+                geometry_name=meta["geometry_name"] or "wkb_geometry",
+            )
+
+    # verify it fails for ZipFile
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with ZipFile(tmp_path / "test.geojson.zip", "w") as z:
+            with z.open("test.geojson", "w") as f:
+                write_arrow(
+                    table,
+                    f,
+                    driver="GeoJSON",
+                    layer="test",
+                    crs=meta["crs"],
+                    geometry_type=meta["geometry_type"],
+                    geometry_name=meta["geometry_name"] or "wkb_geometry",
+                )
 
 
 @requires_arrow_write_api

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from io import BytesIO
 import locale
 import warnings
+from zipfile import ZipFile
 
 import numpy as np
 import pytest
@@ -1969,6 +1970,27 @@ def test_write_memory_existing_unsupported(naturalearth_lowres):
         match="writing to existing in-memory object is not supported",
     ):
         write_dataframe(df.head(1), buffer, driver="GeoJSON", layer="test")
+
+
+def test_write_open_file_handle(tmp_path, naturalearth_lowres):
+    """Verify that writing to an open file handle is not currently supported"""
+
+    df = read_dataframe(naturalearth_lowres)
+
+    # verify it fails for regular file handle
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with open(tmp_path / "test.geojson", "wb") as f:
+            write_dataframe(df.head(1), f)
+
+    # verify it fails for ZipFile
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with ZipFile(tmp_path / "test.geojson.zip", "w") as z:
+            with z.open("test.geojson", "w") as f:
+                write_dataframe(df.head(1), f)
 
 
 @pytest.mark.parametrize("ext", ["gpkg", "geojson"])

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -3,6 +3,7 @@ import ctypes
 from io import BytesIO
 import json
 import sys
+from zipfile import ZipFile
 
 import numpy as np
 from numpy import array_equal
@@ -1169,6 +1170,27 @@ def test_write_memory_existing_unsupported(naturalearth_lowres):
         match="writing to existing in-memory object is not supported",
     ):
         write(buffer, geometry, field_data, driver="GeoJSON", layer="test", **meta)
+
+
+def test_write_open_file_handle(tmp_path, naturalearth_lowres):
+    """Verify that writing to an open file handle is not currently supported"""
+
+    meta, _, geometry, field_data = read(naturalearth_lowres)
+
+    # verify it fails for regular file handle
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with open(tmp_path / "test.geojson", "wb") as f:
+            write(f, geometry, field_data, driver="GeoJSON", layer="test", **meta)
+
+    # verify it fails for ZipFile
+    with pytest.raises(
+        NotImplementedError, match="writing to an open file handle is not yet supported"
+    ):
+        with ZipFile(tmp_path / "test.geojson.zip", "w") as z:
+            with z.open("test.geojson", "w") as f:
+                write(f, geometry, field_data, driver="GeoJSON", layer="test", **meta)
 
 
 @pytest.mark.parametrize("ext", ["fgb", "gpkg", "geojson"])


### PR DESCRIPTION
As indicated in #430 and [geopandas #3369](https://github.com/geopandas/geopandas/discussions/3369), if a user passed an open file handle to write, we were failing with confusing error messages.  While the docstrings in pyogrio specify the allowed inputs, we weren't strictly verifying those, and so any path that was not BytesIO was first getting cast to a string, and then failing badly from there.

These usages worked for users with the Fiona engine (previous default) in GeoPandas, so it is proving to be a point of confusion now that Pyogrio is the default engine and things are no longer working as expected.

In most cases, writing the dataset to BytesIO and then writing those bytes to the file handle (regular file handle via `open`, an fsspec opened file handle, or an open handle within a `ZipFile`), so the error message includes a brief instruction to do that instead.  That also helps defer catching issues around supported drivers and lack of append support to the BytesIO handler.

In the mid term, we may be able to detect that the user passed a writeable file handle, and wrap in BytesIO ourselves, but this is more involved than I had time to take on at the moment.