### PR TITLE
Fix reading from zstd decompression stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 -   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
 -   BUG: Enable mask & bbox filter when geometry column not read (#431).
+-   Prevent seek on read from compressed inputs (#443).
 
 ## 0.9.0 (2024-06-17)
 

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -168,6 +168,12 @@ def test_read_arrow_bytes(geojson_bytes):
     assert len(table) == 3
 
 
+def test_read_arrow_nonseekable_bytes(nonseekable_bytes):
+    meta, table = read_arrow(nonseekable_bytes)
+    assert meta["fields"].shape == (0,)
+    assert len(table) == 1
+
+
 def test_read_arrow_filelike(geojson_filelike):
     meta, table = read_arrow(geojson_filelike)
 

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -184,6 +184,13 @@ def test_list_layers_bytes(geojson_bytes):
     assert layers[0, 0] == "test"
 
 
+def test_list_layers_nonseekable_bytes(nonseekable_bytes):
+    layers = list_layers(nonseekable_bytes)
+
+    assert layers.shape == (1, 2)
+    assert layers[0, 1] == "Point"
+
+
 def test_list_layers_filelike(geojson_filelike):
     layers = list_layers(geojson_filelike)
 
@@ -216,6 +223,13 @@ def test_read_bounds_bytes(geojson_bytes):
     assert fids.shape == (3,)
     assert bounds.shape == (4, 3)
     assert allclose(bounds[:, 0], [-180.0, -18.28799, 180.0, -16.02088])
+
+
+def test_read_bounds_nonseekable_bytes(nonseekable_bytes):
+    fids, bounds = read_bounds(nonseekable_bytes)
+    assert fids.shape == (1,)
+    assert bounds.shape == (4, 1)
+    assert allclose(bounds[:, 0], [1, 1, 1, 1])
 
 
 def test_read_bounds_filelike(geojson_filelike):
@@ -447,6 +461,13 @@ def test_read_info_bytes(geojson_bytes):
 
     assert meta["fields"].shape == (5,)
     assert meta["features"] == 3
+
+
+def test_read_info_nonseekable_bytes(nonseekable_bytes):
+    meta = read_info(nonseekable_bytes)
+
+    assert meta["fields"].shape == (0,)
+    assert meta["features"] == 1
 
 
 def test_read_info_filelike(geojson_filelike):

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -819,6 +819,12 @@ def test_read_from_file_like(tmp_path, naturalearth_lowres, driver, ext):
     assert_equal_result((meta, index, geometry, field_data), result2)
 
 
+def test_read_from_nonseekable_bytes(nonseekable_bytes):
+    meta, _, geometry, _ = read(nonseekable_bytes)
+    assert meta["fields"].shape == (0,)
+    assert len(geometry) == 1
+
+
 @pytest.mark.parametrize("ext", ["gpkg", "fgb"])
 def test_read_write_data_types_numeric(tmp_path, ext):
     # Point(0, 0)

--- a/pyogrio/util.py
+++ b/pyogrio/util.py
@@ -38,7 +38,7 @@ def get_vsi_path_or_buffer(path_or_buffer):
         bytes_buffer = path_or_buffer.read()
 
         # rewind buffer if possible so that subsequent operations do not need to rewind
-        if hasattr(path_or_buffer, "seek"):
+        if hasattr(path_or_buffer, "seekable") and path_or_buffer.seekable():
             path_or_buffer.seek(0)
 
         return bytes_buffer


### PR DESCRIPTION
Since 0.8.0 reading a zstandard compressed file does not work anymore. The following code works in 0.7.2, but not in 0.8.0 and 0.9.0:

``` python
import geopandas as gpd
import zstandard
import io

# make an uncompressed.geojson and a compressed.geojson.zst (fixture)
gdf = gpd.GeoDataFrame(geometry=[Point(4, 2), Point(4, 2)])

gdf.to_file('uncompressed.geojson', driver='GeoJSON')

with open('uncompressed.geojson', 'rb') as ro:
    content = ro.read()

compressed_content = zstandard.compress(content)
with open('compressed.geojson.zst', 'wb') as w:
    w.write(compressed_content)

# try to read geojson from BytesIO
# works in 0.7.2 and 0.9.0
with open('uncompressed.geojson', 'rb') as fh:
    mem = io.BytesIO(fh.read())

gdf = gpd.read_file(mem)
print(gdf)

# try to read geojson from file handle
# works in 0.7.2 and 0.9.0
with open('uncompressed.geojson', 'rb') as fh:
    gdf = gpd.read_file(fh)

print(gdf)


# try to read geojson from zstandard decompression stream
# works in 0.7.2, but not in 0.9.0
with open('compressed.geojson.zst', 'rb') as fh:
    dctx = zstandard.ZstdDecompressor()
    with dctx.stream_reader(fh) as reader:
        gdf = gpd.read_file(reader)

print(gdf)
```

The last test results in the stack trace:
``` output
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/usr/local/lib/python3.11/dist-packages/geopandas/io/file.py", line 294, in _read_file
    return _read_file_pyogrio(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/geopandas/io/file.py", line 547, in _read_file_pyogrio
    return pyogrio.read_dataframe(path_or_bytes, bbox=bbox, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pyogrio/geopandas.py", line 252, in read_dataframe
    result = read_func(
             ^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pyogrio/raw.py", line 197, in read
    get_vsi_path_or_buffer(path_or_buffer),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pyogrio/util.py", line 43, in get_vsi_path_or_buffer
    path_or_buffer.seek(0)
OSError: cannot seek zstd decompression stream backwards
```

A zstd decompression stream can be seeked [only forwards](https://python-zstandard.readthedocs.io/en/latest/decompressor.html#zstddecompressionreader), but not backwards. [Hence](https://docs.python.org/3/library/io.html#io.IOBase.seekable) its seekable method returns `False`. The issue has been introduced in #397.

This PR fixes it. Instead of only checking, whether the `seek` method exists, this PR checks whether the `seekable` method exists and returns `True`. Only then `seek(0)` is used.

Do you want me to add any test cases for this? If so, based on `zstandard`?