### PR TITLE
MAINT: avoid tests to run if linting fails

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -1,11 +1,6 @@
 name: Docker GDAL Test
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+on: [workflow_call]  # will be called from lint workflow.
 
 # cancel running jobs on new commit to PR
 concurrency:
@@ -13,11 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml  # use the callable lint job to lint
-
   TestLinux:
-    needs: [lint]  # require linting to pass before tests run
     name: GDAL ${{ matrix.container }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -1,14 +1,14 @@
-name: Docker GDAL Test
+name: Docker GDAL Tests
 
 on: [workflow_call]  # will be called from lint workflow.
 
 # cancel running jobs on new commit to PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: Tests-docker-gdal-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  TestLinux:
+  Tests-docker-gdal:
     name: GDAL ${{ matrix.container }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -1,4 +1,4 @@
-name: Docker GDAL Tests
+name: Docker GDAL Test
 
 on: [workflow_call]  # will be called from lint workflow.
 

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -13,7 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml  # use the callable lint job to lint
+
   TestLinux:
+    needs: [lint]  # require linting to pass before tests run
     name: GDAL ${{ matrix.container }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,6 @@
 name: Linting
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+on: [workflow_call]  # Linting will be called from the test workflows.
 
 jobs:
   Linting:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,11 @@ jobs:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
 
-  Tests-conda:
+  Call-tests-conda:
     needs: [Linting]  # require linting to pass before tests run
     uses: ./.github/workflows/tests-conda.yml
   
-  Tests-docker-gdal:
+  Call-tests-docker-gdal:
     needs: [Linting]  # require linting to pass before tests run
     uses: ./.github/workflows/docker-gdal.yml
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Linting
 
-on: [workflow_call]  # Linting will be called from the test workflows.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   Linting:
@@ -12,3 +17,12 @@ jobs:
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
+
+  Tests-conda:
+    needs: [Linting]  # require linting to pass before tests run
+    uses: ./.github/workflows/tests-conda.yml
+  
+  Tests-docker-gdal:
+    needs: [Linting]  # require linting to pass before tests run
+    uses: ./.github/workflows/docker-gdal.yml
+  

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -13,7 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml  # use the callable lint job to lint
+
   test:
+    needs: [lint]  # require linting to pass before tests run
     name: ${{ matrix.os }}, python ${{ matrix.python }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -1,11 +1,6 @@
 name: Conda Tests
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+on: [workflow_call]  # will be called from lint workflow.
 
 # cancel running jobs on new commit to PR
 concurrency:
@@ -13,11 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml  # use the callable lint job to lint
-
   test:
-    needs: [lint]  # require linting to pass before tests run
     name: ${{ matrix.os }}, python ${{ matrix.python }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -4,11 +4,11 @@ on: [workflow_call]  # will be called from lint workflow.
 
 # cancel running jobs on new commit to PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: Tests-conda-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  Tests-conda:
     name: ${{ matrix.os }}, python ${{ matrix.python }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
I noticed the tests run even if the linting fails, which not needed.

This PR changes this so the lint workflow triggers both test workflows if the linting is ready.