### PR TITLE
Remove unnecessary build requirement

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          uv pip install pip wheel
           uv pip install -e .[dev,test,geopandas]
 
       - name: Install pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
     "Cython>=0.29",
     "versioneer[toml]==0.28",
     # tomli is used by versioneer


### PR DESCRIPTION
I recall `wheel` being listed in instructions somewhere (maybe for `setuptools`), but it wasn't, and isn't, necessary.