### PR TITLE
CI: disable caching of conda env so most recent versions of dependencies are used

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -56,7 +56,6 @@ jobs:
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}
-          cache-environment: true
 
       - name: Set environment variables (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
The caching results in older depencencies being used for long times, so incompatibilities with new versions not raised asap.

Reference https://github.com/geopandas/pyogrio/pull/452, where conda tests keep failing as the newest version of shapely, 2.0.6 , is not picked up due to the caching. In this PR shapely 2.0.6 is immediately picked up.