### PR TITLE
Exclude development files from wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,7 @@ setup(
         "geopandas": ["geopandas"],
     },
     include_package_data=True,
+    exclude_package_data={'': ['*.h', '_*.pxd', '_*.pyx']},
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     package_data=package_data,


### PR DESCRIPTION
The Cython files are private (`_`-prefixed), so probably shouldn't be used by downstreams.