### PR TITLE
BLD: update docker image tags for linux wheel building

### DIFF
--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64:2024-04-15-dd44d68
+FROM quay.io/pypa/manylinux2014_x86_64:2024-08-12-7fde9b1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN yum install -y curl unzip zip tar perl-IPC-Cmd

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_aarch64:2024-04-15-dd44d68
+FROM quay.io/pypa/manylinux_2_28_aarch64:2024-08-12-7fde9b1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd


### PR DESCRIPTION
I know this is also being handled in https://github.com/geopandas/pyogrio/pull/451, but I _think_ that simply updating the docker images might be sufficient to at least get green CI in the meantime