### PR TITLE
MAINT: move generic project settings to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,35 @@ requires = [
     "tomli; python_version < '3.11'",
 ]
 
+[project]
+name = "pyogrio"
+dynamic = ["version"]
+authors = [{ name = "Brendan C. Ward", email = "bcward@astutespruce.com" }]
+maintainers = [{ name = "pyogrio contributors" }]
+license = { text = "MIT License" }
+description = "Vectorized spatial vector file format I/O using GDAL/OGR"
+readme = "README.md"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: GIS",
+]
+requires-python = ">=3.8"
+dependencies = ["certifi", "numpy", "packaging"]
+
+[project.optional-dependencies]
+dev = ["cython"]
+test = ["pytest", "pytest-cov"]
+benchmark = ["pytest-benchmark"]
+geopandas = ["geopandas"]
+
+[project.urls]
+Home = "https://pyogrio.readthedocs.io/"
+Repository = "https://github.com/geopandas/pyogrio"
+
 [tool.cibuildwheel]
 skip = ["cp36-*", "cp37-*", "pp*", "*musllinux*"]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyogrio"
 dynamic = ["version"]
-authors = [{ name = "Brendan C. Ward", email = "bcward@astutespruce.com" }, { name = "pyogrio contributors" }]
+authors = [
+    { name = "Brendan C. Ward", email = "bcward@astutespruce.com" },
+    { name = "pyogrio contributors" }
+]
 maintainers = [{ name = "pyogrio contributors" }]
 license = { file = "LICENSE" }
 description = "Vectorized spatial vector file format I/O using GDAL/OGR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "pyogrio"
 dynamic = ["version"]
 authors = [{ name = "Brendan C. Ward", email = "bcward@astutespruce.com" }]
 maintainers = [{ name = "pyogrio contributors" }]
-license = { text = "MIT License" }
+license = { file = "LICENSE" }
 description = "Vectorized spatial vector file format I/O using GDAL/OGR"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     # tomli is used by versioneer
     "tomli; python_version < '3.11'",
 ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyogrio"
@@ -37,7 +38,7 @@ Home = "https://pyogrio.readthedocs.io/"
 Repository = "https://github.com/geopandas/pyogrio"
 
 [tool.cibuildwheel]
-skip = ["cp36-*", "cp37-*", "pp*", "*musllinux*"]
+skip = ["pp*", "*musllinux*"]
 archs = ["auto64"]
 manylinux-x86_64-image = "manylinux-vcpkg-gdal:latest"
 manylinux-aarch64-image = "manylinux-aarch64-vcpkg-gdal:latest"
@@ -92,7 +93,6 @@ tag_prefix = "v"
 [tool.ruff]
 line-length = 88
 extend-exclude = ["doc/*", "benchmarks/*", "pyogrio/_version.py"]
-target-version = "py38"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyogrio"
 dynamic = ["version"]
-authors = [{ name = "Brendan C. Ward", email = "bcward@astutespruce.com" }]
+authors = [{ name = "Brendan C. Ward", email = "bcward@astutespruce.com" }, { name = "pyogrio contributors" }]
 maintainers = [{ name = "pyogrio contributors" }]
 license = { file = "LICENSE" }
 description = "Vectorized spatial vector file format I/O using GDAL/OGR"

--- a/setup.py
+++ b/setup.py
@@ -202,24 +202,8 @@ cmdclass = versioneer.get_cmdclass()
 cmdclass["build_ext"] = build_ext
 
 setup(
-    name="pyogrio",
     version=version,
     packages=find_packages(),
-    url="https://github.com/geopandas/pyogrio",
-    license="MIT",
-    author="Brendan C. Ward",
-    author_email="bcward@astutespruce.com",
-    description="Vectorized spatial vector file format I/O using GDAL/OGR",
-    long_description_content_type="text/markdown",
-    long_description=open("README.md").read(),
-    python_requires=">=3.8",
-    install_requires=["certifi", "numpy", "packaging"],
-    extras_require={
-        "dev": ["Cython"],
-        "test": ["pytest", "pytest-cov"],
-        "benchmark": ["pytest-benchmark"],
-        "geopandas": ["geopandas"],
-    },
     include_package_data=True,
     exclude_package_data={'': ['*.h', '_*.pxd', '_*.pyx']},
     cmdclass=cmdclass,


### PR DESCRIPTION
This moves the generic project settings to the `pyproject.toml` `[project]` table, for now leaving setuptools specific ones in the setup.py file.

All info is just moved 1:1, except for the few things I commented about below.

I built the sdist and wheel locally, and that looked all good.