### PR TITLE
DOC: Add install note re: advanced drivers on conda-forge

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -24,6 +24,11 @@ This requires compatible versions of `GDAL` and `numpy` from `conda-forge` for
 raw I/O support and `geopandas` and their dependencies for GeoDataFrame
 I/O support.
 
+To enable additional GDAL divers, you may need to install them directly:
+
+-   LIBKML: [libkml](https://anaconda.org/conda-forge/libkml)
+-   Spatialite: [libspatialite](https://anaconda.org/conda-forge/libspatialite)
+
 ### PyPI
 
 This package is available on [PyPI](https://pypi.org/project/pyogrio/) for Linux,
@@ -39,6 +44,11 @@ If you get installation errors about Cython or GDAL not being available, this is
 most likely due to the installation process falling back to installing from the
 source distribution because the available wheels are not compatible with your
 platform.
+
+The binary wheels available on PyPI include the core GDAL drivers (GeoJSON,
+ESRI Shapefile, GPKG, FGB, OpenFileGDB, etc) but do not include more advanced
+drivers such as LIBKML and Spatialite. Use conda-forge to install pyogrio and
+then install these additional drivers directly.
 
 ### Troubleshooting installation errors
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -22,15 +22,15 @@ conda install -c conda-forge pyogrio
 
 This requires compatible versions of `GDAL` and `numpy` from `conda-forge` for
 raw I/O support and `geopandas` and their dependencies for GeoDataFrame
-I/O support.
+I/O support. By default, the `GDAL` package on conda-forge already supports a
+wide range of vector formats. If needed, you can install additional drivers by
+installing the associated
+[conda-forge package](https://gdal.org/en/latest/download.html#conda). The
+following packages are currently available to install extra vector drivers:
 
-By default, the `GDAL` package on conda-forge currently includes LIBKML and
-Spatialite. However, you may need to install additional drivers by installing
-the associated [conda-forge package](https://gdal.org/en/latest/download.html#conda):
-
--   `libgdal-arrow-parquet`
--   `libgdal-pg`
--   `libgdal-xls`
+-   `libgdal-arrow-parquet` ((Geo)Parquet and (Geo)Arrow IPC)
+-   `libgdal-pg` (PostgreSQL / PostGIS)
+-   `libgdal-xls` (XLS - MS Excel format)
 
 ### PyPI
 
@@ -50,8 +50,8 @@ platform.
 
 The binary wheels available on PyPI include the core GDAL drivers (GeoJSON,
 ESRI Shapefile, GPKG, FGB, OpenFileGDB, etc) but do not include more advanced
-drivers such as LIBKML and Spatialite. Use conda-forge to install pyogrio and
-then install these additional drivers directly if needed.
+drivers such as LIBKML and Spatialite. If you need such drivers, we recommend
+that you use conda-forge to install pyogrio as explained above.
 
 ### Troubleshooting installation errors
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -24,10 +24,13 @@ This requires compatible versions of `GDAL` and `numpy` from `conda-forge` for
 raw I/O support and `geopandas` and their dependencies for GeoDataFrame
 I/O support.
 
-To enable additional GDAL divers, you may need to install them directly:
+By default, the `GDAL` package on conda-forge currently includes LIBKML and
+Spatialite. However, you may need to install additional drivers by installing
+the associated [conda-forge package](https://gdal.org/en/latest/download.html#conda):
 
--   LIBKML: [libkml](https://anaconda.org/conda-forge/libkml)
--   Spatialite: [libspatialite](https://anaconda.org/conda-forge/libspatialite)
+-   `libgdal-arrow-parquet`
+-   `libgdal-pg`
+-   `libgdal-xls`
 
 ### PyPI
 
@@ -48,7 +51,7 @@ platform.
 The binary wheels available on PyPI include the core GDAL drivers (GeoJSON,
 ESRI Shapefile, GPKG, FGB, OpenFileGDB, etc) but do not include more advanced
 drivers such as LIBKML and Spatialite. Use conda-forge to install pyogrio and
-then install these additional drivers directly.
+then install these additional drivers directly if needed.
 
 ### Troubleshooting installation errors
 


### PR DESCRIPTION
Resolves #472, obviates #378.

It is potentially a bit confusing while we're still using `libgdal` on conda-forge, but I think these may need to be installed once we switch to `libgdal-core`.