### PR TITLE
CI: Try to resolve mamba install issue on windows when using with pip

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -49,10 +49,21 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install Conda environment with Micromamba
+      - name: Install Conda environment with Micromamba (Linux/MacOS)
+        if: runner.os != 'Windows'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/envs/${{ matrix.env }}.yml
+          create-args: >-
+            python=${{ matrix.python }}
+            ${{ matrix.extra }}
+
+      - name: Install Conda environment with Micromamba (Windows)p
+        if: runner.os == 'Windows'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: ci/envs/${{ matrix.env }}.yml
+          mamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -63,7 +63,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/envs/${{ matrix.env }}.yml
-          mamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
+          micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           environment-file: ci/envs/${{ matrix.env }}.yml
           micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
+          micromamba-root-path: ${{ runner.temp }}\micromamba
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -49,22 +49,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install Conda environment with Micromamba (Linux/MacOS)
-        if: runner.os != 'Windows'
+      - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/envs/${{ matrix.env }}.yml
-          create-args: >-
-            python=${{ matrix.python }}
-            ${{ matrix.extra }}
-
-      - name: Install Conda environment with Micromamba (Windows)p
-        if: runner.os == 'Windows'
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: ci/envs/${{ matrix.env }}.yml
-          micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
-          micromamba-root-path: ${{ runner.temp }}\micromamba
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}

--- a/ci/envs/libgdal3.5.1.yml
+++ b/ci/envs/libgdal3.5.1.yml
@@ -5,8 +5,3 @@ dependencies:
   - numpy
   - libgdal==3.5.1
   - pytest
-  - geopandas-base
-  - pip
-  - pip:
-      # install Shapely >= 2.0 using pip because it is not available on conda-forge for above libgdal
-      - shapely>=2


### PR DESCRIPTION
The windows conda-forge test runner fails for the `libgdal3.5.1` env when using `pip` to install shapely.  It looks like an issue with where the mamba executables are installed.