### PR TITLE
ENH: raise specific error when trying to read non-UTF-8 file with use_arrow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ### Improvements
 
 -   Add support to read, write, list, and remove `/vsimem/` files (#457).
+-   Raise specific error when trying to read non-UTF-8 file with
+    `use_arrow=True` (#490).
 
 ### Bug fixes
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -289,7 +289,15 @@ def read_dataframe(
         kwargs = {"self_destruct": True}
         if arrow_to_pandas_kwargs is not None:
             kwargs.update(arrow_to_pandas_kwargs)
-        df = table.to_pandas(**kwargs)
+
+        try:
+            df = table.to_pandas(**kwargs)
+        except UnicodeDecodeError as ex:
+            # Arrow does not support reading data in a non-UTF-8 encoding
+            raise DataSourceError(
+                "The file being read is not encoded in UTF-8; please use_arrow=False"
+            ) from ex
+
         del table
 
         if fid_as_index:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -140,19 +140,18 @@ def test_read_csv_platform_encoding(tmp_path, use_arrow):
         csv.write("Wilhelm Röntgen,Zürich\n")
 
     if use_arrow:
-        handler = pytest.raises(
-            DataSourceError, match="The file being read is not encoded in UTF-8"
-        )
+        with pytest.raises(
+            DataSourceError,
+            match="; please use_arrow=False",
+        ):
+            df = read_dataframe(csv_path, use_arrow=use_arrow)
     else:
-        handler = contextlib.nullcontext()
-
-    with handler:
         df = read_dataframe(csv_path, use_arrow=use_arrow)
 
-    assert len(df) == 1
-    assert df.columns.tolist() == ["näme", "city"]
-    assert df.city.tolist() == ["Zürich"]
-    assert df.näme.tolist() == ["Wilhelm Röntgen"]
+        assert len(df) == 1
+        assert df.columns.tolist() == ["näme", "city"]
+        assert df.city.tolist() == ["Zürich"]
+        assert df.näme.tolist() == ["Wilhelm Röntgen"]
 
 
 def test_read_dataframe(naturalearth_lowres_all_ext):
@@ -2194,7 +2193,10 @@ def test_non_utf8_encoding_io_shapefile(tmp_path, encoded_text, use_arrow):
 
     if use_arrow:
         # pyarrow cannot decode column name with incorrect encoding
-        with pytest.raises(UnicodeDecodeError):
+        with pytest.raises(
+            DataSourceError,
+            match="The file being read is not encoded in UTF-8; please use_arrow=False",
+        ):
             read_dataframe(output_path, use_arrow=True)
     else:
         bad = read_dataframe(output_path, use_arrow=False)


### PR DESCRIPTION
Reading non-UTF-8 encoded files (e.g. .csv or .shp files) with `use_arrow=True` is not supported, but it is typically supported with `use_arrow=False`.

This PR changes the exception thrown so the advice to use `use_arrow=False` is given when appropriate:
``` python
raise DataSourceError("The file being read is not encoded in UTF-8; please use_arrow=False")
```