### PR TITLE
ENH: capture all errors logged by gdal when opening a file fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 
 -   Silence warning from `write_dataframe` with `GeoSeries.notna()` (#435).
 -   Enable mask & bbox filter when geometry column not read (#431).
--   Raise NotImplmentedError when user attempts to write to an open file handle (#442).
+-   Raise `NotImplementedError` when user attempts to write to an open file handle (#442).
 -   Prevent seek on read from compressed inputs (#443).
 
 ### Packaging

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.11.0 (????-??-??)
+
+### Improvements
+
+-   Capture all errors logged by gdal when opening a file fails (#495).
+
 ## 0.10.0 (2024-09-28)
 
 ### Improvements

--- a/pyogrio/_compat.py
+++ b/pyogrio/_compat.py
@@ -40,6 +40,7 @@ PANDAS_GE_15 = pandas is not None and Version(pandas.__version__) >= Version("1.
 PANDAS_GE_20 = pandas is not None and Version(pandas.__version__) >= Version("2.0.0")
 PANDAS_GE_22 = pandas is not None and Version(pandas.__version__) >= Version("2.2.0")
 
+GDAL_GE_352 = __gdal_version__ >= (3, 5, 2)
 GDAL_GE_38 = __gdal_version__ >= (3, 8, 0)
 
 HAS_GDAL_GEOS = __gdal_geos_version__ is not None

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -1,6 +1,5 @@
 cdef object check_last_error()
 cdef int check_int(int retval) except -1
-cdef int check_ogrerr(int retval) except -1
 cdef void *check_pointer(void *ptr) except NULL
 
 cdef class ErrorHandler:

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -6,3 +6,4 @@ cdef class ErrorHandler:
     cdef object error_stack
     cdef int check_int(self, int retval, bint squash_errors) except -1
     cdef void *check_pointer(self, void *ptr, bint squash_errors) except NULL
+    cdef void _handle_error_stack(self, bint squash_errors)

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -3,7 +3,7 @@ cdef int exc_wrap_int(int retval) except -1
 cdef int exc_wrap_ogrerr(int retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL
 
-cdef class StackChecker:
+cdef class ErrorHandler:
     cdef object error_stack
     cdef int exc_wrap_int(self, int retval) except -1
     cdef void *exc_wrap_pointer(self, void *ptr) except NULL

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -5,5 +5,5 @@ cdef void *check_pointer(void *ptr) except NULL
 
 cdef class ErrorHandler:
     cdef object error_stack
-    cdef int check_int(self, int retval) except -1
-    cdef void *check_pointer(self, void *ptr) except NULL
+    cdef int check_int(self, int retval, bint squash_errors) except -1
+    cdef void *check_pointer(self, void *ptr, bint squash_errors) except NULL

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -1,9 +1,9 @@
-cdef object exc_check()
-cdef int exc_wrap_int(int retval) except -1
-cdef int exc_wrap_ogrerr(int retval) except -1
-cdef void *exc_wrap_pointer(void *ptr) except NULL
+cdef object check_last_error()
+cdef int check_int(int retval) except -1
+cdef int check_ogrerr(int retval) except -1
+cdef void *check_pointer(void *ptr) except NULL
 
 cdef class ErrorHandler:
     cdef object error_stack
-    cdef int exc_wrap_int(self, int retval) except -1
-    cdef void *exc_wrap_pointer(self, void *ptr) except NULL
+    cdef int check_int(self, int retval) except -1
+    cdef void *check_pointer(self, void *ptr) except NULL

--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -2,3 +2,8 @@ cdef object exc_check()
 cdef int exc_wrap_int(int retval) except -1
 cdef int exc_wrap_ogrerr(int retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL
+
+cdef class StackChecker:
+    cdef object error_stack
+    cdef int exc_wrap_int(self, int retval) except -1
+    cdef void *exc_wrap_pointer(self, void *ptr) except NULL

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -428,7 +428,6 @@ cdef void stacking_error_handler(
     elif err_class == CE_Failure:
         # For Failures, add them to the error exception stack
         with gil:
-            global _ERROR_STACK
             stack = _ERROR_STACK.get()
             stack.append(
                 exception_map.get(err_no, CPLE_BaseError)(
@@ -460,7 +459,6 @@ def capture_errors():
     if any were captured.
     """
     CPLErrorReset()
-    global _ERROR_STACK
     _ERROR_STACK.set([])
 
     # stacking_error_handler records GDAL errors in the order they occur and

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -10,9 +10,9 @@ from itertools import zip_longest
 
 from pyogrio._ogr cimport (
     CE_None, CE_Debug, CE_Warning, CE_Failure, CE_Fatal, CPLErrorReset,
-    CPLGetLastErrorType, CPLGetLastErrorNo, CPLGetLastErrorMsg, OGRErr, OGRERR_NONE,
-    CPLErr, CPLErrorHandler, CPLDefaultErrorHandler, CPLPopErrorHandler,
-    CPLPushErrorHandler, CPLPushErrorHandlerEx)
+    CPLGetLastErrorType, CPLGetLastErrorNo, CPLGetLastErrorMsg, OGRErr,
+    OGRERR_NONE, CPLErr, CPLErrorHandler, CPLDefaultErrorHandler,
+    CPLPopErrorHandler, CPLPushErrorHandler)
 
 _ERROR_STACK = ContextVar("error_stack")
 _ERROR_STACK.set([])

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -162,43 +162,6 @@ exception_map = {
     17: CPLE_AWSError
 }
 
-cdef dict _CODE_MAP = {
-    0: 'CPLE_None',
-    1: 'CPLE_AppDefined',
-    2: 'CPLE_OutOfMemory',
-    3: 'CPLE_FileIO',
-    4: 'CPLE_OpenFailed',
-    5: 'CPLE_IllegalArg',
-    6: 'CPLE_NotSupported',
-    7: 'CPLE_AssertionFailed',
-    8: 'CPLE_NoWriteAccess',
-    9: 'CPLE_UserInterrupt',
-    10: 'ObjectNull',
-    11: 'CPLE_HttpResponse',
-    12: 'CPLE_AWSBucketNotFound',
-    13: 'CPLE_AWSObjectNotFound',
-    14: 'CPLE_AWSAccessDenied',
-    15: 'CPLE_AWSInvalidCredentials',
-    16: 'CPLE_AWSSignatureDoesNotMatch',
-    17: 'CPLE_AWSError'
-}
-
-
-cdef class GDALErrCtxManager:
-    """A manager for GDAL error handling contexts."""
-
-    def __enter__(self):
-        CPLErrorReset()
-        return self
-
-    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
-        cdef int err_type = CPLGetLastErrorType()
-        cdef int err_no = CPLGetLastErrorNo()
-        cdef const char *msg = CPLGetLastErrorMsg()
-        # TODO: warn for err_type 2?
-        if err_type >= 2:
-            raise exception_map[err_no](err_type, err_no, msg)
-
 
 cdef inline object check_last_error():
     """Checks if the last GDAL error was a fatal or non-fatal error.
@@ -349,8 +312,6 @@ cdef void error_handler(CPLErr err_class, int err_no, const char* err_msg) noexc
 
 def _register_error_handler():
     CPLPushErrorHandler(<CPLErrorHandler>error_handler)
-
-cpl_errs = GDALErrCtxManager()
 
 
 cdef class ErrorHandler:

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -358,7 +358,7 @@ cdef void stacking_error_handler(
     CPLErr err_class,
     int err_no,
     const char* err_msg
-) noexcept with gil:
+) noexcept nogil:
     """Custom CPL error handler that adds non-fatal errors to a stack.
 
     All non-fatal errors (CE_Failure) are not printed to stderr (behaviour
@@ -367,31 +367,30 @@ cdef void stacking_error_handler(
 
     Warnings are converted to Python warnings.
     """
-    global _ERROR_STACK
-
     if err_class == CE_Fatal:
         # If the error class is CE_Fatal, we want to have a message issued
         # because the CPL support code does an abort() before any exception
         # can be generated
         CPLDefaultErrorHandler(err_class, err_no, err_msg)
-
         return
 
     elif err_class == CE_Failure:
         # For Failures, add them to the error exception stack
-        stack = _ERROR_STACK.get()
-        stack.append(
-            exception_map.get(err_no, CPLE_BaseError)(
-                err_class, err_no, clean_error_message(err_msg)
-            ),
-        )
-        _ERROR_STACK.set(stack)
+        with gil:
+            global _ERROR_STACK
+            stack = _ERROR_STACK.get()
+            stack.append(
+                exception_map.get(err_no, CPLE_BaseError)(
+                    err_class, err_no, clean_error_message(err_msg)
+                ),
+            )
+            _ERROR_STACK.set(stack)
 
         return
 
     elif err_class == CE_Warning:
-        warnings.warn(clean_error_message(err_msg), RuntimeWarning)
-
+        with gil:
+            warnings.warn(clean_error_message(err_msg), RuntimeWarning)
         return
 
     # Fall back to the default handler for non-failure messages since

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -4,7 +4,6 @@ Ported from fiona::_err.pyx
 """
 
 import contextlib
-import logging
 import warnings
 from contextvars import ContextVar
 from enum import IntEnum

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -162,7 +162,7 @@ cdef inline object check_last_error():
     """
     err_type = CPLGetLastErrorType()
     err_no = CPLGetLastErrorNo()
-    err_msg = get_last_error_msg()
+    err_msg = clean_error_message(CPLGetLastErrorMsg())
 
     if err_type == CE_Failure:
         CPLErrorReset()
@@ -174,17 +174,6 @@ cdef inline object check_last_error():
 
     else:
         return
-
-
-cdef get_last_error_msg():
-    """Checks GDAL error stack for the latest error message.
-
-    Returns
-    -------
-    An error message or empty string
-
-    """
-    return clean_error_message(CPLGetLastErrorMsg())
 
 
 cdef clean_error_message(const char* err_msg):

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -19,19 +19,6 @@ _ERROR_STACK = ContextVar("error_stack")
 _ERROR_STACK.set([])
 
 
-# CPL Error types as an enum.
-class GDALError(IntEnum):
-    """GDAL error types/classes.
-    
-    GDAL doc: https://gdal.org/en/latest/doxygen/cpl__error_8h.html#a463ba7c7202a505416ff95b1aeefa2de
-    """
-    none = CE_None
-    debug = CE_Debug
-    warning = CE_Warning
-    failure = CE_Failure
-    fatal = CE_Fatal
-
-
 class CPLE_BaseError(Exception):
     """Base CPL error class.
 

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -414,7 +414,7 @@ def capture_errors():
 
     # stacking_error_handler records GDAL errors in the order they occur and
     # converts them to exceptions.
-    CPLPushErrorHandlerEx(<CPLErrorHandler>stacking_error_handler, NULL)
+    CPLPushErrorHandler(<CPLErrorHandler>stacking_error_handler)
 
     # Run code in the `with` block.
     yield ErrorHandler(_ERROR_STACK)

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -6,7 +6,6 @@ Ported from fiona::_err.pyx
 import contextlib
 import warnings
 from contextvars import ContextVar
-from enum import IntEnum
 from itertools import zip_longest
 
 from pyogrio._ogr cimport (

--- a/pyogrio/_geometry.pyx
+++ b/pyogrio/_geometry.pyx
@@ -84,7 +84,7 @@ cdef str get_geometry_type(void *ogr_layer):
     cdef OGRwkbGeometryType ogr_type
 
     try:
-        ogr_featuredef = exc_wrap_pointer(OGR_L_GetLayerDefn(ogr_layer))
+        ogr_featuredef = check_pointer(OGR_L_GetLayerDefn(ogr_layer))
     except NullPointerError:
         raise DataLayerError("Could not get layer definition")
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -214,7 +214,7 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
 
     except NullPointerError:
         raise DataSourceError(
-            f"Failed to open dataset (mode={mode}): {path_c.decode('utf-8')}"
+            f"Failed to open dataset ({mode=}): {path_c.decode('utf-8')}"
         ) from None
 
     except CPLE_BaseError as exc:

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -218,15 +218,15 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         ) from None
 
     except CPLE_BaseError as exc:
-        if " a supported file format." in exc.errmsg:
+        if " a supported file format." in str(exc):
             # In gdal 3.9, this error message was slightly changed, so we can only check
             # on this part of the error message.
             raise DataSourceError(
-                f"{exc.errmsg}; It might help to specify the correct driver explicitly by "
+                f"{str(exc)}; It might help to specify the correct driver explicitly by "
                 "prefixing the file path with '<DRIVER>:', e.g. 'CSV:path'."
             ) from None
 
-        raise DataSourceError(exc.errmsg) from None
+        raise DataSourceError(str(exc)) from None
 
 
 cdef ogr_close(GDALDatasetH ogr_dataset):

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -26,7 +26,7 @@ import numpy as np
 
 from pyogrio._ogr cimport *
 from pyogrio._err cimport (
-    check_last_error, check_int, check_ogrerr, check_pointer, ErrorHandler
+    check_last_error, check_int, check_pointer, ErrorHandler
 )
 from pyogrio._vsi cimport *
 from pyogrio._err import (
@@ -478,13 +478,12 @@ cdef get_total_bounds(OGRLayerH ogr_layer, int force):
     """
 
     cdef OGREnvelope ogr_envelope
-    try:
-        check_ogrerr(OGR_L_GetExtent(ogr_layer, &ogr_envelope, force))
+
+    if OGR_L_GetExtent(ogr_layer, &ogr_envelope, force) == OGRERR_NONE:
         bounds = (
            ogr_envelope.MinX, ogr_envelope.MinY, ogr_envelope.MaxX, ogr_envelope.MaxY
         )
-
-    except CPLE_BaseError:
+    else:
         bounds = None
 
     return bounds

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -218,7 +218,9 @@ cdef void* ogr_open(const char* path_c, int mode, char** options) except NULL:
         ) from None
 
     except CPLE_BaseError as exc:
-        if " not recognized as a supported file format." in exc.errmsg:
+        if " a supported file format." in exc.errmsg:
+            # In gdal 3.9, this error message was slightly changed, so we can only check
+            # on this part of the error message.
             raise DataSourceError(
                 f"{exc.errmsg}; It might help to specify the correct driver explicitly by "
                 "prefixing the file path with '<DRIVER>:', e.g. 'CSV:path'."

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -33,6 +33,7 @@ cdef extern from "cpl_error.h" nogil:
     ctypedef void (*CPLErrorHandler)(CPLErr, int, const char*)
     void CPLDefaultErrorHandler(CPLErr, int, const char *)
     void CPLPushErrorHandler(CPLErrorHandler handler)
+    void CPLPushErrorHandlerEx(CPLErrorHandler handler, void *userdata)
     void CPLPopErrorHandler()
 
 

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -33,7 +33,6 @@ cdef extern from "cpl_error.h" nogil:
     ctypedef void (*CPLErrorHandler)(CPLErr, int, const char*)
     void CPLDefaultErrorHandler(CPLErr, int, const char *)
     void CPLPushErrorHandler(CPLErrorHandler handler)
-    void CPLPushErrorHandlerEx(CPLErrorHandler handler, void *userdata)
     void CPLPopErrorHandler()
 
 

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -3,7 +3,7 @@ import sys
 from uuid import uuid4
 import warnings
 
-from pyogrio._err cimport check_int, check_ogrerr, check_pointer
+from pyogrio._err cimport check_int, check_pointer
 from pyogrio._err import CPLE_BaseError, NullPointerError
 from pyogrio.errors import DataSourceError
 
@@ -182,15 +182,15 @@ def has_proj_data():
     """
     cdef OGRSpatialReferenceH srs = OSRNewSpatialReference(NULL)
 
-    try:
-        check_ogrerr(check_int(OSRImportFromEPSG(srs, 4326)))
-    except CPLE_BaseError:
-        return False
-    else:
+    retval = OSRImportFromEPSG(srs, 4326)
+    if srs != NULL:
+        OSRRelease(srs)
+
+    if retval == OGRERR_NONE:
+        # Succesfull return, so PROJ data files are correctly found
         return True
-    finally:
-        if srs != NULL:
-            OSRRelease(srs)
+    else:
+        return False
 
 
 def init_gdal_data():

--- a/pyogrio/_ogr.pyx
+++ b/pyogrio/_ogr.pyx
@@ -3,7 +3,7 @@ import sys
 from uuid import uuid4
 import warnings
 
-from pyogrio._err cimport exc_wrap_int, exc_wrap_ogrerr, exc_wrap_pointer
+from pyogrio._err cimport check_int, check_ogrerr, check_pointer
 from pyogrio._err import CPLE_BaseError, NullPointerError
 from pyogrio.errors import DataSourceError
 
@@ -183,7 +183,7 @@ def has_proj_data():
     cdef OGRSpatialReferenceH srs = OSRNewSpatialReference(NULL)
 
     try:
-        exc_wrap_ogrerr(exc_wrap_int(OSRImportFromEPSG(srs, 4326)))
+        check_ogrerr(check_int(OSRImportFromEPSG(srs, 4326)))
     except CPLE_BaseError:
         return False
     else:
@@ -282,7 +282,7 @@ def _get_driver_metadata_item(driver, metadata_item):
     cdef void *cogr_driver = NULL
 
     try:
-        cogr_driver = exc_wrap_pointer(GDALGetDriverByName(driver.encode('UTF-8')))
+        cogr_driver = check_pointer(GDALGetDriverByName(driver.encode('UTF-8')))
     except NullPointerError:
         raise DataSourceError(
             f"Could not obtain driver: {driver} (check that it was installed "

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -124,6 +124,11 @@ def naturalearth_lowres_all_ext(tmp_path, naturalearth_lowres, request):
     return prepare_testfile(naturalearth_lowres, tmp_path, request.param)
 
 
+@pytest.fixture(scope="function", params=[".geojson"])
+def naturalearth_lowres_geojson(tmp_path, naturalearth_lowres, request):
+    return prepare_testfile(naturalearth_lowres, tmp_path, request.param)
+
+
 @pytest.fixture(scope="function")
 def naturalearth_lowres_vsi(tmp_path, naturalearth_lowres):
     """Wrap naturalearth_lowres as a zip file for VSI tests"""

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -229,14 +229,15 @@ def test_read_force_2d(tmp_path, use_arrow):
 
 
 def test_read_geojson_error(naturalearth_lowres_geojson, use_arrow):
-    set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": 0.01})
-    with pytest.raises(
-        DataSourceError,
-        match="Failed to read GeoJSON data; .* GeoJSON object too complex",
-    ):
-        read_dataframe(naturalearth_lowres_geojson, use_arrow=use_arrow)
-
-    set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": None})
+    try:
+        set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": 0.01})
+        with pytest.raises(
+            DataSourceError,
+            match="Failed to read GeoJSON data; .* GeoJSON object too complex",
+        ):
+            read_dataframe(naturalearth_lowres_geojson, use_arrow=use_arrow)
+    finally:
+        set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": None})
 
 
 def test_read_layer(tmp_path, use_arrow):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -16,7 +16,7 @@ from pyogrio import (
     vsi_listtree,
     vsi_unlink,
 )
-from pyogrio._compat import HAS_ARROW_WRITE_API, HAS_PYPROJ, PANDAS_GE_15
+from pyogrio._compat import GDAL_GE_352, HAS_ARROW_WRITE_API, HAS_PYPROJ, PANDAS_GE_15
 from pyogrio.errors import DataLayerError, DataSourceError, FeatureError, GeometryError
 from pyogrio.geopandas import PANDAS_GE_20, read_dataframe, write_dataframe
 from pyogrio.raw import (
@@ -228,6 +228,10 @@ def test_read_force_2d(tmp_path, use_arrow):
     assert not df.iloc[0].geometry.has_z
 
 
+@pytest.mark.skipif(
+    not GDAL_GE_352,
+    reason="gdal >= 3.5.2 needed to use OGR_GEOJSON_MAX_OBJ_SIZE with a float value",
+)
 def test_read_geojson_error(naturalearth_lowres_geojson, use_arrow):
     try:
         set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": 0.01})

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -12,6 +12,7 @@ from pyogrio import (
     list_drivers,
     list_layers,
     read_info,
+    set_gdal_config_options,
     vsi_listtree,
     vsi_unlink,
 )
@@ -225,6 +226,17 @@ def test_read_force_2d(tmp_path, use_arrow):
         use_arrow=use_arrow,
     )
     assert not df.iloc[0].geometry.has_z
+
+
+def test_read_geojson_error(naturalearth_lowres_geojson, use_arrow):
+    set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": 0.01})
+    with pytest.raises(
+        DataSourceError,
+        match="Failed to read GeoJSON data; .* GeoJSON object too complex",
+    ):
+        read_dataframe(naturalearth_lowres_geojson, use_arrow=use_arrow)
+
+    set_gdal_config_options({"OGR_GEOJSON_MAX_OBJ_SIZE": None})
 
 
 def test_read_layer(tmp_path, use_arrow):


### PR DESCRIPTION
This was present in Rasterio (https://github.com/rasterio/rasterio/pull/2526) and has been included in fiona::_err recently (https://github.com/Toblerity/Fiona/pull/1408)... so this PR is based on the change there.

Closes #491