### PR TITLE
Fix WKB writing on big-endian systems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 0.11.0 (TBD)
 
+### Bug fixes
+
+-   Fix WKB writing on big-endian systems (#497).
+
 ### Packaging
 
 -   the GDAL library included in the wheels is upgraded from 3.9.2 to 3.10.0 (#499).


### PR DESCRIPTION
`shapely.to_wkb` (called in `pyogrio.geopandas.write_dataframe` via `geopandas.array.to_wkb`) defaults to machine byte order, so simply reading the first byte (of a 4-byte integer geometry type) is broken on big-endian machines. And since some geometry type could be 2 bytes, this also seems broken on little-endian machines, though I did not check if any 2-byte types could be produced.

The commented-out code here indicates the correct course of action (reading the first byte to determine byte order).

This fixes the 190 tests that go through this function and fail on big-endian.