### PR TITLE
BLD/RLS: ensure wheels are including GDAL built with openssl

### DIFF
--- a/ci/vcpkg.json
+++ b/ci/vcpkg.json
@@ -5,7 +5,7 @@
         {
             "name": "gdal",
             "default-features": false,
-            "features": ["recommended-features", "curl", "geos", "iconv"]
+            "features": ["recommended-features", "curl", "geos", "iconv", "openssl"]
         }
     ],
     "builtin-baseline": "0857a4b08c14030bbe41e80accb2b1fddb047a74"


### PR DESCRIPTION
I am running into the issue that pyogrio (or geopandas with the pyogrio engine) cannot read  a file from Google Cloud Storage. 
I get intermittently either a `DataSourceError: CPLRSASHA256Sign() not implemented: GDAL must be built against libcrypto++ or libcrypto (openssl)` or `DataSourceError: HTTP response code: 403`. 
This is specifically with the wheels (with conda it works), and using fiona it also works. The first error message seems to indicate we don't properly built with openssl, although vcpkg _does_ install openssl. For the Fiona wheels (and the conda libgdal), I can verify with `ldd` that the libgdal.so included in the wheel is linking against libcrypto (which comes from openssl). For our own wheel I can't check that the same way because we statically link the gdal dependencies into libgdal.so.

Now, based on the fact that sometimes the message indicates GDAL is not built against libcrypto, I am assuming this is indeed the case. 
Looking a bit further into this, the logs of building GDAL with vcpkg on CI clearly shows that vcpkg is also installing openssl. However, the vcpkg port of GDAL has an explicit "feature" for openssl (https://github.com/microsoft/vcpkg/blob/14542c8ad9b6bcb9da755884ab823605c3300b68/ports/gdal/vcpkg.json#L227-L232), and that we are not explicitly enabling. And while GDAL's cmake default is to built against OpenSSL if it is found ([docs](https://gdal.org/en/stable/development/building_from_source.html#cmdoption-arg-GDAL_USE_OPENSSL)), I am assuming that vcpkg might override this default to disable `GDAL_USE_OPENSSL` if you don't explicitly enable the feature through the vcpkg install of gdal (https://github.com/microsoft/vcpkg/blob/14542c8ad9b6bcb9da755884ab823605c3300b68/ports/gdal/portfile.cmake#L47C26-L47C42, not entirely sure how `vcpkg_check_features` works). 

So testing this hypothesis here by explicitly adding `"openssl"` as a vcpkg feature for gdal. I should be able to test the generated wheel. Although not entirely sure if we also have a way we can test this on CI.

