### PR TITLE
LINT: indicate numpy docstrings for ruff pydocstyle rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,3 +206,6 @@ section-order = [
     "geopandas.tests",
     "geopandas.testing",
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
I noticed some warnings locally about conflicting "D" rules, and that seems to go away when specifying the style we use -> https://docs.astral.sh/ruff/settings/#lint_pydocstyle_convention