### PR TITLE
CI: use pyarrow-core as dependency in tests

### DIFF
--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -7,4 +7,4 @@ dependencies:
   - pytest
   - shapely>=2
   - geopandas-base
-  - pyarrow
+  - pyarrow-core


### PR DESCRIPTION
We don't need/use the full pyarrow... and since pyarrow 16 there is a "pyarrow-core" available on conda.

Number of skipped tests stays the same...