### PR TITLE
BUG: fix error in write_dataframe when writing an empty or all-None object column with use_arrow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@
 
 -   Fix WKB writing on big-endian systems (#497).
 -   Fix writing fids to e.g. GPKG file with `use_arrow` (#511).
--   Fix error when an empty object column is written with `use_arrow` (#512).
+-   Fix error in `write_dataframe` when writing an empty or all-None object
+    column with `use_arrow` (#512).
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@
 ### Bug fixes
 
 -   Fix WKB writing on big-endian systems (#497).
--   Fix writing fids to e.g. GPKG file with use_arrow (#511).
+-   Fix writing fids to e.g. GPKG file with `use_arrow` (#511).
+-   Fix error when an empty object column is written with `use_arrow` (#512).
 
 ### Packaging
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -458,7 +458,7 @@ def write_dataframe(
         use_arrow = bool(int(os.environ.get("PYOGRIO_USE_ARROW", "0")))
     path, driver = _get_write_path_driver(path, driver, append=append)
 
-    if use_arrow and df.empty or len(df) == 0:
+    if use_arrow and (df.empty or len(df) == 0):
         # with arrow, string columns without data trigger an error, so disable arrow
         # when writing an empty dataframe.
         use_arrow = False

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -458,6 +458,11 @@ def write_dataframe(
         use_arrow = bool(int(os.environ.get("PYOGRIO_USE_ARROW", "0")))
     path, driver = _get_write_path_driver(path, driver, append=append)
 
+    if use_arrow and df.empty or len(df) == 0:
+        # with arrow, string columns without data trigger an error, so disable arrow
+        # when writing an empty dataframe.
+        use_arrow = False
+
     geometry_columns = df.columns[df.dtypes == "geometry"]
     if len(geometry_columns) > 1:
         raise ValueError(

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1157,9 +1157,6 @@ def test_write_dataframe_index(tmp_path, naturalearth_lowres, use_arrow):
 )
 @pytest.mark.requires_arrow_write_api
 def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
-    if use_arrow and dtype is object:
-        pytest.xfail(reason="writing an empty object column with Arrow gives an error")
-
     expected = gp.GeoDataFrame(geometry=[], columns=columns, dtype=dtype, crs=4326)
 
     filename = tmp_path / f"test{ext}"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1157,6 +1157,11 @@ def test_write_dataframe_index(tmp_path, naturalearth_lowres, use_arrow):
 )
 @pytest.mark.requires_arrow_write_api
 def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
+    """Test writing dataframe with no rows.
+
+    With use_arrow, object type columns with no rows are converted to null type columns
+    by pyarrow, but null columns are not supported by GDAL. Added to test fix for #513.
+    """
     expected = gp.GeoDataFrame(geometry=[], columns=columns, dtype=dtype, crs=4326)
     filename = tmp_path / f"test{ext}"
     write_dataframe(expected, filename, use_arrow=use_arrow)
@@ -1185,11 +1190,11 @@ def test_write_empty_geometry(tmp_path):
 
 @pytest.mark.requires_arrow_write_api
 def test_write_None_string_column(tmp_path, use_arrow):
-    if use_arrow:
-        pytest.xfail(
-            "error when an object column with only None values is written with arrow."
-        )
+    """Test pandas object columns with all None values.
 
+    With use_arrow, such columns are converted to null type columns by pyarrow, but null
+    columns are not supported by GDAL. Added to test fix for #513.
+    """
     gdf = gp.GeoDataFrame({"object_col": [None]}, geometry=[Point(0, 0)], crs=4326)
     filename = tmp_path / "test.gpkg"
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1157,7 +1157,9 @@ def test_write_dataframe_index(tmp_path, naturalearth_lowres, use_arrow):
 )
 @pytest.mark.requires_arrow_write_api
 def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
-    expected = gp.GeoDataFrame(geometry=[], columns=columns, dtype=dtype, crs=4326)
+    expected = gp.GeoDataFrame(geometry=[], columns=columns, crs=4326)
+    for column in columns:
+        expected[column] = expected[column].astype(dtype)
 
     filename = tmp_path / f"test{ext}"
     write_dataframe(expected, filename, use_arrow=use_arrow)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1166,7 +1166,7 @@ def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
 
     assert filename.exists()
     df = read_dataframe(filename, use_arrow=use_arrow)
-    assert_geodataframe_equal(df, expected)
+    assert_geodataframe_equal(df, expected, check_index_type=False)
 
 
 def test_write_empty_geometry(tmp_path):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1184,6 +1184,24 @@ def test_write_empty_geometry(tmp_path):
     assert_geodataframe_equal(df, expected)
 
 
+@pytest.mark.requires_arrow_write_api
+def test_write_None_string_column(tmp_path, use_arrow):
+    if use_arrow:
+        pytest.xfail(
+            "error when an object column with only None values is written with arrow."
+        )
+
+    gdf = gp.GeoDataFrame({"object_col": [None]}, geometry=[Point(0, 0)], crs=4326)
+    filename = tmp_path / "test.gpkg"
+
+    write_dataframe(gdf, filename, use_arrow=use_arrow)
+    assert filename.exists()
+
+    result_gdf = read_dataframe(filename, use_arrow=use_arrow)
+    assert result_gdf.object_col.dtype == object
+    assert_geodataframe_equal(result_gdf, gdf)
+
+
 @pytest.mark.parametrize("ext", [".geojsonl", ".geojsons"])
 @pytest.mark.requires_arrow_write_api
 def test_write_read_empty_dataframe_unsupported(tmp_path, ext, use_arrow):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1168,7 +1168,7 @@ def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
 
     assert filename.exists()
     df = read_dataframe(filename, use_arrow=use_arrow)
-    assert_geodataframe_equal(df, expected, check_index_type=False)
+    assert_geodataframe_equal(df, expected)
 
 
 def test_write_empty_geometry(tmp_path):

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1157,10 +1157,7 @@ def test_write_dataframe_index(tmp_path, naturalearth_lowres, use_arrow):
 )
 @pytest.mark.requires_arrow_write_api
 def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
-    expected = gp.GeoDataFrame(geometry=[], columns=columns, crs=4326)
-    for column in columns:
-        expected[column] = expected[column].astype(dtype)
-
+    expected = gp.GeoDataFrame(geometry=[], columns=columns, dtype=dtype, crs=4326)
     filename = tmp_path / f"test{ext}"
     write_dataframe(expected, filename, use_arrow=use_arrow)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1168,7 +1168,12 @@ def test_write_empty_dataframe(tmp_path, ext, columns, dtype, use_arrow):
 
     assert filename.exists()
     df = read_dataframe(filename, use_arrow=use_arrow)
-    assert_geodataframe_equal(df, expected)
+
+    # Check result
+    # For older pandas versions, the index is created as Object dtype but read as
+    # RangeIndex, so don't check the index dtype in that case.
+    check_index_type = True if PANDAS_GE_20 else False
+    assert_geodataframe_equal(df, expected, check_index_type=check_index_type)
 
 
 def test_write_empty_geometry(tmp_path):


### PR DESCRIPTION
When a dataframe is being written with an object column without any rows or with only None values in the object column, the object column is converted to an null type arrow column, which is not supported by gdal and leads to an error being thrown.

Fixes #513