### PR TITLE
CI: Use setup-uv action in docker tests

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -48,13 +48,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Create virtual environment
-        # install uv and use it to create a virtual environment, then add it to
-        # environment variables so that it is automatically activated and can be
-        # used for tests below
+        # use uv to create a virtual environment, then add it to environment
+        # variables so that it is automatically activated and can be used for
+        # tests below
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          . $HOME/.local/bin/env
           uv venv .venv
           echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This updates the docker tests to use the `setup-uv` action for installing `uv` instead of installing manually ourselves.  This matches the way it installed in the release workflow.