### PR TITLE
CI: also use gdal nightly in nightly-deps tests

### DIFF
--- a/ci/envs/nightly-deps.yml
+++ b/ci/envs/nightly-deps.yml
@@ -1,5 +1,6 @@
-name: test
+name: test-nightly-deps
 channels:
+  - gdal-master
   - conda-forge
 dependencies:
   - libgdal-core
@@ -12,5 +13,3 @@ dependencies:
     - shapely
     - pandas
     - pyarrow
-
-


### PR DESCRIPTION
Up to now, the nightly gdal is not used in the conda environment for this test. Probably better to also use the master/nightly version of GDAL in this test?

Remark: there is also a test using the latest gdal docker image... which is also typically a master/nightly version of gdal that is used.