### PR TITLE
TST: changes in tests to pass GDAL 3.11 (nightlies)

### DIFF
--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -106,7 +106,7 @@ def test_detect_write_driver_unsupported(path):
         detect_write_driver(path)
 
 
-@pytest.mark.parametrize("path", ["test.xml", "test.txt"])
+@pytest.mark.parametrize("path", ["test.xml"])
 def test_detect_write_driver_multiple_unsupported(path):
     with pytest.raises(ValueError, match="multiple drivers are available "):
         detect_write_driver(path)

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -108,7 +108,7 @@ def test_detect_write_driver_unsupported(path):
 
 @pytest.mark.parametrize("path", ["test.xml", "test.txt"])
 def test_detect_write_driver_multiple_unsupported(path):
-    with pytest.raises(ValueError, match="multiple drivers are available"):
+    with pytest.raises(ValueError, match="multiple drivers are available "):
         detect_write_driver(path)
 
 


### PR DESCRIPTION
GDAL 3.11 retires quite some drivers... and apparently the .txt ext doesn't have multiple drivers anymore, so remove it from the test.