### PR TITLE
DOC/TST: document and test read_dataframe with on_invalid=fix

### DIFF
--- a/pyogrio/_compat.py
+++ b/pyogrio/_compat.py
@@ -46,3 +46,4 @@ GDAL_GE_38 = __gdal_version__ >= (3, 8, 0)
 HAS_GDAL_GEOS = __gdal_geos_version__ is not None
 
 HAS_SHAPELY = shapely is not None and Version(shapely.__version__) >= Version("2.0.0")
+SHAPELY_GE_21 = shapely is not None and Version(shapely.__version__) >= Version("2.1.0")

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -209,6 +209,9 @@ def read_dataframe(
           warning will be raised.
         - **ignore**: invalid WKB geometries will be returned as ``None``
           without a warning.
+        - **fix**: an effort is made to fix invalid input geometries (currently
+          just unclosed rings). If this is not possible, they are returned as
+          ``None`` without a warning. Requires GEOS >= 3.11.
 
     arrow_to_pandas_kwargs : dict, optional (default: None)
         When `use_arrow` is True, these kwargs will be passed to the `to_pandas`_

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -211,7 +211,7 @@ def read_dataframe(
           without a warning.
         - **fix**: an effort is made to fix invalid input geometries (currently
           just unclosed rings). If this is not possible, they are returned as
-          ``None`` without a warning. Requires GEOS >= 3.11.
+          ``None`` without a warning. Requires GEOS >= 3.11 and shapely >= 2.1.
 
     arrow_to_pandas_kwargs : dict, optional (default: None)
         When `use_arrow` is True, these kwargs will be passed to the `to_pandas`_

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1794,8 +1794,8 @@ def test_write_geometry_z_types_auto(
 )
 @pytest.mark.filterwarnings("ignore:Non closed ring detected:RuntimeWarning")
 def test_read_invalid_poly_ring(tmp_path, use_arrow, on_invalid, message, expected_wkt):
-    # if on_invalid == "fix" and not SHAPELY_GE_21:
-    #    pytest.skip("on_invalid=fix not available for Shapely < 2.1")
+    if on_invalid == "fix" and not SHAPELY_GE_21:
+        pytest.skip("on_invalid=fix not available for Shapely < 2.1")
 
     if on_invalid == "raise":
         handler = pytest.raises(shapely.errors.GEOSException, match=message)


### PR DESCRIPTION
Document and test the extra option "fix" for the `on_invalid` parameter of `read_dataframe` made possible in shapely 2.1.

resolves #423