### PR TITLE
CI: update windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
             vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
             vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
 
-          - os: "windows-2019"
+          - os: "windows-2022"
             triplet: "x64-windows-dynamic-release"
             arch: AMD64
             # windows requires windows-specific paths

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         python: ["3.10", "3.11", "3.12", "3.13"]
         env: ["latest"]
         include:
@@ -37,7 +37,7 @@ jobs:
             env: "minimal"
           # environment for older Windows libgdal to make sure gdal_i.lib is
           # properly detected
-          - os: "windows-2019"
+          - os: "windows-2022"
             python: "3.10"
             env: "libgdal3.5.1"
           # environment with nightly wheels


### PR DESCRIPTION
The `windows-2019 ` image was deprecated and now the builds were no longer running