### PR TITLE
ENH: add support to read list fields without arrow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.12.0 (yyyy-mm-dd)
+
+### Improvements
+
+-   Add support to read list fields without arrow (#558).
+
 ## 0.11.1 (2025-08-02)
 
 ### Bug fixes

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -991,7 +991,9 @@ cdef process_fields(
         elif field_type == OFTInteger64List:
             # According to GDAL doc, this can return NULL for an empty list, which is a
             # valid result. So don't use check_pointer as it would throw an exception.
-            int64s_c = OGR_F_GetFieldAsInteger64List(ogr_feature, field_index, &ret_length)
+            int64s_c = OGR_F_GetFieldAsInteger64List(
+                ogr_feature, field_index, &ret_length
+            )
 
             int_arr = np.ndarray(shape=(ret_length,), dtype=np.int64)
             for j in range(ret_length):
@@ -1001,7 +1003,9 @@ cdef process_fields(
         elif field_type == OFTRealList:
             # According to GDAL doc, this can return NULL for an empty list, which is a
             # valid result. So don't use check_pointer as it would throw an exception.
-            doubles_c = OGR_F_GetFieldAsDoubleList(ogr_feature, field_index, &ret_length)
+            doubles_c = OGR_F_GetFieldAsDoubleList(
+                ogr_feature, field_index, &ret_length
+            )
 
             double_arr = np.ndarray(shape=(ret_length,), dtype=np.float64)
             for j in range(ret_length):

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -975,14 +975,15 @@ cdef process_fields(
 
         elif field_type == OFTIntegerList:
             ints_c = OGR_F_GetFieldAsIntegerList(ogr_feature, field_index, &ret_length)
-            
+
             int_arr = np.ndarray(shape=(ret_length,), dtype=np.int32)
             for j in range(ret_length):
                 int_arr[j] = ints_c[j]
             data[i] = int_arr
-        
+
         elif field_type == OFTInteger64List:
-            int64s_c = OGR_F_GetFieldAsInteger64List(ogr_feature, field_index, &ret_length)
+            int64s_c = OGR_F_GetFieldAsInteger64List(
+                           ogr_feature, field_index, &ret_length)
 
             int_arr = np.ndarray(shape=(ret_length,), dtype=np.int64)
             for j in range(ret_length):
@@ -1061,7 +1062,7 @@ cdef get_features(
             dtype = "object"
         else:
             dtype = fields[field_index, 3]
-        
+
         field_data.append(np.empty(shape=(num_features, ), dtype=dtype))
 
     field_data_view = [field_data[field_index][:] for field_index in range(n_fields)]

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -283,6 +283,12 @@ cdef extern from "ogr_api.h":
     int             OGR_F_GetFieldAsInteger(OGRFeatureH feature, int n)
     int64_t         OGR_F_GetFieldAsInteger64(OGRFeatureH feature, int n)
     const char*     OGR_F_GetFieldAsString(OGRFeatureH feature, int n)
+    char **         OGR_F_GetFieldAsStringList(OGRFeatureH feature, int n)
+    int *           OGR_F_GetFieldAsIntegerList(
+                        OGRFeatureH feature, int n, int* pnCount)
+    int64_t *       OGR_F_GetFieldAsInteger64List(
+                        OGRFeatureH feature, int n, int* pnCount)
+
     int             OGR_F_IsFieldSetAndNotNull(OGRFeatureH feature, int n)
 
     void OGR_F_SetFieldDateTime(OGRFeatureH feature,

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -290,7 +290,6 @@ cdef extern from "ogr_api.h":
                         OGRFeatureH feature, int n, int* pnCount)
     double *        OGR_F_GetFieldAsDoubleList(
                         OGRFeatureH feature, int n, int* pnCount)
-    
 
     int             OGR_F_IsFieldSetAndNotNull(OGRFeatureH feature, int n)
 

--- a/pyogrio/_ogr.pxd
+++ b/pyogrio/_ogr.pxd
@@ -288,6 +288,9 @@ cdef extern from "ogr_api.h":
                         OGRFeatureH feature, int n, int* pnCount)
     int64_t *       OGR_F_GetFieldAsInteger64List(
                         OGRFeatureH feature, int n, int* pnCount)
+    double *        OGR_F_GetFieldAsDoubleList(
+                        OGRFeatureH feature, int n, int* pnCount)
+    
 
     int             OGR_F_IsFieldSetAndNotNull(OGRFeatureH feature, int n)
 

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -209,27 +209,52 @@ def list_field_values_file(tmp_path):
         "features": [
             {
                 "type": "Feature",
-                "properties": { "int64": 1, "list_int64": [0, 1] },
+                "properties": {
+                    "int64": 1,
+                    "list_int64": [0, 1],
+                    "list_double": [0.0, 1.0],
+                    "list_string": ["string1", "string2"]
+                },
                 "geometry": { "type": "Point", "coordinates": [0, 2] }
             },
             {
                 "type": "Feature",
-                "properties": { "int64": 2, "list_int64": [2, 3] },
+                "properties": {
+                    "int64": 2,
+                    "list_int64": [2, 3],
+                    "list_double": [2.0, 3.0],
+                    "list_string": ["string3", "string4"]
+                },
                 "geometry": { "type": "Point", "coordinates": [1, 2] }
             },
             {
                 "type": "Feature",
-                "properties": { "int64": 3, "list_int64": [4, 5] },
+                "properties": {
+                    "int64": 3,
+                    "list_int64": [4, 5],
+                    "list_double": [4.0, 5.0],
+                    "list_string": ["string5", "string6"]
+                },
                 "geometry": { "type": "Point", "coordinates": [2, 2] }
             },
             {
                 "type": "Feature",
-                "properties": { "int64": 4, "list_int64": [6, 7] },
+                "properties": {
+                    "int64": 4,
+                    "list_int64": [6, 7],
+                    "list_double": [6.0, 7.0],
+                    "list_string": ["string7", "string8"]
+                },
                 "geometry": { "type": "Point", "coordinates": [3, 2] }
             },
             {
                 "type": "Feature",
-                "properties": { "int64": 5, "list_int64": [8, 9] },
+                "properties": {
+                    "int64": 5,
+                    "list_int64": [8, 9],
+                    "list_double": [8.0, 9.0],
+                    "list_string": ["string9", "string10"]
+                },
                 "geometry": { "type": "Point", "coordinates": [4, 2] }
             }
         ]

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -235,9 +235,9 @@ def list_field_values_file(tmp_path):
                 "type": "Feature",
                 "properties": {
                     "int64": 3,
-                    "list_int64": [4, 5],
-                    "list_double": [4.0, 5.0],
-                    "list_string": ["string5", "string6"]
+                    "list_int64": [],
+                    "list_double": [],
+                    "list_string": []
                 },
                 "geometry": { "type": "Point", "coordinates": [2, 2] }
             },
@@ -245,21 +245,11 @@ def list_field_values_file(tmp_path):
                 "type": "Feature",
                 "properties": {
                     "int64": 4,
-                    "list_int64": [6, 7],
-                    "list_double": [6.0, 7.0],
-                    "list_string": ["string7", "string8"]
+                    "list_int64": null,
+                    "list_double": null,
+                    "list_string": null
                 },
-                "geometry": { "type": "Point", "coordinates": [3, 2] }
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "int64": 5,
-                    "list_int64": [8, 9],
-                    "list_double": [8.0, 9.0],
-                    "list_string": ["string9", "string10"]
-                },
-                "geometry": { "type": "Point", "coordinates": [4, 2] }
+                "geometry": { "type": "Point", "coordinates": [2, 2] }
             }
         ]
     }"""

--- a/pyogrio/tests/conftest.py
+++ b/pyogrio/tests/conftest.py
@@ -217,7 +217,9 @@ def list_field_values_file(tmp_path):
                     "int64": 1,
                     "list_int64": [0, 1],
                     "list_double": [0.0, 1.0],
-                    "list_string": ["string1", "string2"]
+                    "list_string": ["string1", "string2"],
+                    "list_int_with_null": [0, null],
+                    "list_string_with_null": ["string1", null]
                 },
                 "geometry": { "type": "Point", "coordinates": [0, 2] }
             },
@@ -227,7 +229,9 @@ def list_field_values_file(tmp_path):
                     "int64": 2,
                     "list_int64": [2, 3],
                     "list_double": [2.0, 3.0],
-                    "list_string": ["string3", "string4"]
+                    "list_string": ["string3", "string4", ""],
+                    "list_int_with_null": [2, 3],
+                    "list_string_with_null": ["string3", "string4", ""]
                 },
                 "geometry": { "type": "Point", "coordinates": [1, 2] }
             },
@@ -237,7 +241,9 @@ def list_field_values_file(tmp_path):
                     "int64": 3,
                     "list_int64": [],
                     "list_double": [],
-                    "list_string": []
+                    "list_string": [],
+                    "list_int_with_null": [],
+                    "list_string_with_null": []
                 },
                 "geometry": { "type": "Point", "coordinates": [2, 2] }
             },
@@ -247,7 +253,21 @@ def list_field_values_file(tmp_path):
                     "int64": 4,
                     "list_int64": null,
                     "list_double": null,
-                    "list_string": null
+                    "list_string": null,
+                    "list_int_with_null": null,
+                    "list_string_with_null": null
+                },
+                "geometry": { "type": "Point", "coordinates": [2, 2] }
+            },
+            {
+                "type": "Feature",
+                "properties": {
+                    "int64": 5,
+                    "list_int64": null,
+                    "list_double": null,
+                    "list_string": [""],
+                    "list_int_with_null": null,
+                    "list_string_with_null": [""]
                 },
                 "geometry": { "type": "Point", "coordinates": [2, 2] }
             }

--- a/pyogrio/tests/test_arrow.py
+++ b/pyogrio/tests/test_arrow.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import math
-import os
 import sys
 from io import BytesIO
 from packaging.version import Version
@@ -131,13 +130,6 @@ def test_read_arrow_ignore_geometry(naturalearth_lowres):
         columns=["geometry"]
     )
     assert_frame_equal(result, expected)
-
-
-def test_read_arrow_nested_types(list_field_values_file):
-    # with arrow, list types are supported
-    result = read_dataframe(list_field_values_file, use_arrow=True)
-    assert "list_int64" in result.columns
-    assert result["list_int64"][0].tolist() == [0, 1]
 
 
 def test_read_arrow_to_pandas_kwargs(no_geometry_file):
@@ -298,29 +290,6 @@ def test_open_arrow_capsule_protocol_without_pyarrow(naturalearth_lowres):
 
     _, expected = read_arrow(naturalearth_lowres)
     assert result.equals(expected)
-
-
-@contextlib.contextmanager
-def use_arrow_context():
-    original = os.environ.get("PYOGRIO_USE_ARROW", None)
-    os.environ["PYOGRIO_USE_ARROW"] = "1"
-    yield
-    if original:
-        os.environ["PYOGRIO_USE_ARROW"] = original
-    else:
-        del os.environ["PYOGRIO_USE_ARROW"]
-
-
-def test_enable_with_environment_variable(list_field_values_file):
-    # list types are only supported with arrow, so don't work by default and work
-    # when arrow is enabled through env variable
-    result = read_dataframe(list_field_values_file)
-    assert "list_int64" not in result.columns
-
-    with use_arrow_context():
-        result = read_dataframe(list_field_values_file)
-
-    assert "list_int64" in result.columns
 
 
 @pytest.mark.skipif(

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -395,9 +395,9 @@ def test_read_list_types(list_field_values_file, use_arrow):
     assert result["list_string"][3] is None
     assert result["list_string"][4] == [""]
 
-    # Once any row of a column contains a null value in a lists (in the test geojson),
-    # the column isn't recognized as a list anymore and the values are returned as
-    # strings.
+    # Once any row of a column contains a null value in a list (in the test geojson),
+    # the column isn't recognized as a list column anymore and the values are returned
+    # as strings.
     assert "list_int_with_null" in result.columns
     assert result["list_int_with_null"][0] == "[ 0, null ]"
     assert result["list_int_with_null"][1] == "[ 2, 3 ]"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2222,6 +2222,7 @@ def test_arrow_bool_exception(tmp_path, ext):
         _ = read_dataframe(filename, use_arrow=True)
 
 
+@pytest.mark.requires_arrow_write_api
 def test_arrow_enable_with_environment_variable(tmp_path):
     """Test if arrow can be enabled via an environment variable."""
     # Latin 1 / Western European

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1,5 +1,6 @@
 import contextlib
 import locale
+import os
 import warnings
 from datetime import datetime
 from io import BytesIO
@@ -91,6 +92,17 @@ def skip_if_no_arrow_write_api(request):
         and request.node.get_closest_marker("requires_arrow_write_api")
     ):
         pytest.skip("GDAL>=3.8 required for Arrow write API")
+
+
+@contextlib.contextmanager
+def use_arrow_context():
+    original = os.environ.get("PYOGRIO_USE_ARROW", None)
+    os.environ["PYOGRIO_USE_ARROW"] = "1"
+    yield
+    if original:
+        os.environ["PYOGRIO_USE_ARROW"] = original
+    else:
+        del os.environ["PYOGRIO_USE_ARROW"]
 
 
 def spatialite_available(path):
@@ -361,8 +373,13 @@ def test_read_datetime_tz(datetime_tz_file, tmp_path, use_arrow):
 def test_read_list_types(list_field_values_file, use_arrow):
     # with arrow, list types are supported
     result = read_dataframe(list_field_values_file, use_arrow=use_arrow)
+
     assert "list_int64" in result.columns
     assert result["list_int64"][0].tolist() == [0, 1]
+    assert "list_double" in result.columns
+    assert result["list_double"][0].tolist() == [0.0, 1.0]
+    assert "list_string" in result.columns
+    assert result["list_string"][0].tolist() == ["string1", "string2"]
 
 
 @pytest.mark.filterwarnings(
@@ -2203,6 +2220,28 @@ def test_arrow_bool_exception(tmp_path, ext):
 
     else:
         _ = read_dataframe(filename, use_arrow=True)
+
+
+def test_arrow_enable_with_environment_variable(tmp_path):
+    """Test if arrow can be enabled via an environment variable."""
+    # Latin 1 / Western European
+    encoding = "CP1252"
+    text = "ÿ"
+    test_path = tmp_path / "test.gpkg"
+
+    df = gp.GeoDataFrame({text: [text], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+    write_dataframe(df, test_path, encoding=encoding)
+
+    # Without arrow, specifying the encoding is supported
+    result = read_dataframe(test_path, encoding="cp1252")
+    assert result is not None
+
+    # With arrow enabled, specifying the encoding is not supported
+    with use_arrow_context():
+        with pytest.raises(
+            ValueError, match="non-UTF-8 encoding is not supported for Arrow"
+        ):
+            _ = read_dataframe(test_path, encoding="cp1252")
 
 
 @pytest.mark.filterwarnings("ignore:File /vsimem:RuntimeWarning")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -371,6 +371,9 @@ def test_read_datetime_tz(datetime_tz_file, tmp_path, use_arrow):
 
 
 def test_read_list_types(list_field_values_file, use_arrow):
+    if not GDAL_GE_352:
+        pytest.xfail(reason="GDAL 3.4.3 didn't handle all list types perfectly")
+
     result = read_dataframe(list_field_values_file, use_arrow=use_arrow)
 
     assert "list_int64" in result.columns

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -358,6 +358,13 @@ def test_read_datetime_tz(datetime_tz_file, tmp_path, use_arrow):
     assert_series_equal(df_read.datetime_col, expected)
 
 
+def test_read_list_types(list_field_values_file, use_arrow):
+    # with arrow, list types are supported
+    result = read_dataframe(list_field_values_file, use_arrow=use_arrow)
+    assert "list_int64" in result.columns
+    assert result["list_int64"][0].tolist() == [0, 1]
+
+
 @pytest.mark.filterwarnings(
     "ignore: Non-conformant content for record 1 in column dates"
 )

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -378,16 +378,35 @@ def test_read_list_types(list_field_values_file, use_arrow):
     assert result["list_int64"][1].tolist() == [2, 3]
     assert result["list_int64"][2].tolist() == []
     assert result["list_int64"][3] is None
+    assert result["list_int64"][4] is None
     assert "list_double" in result.columns
     assert result["list_double"][0].tolist() == [0.0, 1.0]
     assert result["list_double"][1].tolist() == [2.0, 3.0]
     assert result["list_double"][2].tolist() == []
     assert result["list_double"][3] is None
+    assert result["list_double"][4] is None
     assert "list_string" in result.columns
     assert result["list_string"][0].tolist() == ["string1", "string2"]
-    assert result["list_string"][1].tolist() == ["string3", "string4"]
+    assert result["list_string"][1].tolist() == ["string3", "string4", ""]
     assert result["list_string"][2].tolist() == []
     assert result["list_string"][3] is None
+    assert result["list_string"][4] == [""]
+
+    # Once any row of a column contains a null value in a lists (in the test geojson),
+    # the column isn't recognized as a list anymore and the values are returned as
+    # strings.
+    assert "list_int_with_null" in result.columns
+    assert result["list_int_with_null"][0] == "[ 0, null ]"
+    assert result["list_int_with_null"][1] == "[ 2, 3 ]"
+    assert result["list_int_with_null"][2] == "[ ]"
+    assert result["list_int_with_null"][3] is None
+    assert result["list_int_with_null"][4] is None
+    assert "list_string_with_null" in result.columns
+    assert result["list_string_with_null"][0] == '[ "string1", null ]'
+    assert result["list_string_with_null"][1] == '[ "string3", "string4", "" ]'
+    assert result["list_string_with_null"][2] == "[ ]"
+    assert result["list_string_with_null"][3] is None
+    assert result["list_string_with_null"][4] == '[ "" ]'
 
 
 @pytest.mark.filterwarnings(

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -371,15 +371,23 @@ def test_read_datetime_tz(datetime_tz_file, tmp_path, use_arrow):
 
 
 def test_read_list_types(list_field_values_file, use_arrow):
-    # with arrow, list types are supported
     result = read_dataframe(list_field_values_file, use_arrow=use_arrow)
 
     assert "list_int64" in result.columns
     assert result["list_int64"][0].tolist() == [0, 1]
+    assert result["list_int64"][1].tolist() == [2, 3]
+    assert result["list_int64"][2].tolist() == []
+    assert result["list_int64"][3] is None
     assert "list_double" in result.columns
     assert result["list_double"][0].tolist() == [0.0, 1.0]
+    assert result["list_double"][1].tolist() == [2.0, 3.0]
+    assert result["list_double"][2].tolist() == []
+    assert result["list_double"][3] is None
     assert "list_string" in result.columns
     assert result["list_string"][0].tolist() == ["string1", "string2"]
+    assert result["list_string"][1].tolist() == ["string3", "string4"]
+    assert result["list_string"][2].tolist() == []
+    assert result["list_string"][3] is None
 
 
 @pytest.mark.filterwarnings(

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2222,7 +2222,7 @@ def test_arrow_bool_exception(tmp_path, ext):
         _ = read_dataframe(filename, use_arrow=True)
 
 
-@pytest.mark.requires_arrow_write_api
+@requires_pyarrow_api
 def test_arrow_enable_with_environment_variable(tmp_path):
     """Test if arrow can be enabled via an environment variable."""
     # Latin 1 / Western European

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -399,13 +399,13 @@ def test_read_list_types(list_field_values_file, use_arrow):
     assert result["list_int_with_null"][0] == "[ 0, null ]"
     assert result["list_int_with_null"][1] == "[ 2, 3 ]"
     assert result["list_int_with_null"][2] == "[ ]"
-    assert result["list_int_with_null"][3] is None
-    assert result["list_int_with_null"][4] is None
+    assert pd.isna(result["list_int_with_null"][3])
+    assert pd.isna(result["list_int_with_null"][4])
     assert "list_string_with_null" in result.columns
     assert result["list_string_with_null"][0] == '[ "string1", null ]'
     assert result["list_string_with_null"][1] == '[ "string3", "string4", "" ]'
     assert result["list_string_with_null"][2] == "[ ]"
-    assert result["list_string_with_null"][3] is None
+    assert pd.isna(result["list_string_with_null"][3])
     assert result["list_string_with_null"][4] == '[ "" ]'
 
 

--- a/pyogrio/tests/test_raw_io.py
+++ b/pyogrio/tests/test_raw_io.py
@@ -1005,15 +1005,6 @@ def test_read_data_types_numeric_with_null(test_gpkg_nulls):
             assert field.dtype == "float64"
 
 
-def test_read_unsupported_types(list_field_values_file):
-    fields = read(list_field_values_file)[3]
-    # list field gets skipped, only integer field is read
-    assert len(fields) == 1
-
-    fields = read(list_field_values_file, columns=["int64"])[3]
-    assert len(fields) == 1
-
-
 def test_read_datetime_millisecond(datetime_file):
     field = read(datetime_file)[3][0]
     assert field.dtype == "datetime64[ms]"


### PR DESCRIPTION
Add support for all list field types without arrow: list of strings, list of integers and list of double.

closes #17

reference https://github.com/geopandas/geopandas/issues/2113