### PR TITLE
BUG: fix segfault on giving incorrect type to read_info layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 -   Fix decode error reading an sqlite file on windows (#568).
 -   Fix wrong layername when creating .gpkg.zip file (#570).
+-   Fix segfault on providing an invalid value for `layer` in `read_info` (#564).
 
 ### Packaging
 

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -418,7 +418,7 @@ cdef void stacking_error_handler(
 
 @contextlib.contextmanager
 def capture_errors():
-    """A context manager that captures all GDAL non-fatal errors occuring.
+    """A context manager that captures all GDAL non-fatal errors occurring.
 
     It adds all errors to a single stack, so it assumes that no more than one
     GDAL function is called.

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -274,6 +274,10 @@ cdef OGRLayerH get_ogr_layer(GDALDatasetH ogr_dataset, layer) except NULL:
 
         elif isinstance(layer, int):
             ogr_layer = check_pointer(GDALDatasetGetLayer(ogr_dataset, layer))
+        else:
+            raise ValueError(
+                f"'layer' parameter must be a str or int, got {type(layer)}"
+                )
 
     # GDAL does not always raise exception messages in this case
     except NullPointerError:

--- a/pyogrio/core.py
+++ b/pyogrio/core.py
@@ -237,9 +237,9 @@ def read_info(
     ----------
     path_or_buffer : str, pathlib.Path, bytes, or file-like
         A dataset path or URI, raw buffer, or file-like object with a read method.
-    layer : [type], optional
+    layer : str or int, optional
         Name or index of layer in data source.  Reads the first layer by default.
-    encoding : [type], optional (default: None)
+    encoding : str, optional (default: None)
         If present, will be used as the encoding for reading string values from
         the data source, unless encoding can be inferred directly from the data
         source.

--- a/pyogrio/tests/test_core.py
+++ b/pyogrio/tests/test_core.py
@@ -573,6 +573,11 @@ def test_read_info_unspecified_layer_warning(data_dir):
         read_info(data_dir / "sample.osm.pbf")
 
 
+def test_read_info_invalid_layer(naturalearth_lowres):
+    with pytest.raises(ValueError, match="'layer' parameter must be a str or int"):
+        read_bounds(naturalearth_lowres, layer=["list_arg_is_invalid"])
+
+
 def test_read_info_without_geometry(no_geometry_file):
     assert read_info(no_geometry_file)["total_bounds"] is None
 


### PR DESCRIPTION
This was user error, I was trying to do more or less this
```python
layers = pyogrio.list_layers(...)
infos = [pyogrio.read_info(file, layer) for layer in layers]
```
forgetting that layers doesn't return a list of strings.

Here's a minimal reproducer:
```python
import pyogrio
import geodatasets
pyogrio.read_info(geodatasets.get_path("nybb"), layer=['test']) # segfaults because layer is not a str
```

Still think it's worth this giving a proper error message though.

