### PR TITLE
BLD/RLS: build wheels for Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
             "macos-13",
             "macos-latest",
           ]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: "ubuntu-latest"
             artifact: pyogrio-wheel-linux-manylinux2014_x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,13 +313,13 @@ jobs:
       - name: Install dependencies and pyogrio wheel
         shell: bash
         run: |
-          if [ ${{ matrix.python-version }} != "3.13" ]; then
+          if [ ${{ matrix.python-version }} != "3.14" ]; then
             uv pip install -r ci/requirements-wheel-test.txt
           else
             uv pip install pytest numpy certifi packaging
           fi
           uv pip install --no-cache --pre --no-index --find-links wheelhouse pyogrio
-          if [ ${{ matrix.python-version }} != "3.13" ]; then
+          if [ ${{ matrix.python-version }} != "3.14" ]; then
             uv pip install --no-deps geopandas
           fi
           uv pip list

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 -   Add libkml driver to the wheels for more recent Linux platforms supported
     by manylinux_2_28, MacOS, and Windows (#561).
+-   Wheels are now available for Python 3.14.
 
 ## 0.11.1 (2025-08-02)
 

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64:2025-01-11-3165879
+FROM quay.io/pypa/manylinux2014_x86_64:2025.09.19-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN yum install -y curl unzip zip tar perl-IPC-Cmd

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_aarch64:2025-01-11-3165879
+FROM quay.io/pypa/manylinux_2_28_aarch64:2025.09.19-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_x86_64:2025-01-11-3165879
+FROM quay.io/pypa/manylinux_2_28_x86_64:2025.09.19-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Home = "https://pyogrio.readthedocs.io/"
 Repository = "https://github.com/geopandas/pyogrio"
 
 [tool.cibuildwheel]
-skip = ["*musllinux*", "cp314-*", "cp31?t-*"]
+skip = ["*musllinux*", "cp31?t-*"]
 archs = ["auto64"]
 manylinux-x86_64-image = "manylinux-x86_64-vcpkg-gdal:latest"
 manylinux-aarch64-image = "manylinux-aarch64-vcpkg-gdal:latest"


### PR DESCRIPTION
Enabling building and testing wheels for Python 3.14 (the tests only run a subset since not all dependencies are available yet for 3.14)