### PR TITLE
TST: check if test_spatialite_available test actually fails for wheels without libspatialite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
             "macos-13",
             "macos-latest",
           ]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: "ubuntu-latest"
             artifact: pyogrio-wheel-linux-manylinux2014_x86_64

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -106,6 +106,10 @@ def use_arrow_context():
         del os.environ["PYOGRIO_USE_ARROW"]
 
 
+@pytest.mark.skipif(
+    not GDAL_GE_350,
+    reason="GDAL Docker images with GDAL < 3.5 don't contain SpatiaLite",
+)
 def test_spatialite_available(test_gpkg_nulls):
     """Check if SpatiaLite is available by running a simple SQL query."""
     try:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -106,11 +106,11 @@ def use_arrow_context():
         del os.environ["PYOGRIO_USE_ARROW"]
 
 
-def test_spatialite_available(path):
+def test_spatialite_available(test_gpkg_nulls):
     """Check if SpatiaLite is available by running a simple SQL query."""
     try:
         _ = read_dataframe(
-            path, sql="select spatialite_version();", sql_dialect="SQLITE"
+            test_gpkg_nulls, sql="select spatialite_version();", sql_dialect="SQLITE"
         )
     except Exception as ex:
         raise AssertionError(f"SpatiaLite not available: {ex}")

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -106,14 +106,14 @@ def use_arrow_context():
         del os.environ["PYOGRIO_USE_ARROW"]
 
 
-def spatialite_available(path):
+def test_spatialite_available(path):
+    """Check if SpatiaLite is available by running a simple SQL query."""
     try:
         _ = read_dataframe(
             path, sql="select spatialite_version();", sql_dialect="SQLITE"
         )
-        return True
-    except Exception:
-        return False
+    except Exception as ex:
+        raise AssertionError(f"SpatiaLite not available: {ex}")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Temporary PR just to test is a new test to validate if libspatialite is properly added to wheels fails when libspatialite is not yet added to wheels.

It properly fails... so now can be added to PR adding libspatialite to wheels, where it shoud pass: https://github.com/geopandas/pyogrio/pull/546