### PR TITLE
CI/BLD: update retired macos-13 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,13 +161,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-13"
+          - os: "macos-15-intel"
             triplet: "x64-osx-dynamic-release"
             arch: x86_64
             vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
             vcpkg_logs: "/usr/local/share/vcpkg/buildtrees/**/*.log"
 
-          - os: "macos-13"
+          - os: "macos-15"
             triplet: "arm64-osx-dynamic-release"
             arch: arm64
             vcpkg_cache: "/Users/runner/.cache/vcpkg/archives"
@@ -254,7 +254,7 @@ jobs:
             "ubuntu-22.04",
             "ubuntu-24.04-arm",
             "windows-latest",
-            "macos-13",
+            "macos-15-intel",
             "macos-latest",
           ]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
@@ -269,7 +269,7 @@ jobs:
             artifact: pyogrio-wheel-linux-manylinux_2_28_aarch64
           - os: "windows-latest"
             artifact: pyogrio-wheel-x64-windows-dynamic-release
-          - os: "macos-13"
+          - os: "macos-15-intel"
             artifact: pyogrio-wheel-x64-osx-dynamic-release
           - os: "macos-latest"
             artifact: pyogrio-wheel-arm64-osx-dynamic-release


### PR DESCRIPTION
For https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/