### PR TITLE
CI: avoid using nightly pandas in the release tests for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,10 +315,13 @@ jobs:
         run: |
           uv pip install -r ci/requirements-wheel-test.txt
           uv pip install --no-cache --pre --no-index --find-links wheelhouse pyogrio
-          if [ ${{ matrix.python-version }} == "3.14t" ]; then
-            uv pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+          # TMP avoid installing nightly pandas given pandas <-> geopandas compatibility issues
+          # if [ ${{ matrix.python-version }} == "3.14t" ]; then
+          #   uv pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+          # fi
+          if [ ${{ matrix.python-version }} != "3.14t" ]; then
+              uv pip install --no-deps geopandas
           fi
-          uv pip install --no-deps geopandas
           uv pip list
 
       - name: Run tests


### PR DESCRIPTION
There are currently some compatibility issues with the latest nightly pandas (causing failures in geopandas), so just to have green CI in the release builds, avoid installing pandas/geopandas for 3.14t, and then we will just skip the tests that require geopandas for now for this build.