### PR TITLE
CI: tmp avoid pandas nightly in nightly-deps test build

### DIFF
--- a/ci/envs/nightly-deps.yml
+++ b/ci/envs/nightly-deps.yml
@@ -5,11 +5,12 @@ channels:
 dependencies:
   - libgdal-core
   - pytest
+  - pandas
   - pip
   - pip:
     - --pre --prefer-binary --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
     - geopandas
     - numpy>=2.0.0.dev
     - shapely
-    - pandas
+    # - pandas
     - pyarrow

--- a/pyogrio/_compat.py
+++ b/pyogrio/_compat.py
@@ -41,6 +41,7 @@ HAS_GEOPANDAS = geopandas is not None
 PANDAS_GE_15 = pandas is not None and Version(pandas.__version__) >= Version("1.5.0")
 PANDAS_GE_20 = pandas is not None and Version(pandas.__version__) >= Version("2.0.0")
 PANDAS_GE_22 = pandas is not None and Version(pandas.__version__) >= Version("2.2.0")
+PANDAS_GE_23 = pandas is not None and Version(pandas.__version__) >= Version("2.3.0")
 PANDAS_GE_30 = pandas is not None and Version(pandas.__version__) >= Version("3.0.0dev")
 
 GDAL_GE_37 = __gdal_version__ >= (3, 7, 0)

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -23,6 +23,7 @@ from pyogrio._compat import (
     HAS_ARROW_WRITE_API,
     HAS_PYPROJ,
     PANDAS_GE_15,
+    PANDAS_GE_23,
     PANDAS_GE_30,
     SHAPELY_GE_21,
 )
@@ -1470,7 +1471,9 @@ def test_write_None_string_column(tmp_path, use_arrow):
     assert filename.exists()
 
     result_gdf = read_dataframe(filename, use_arrow=use_arrow)
-    if PANDAS_GE_30 and use_arrow:
+    if (
+        PANDAS_GE_30 or (PANDAS_GE_23 and pd.options.future.infer_string)
+    ) and use_arrow:
         assert result_gdf.object_col.dtype == "str"
         gdf["object_col"] = gdf["object_col"].astype("str")
     else:


### PR DESCRIPTION
Because of some pandas<->geopandas interoperability issues, there are currently too many failures of this build to still be useful. So using latest released pandas so we can still test with the nightlies of the other packages.