### PR TITLE
BUG: fix writing some non-string object columns with arrow

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         container:
           - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.12.3
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.0" # python 3.12.3
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.2" # python 3.12.3
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.3" # python 3.12.3
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.3" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.3" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         container:
           - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.12.3
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.3" # python 3.12.3
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.3" # python 3.12.3
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.0" # python 3.12.3
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.2" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.3" # python 3.10.12
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,18 @@
 # CHANGELOG
 
+## 0.12.2 (????-??-??)
+
+### Bug fixes
+
+-   Fix writing non-string object columns with arrow (#630).
+
 ## 0.12.1 (2025-11-28)
 
 ### Bug fixes
 
--   Fix regression in reading date columns (#616)
--   Fix regression in `read_dataframe` when `use_arrow=True` and `columns` is used to filter
-    out columns of some specific types (#611)
+-   Fix regression in reading date columns (#616).
+-   Fix regression in `read_dataframe` when `use_arrow=True` and `columns` is used to
+    filter out columns of some specific types (#611).
 
 ## 0.12.0 (2025-11-26)
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -802,7 +802,7 @@ def write_dataframe(
                     # The arrow timestamp type doesn't support mixed time zone offsets,
                     # so convert to string to avoid data loss and pass on to GDAL
                     # that it is a datetime so GDAL can preserve the type information.
-                    df[name] = df[name].astype("str")
+                    df[name] = df[name].astype("string")
                     datetime_cols.append(name)
                 else:
                     # Check if pyarrow can handle the data in the column. If not,

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -798,17 +798,22 @@ def write_dataframe(
             if dtype == "object":
                 # An object column with datetimes can contain multiple offsets.
                 inferred_dtype = pd.api.types.infer_dtype(df[name])
-                if inferred_dtype in {"mixed", "mixed-integer", "mixed-integer-float"}:
-                    # mixed is an unknown object column, convert to string
-                    df[name] = df[name].astype("string")
+                if inferred_dtype in {"mixed-integer", "mixed-integer-float"}:
+                    # just convert these mixed columns to string
+                    df[name] = df[name].astype("str")
+                elif inferred_dtype == "mixed":
+                    # mixed is an unknown object column... if it isn't a list, convert
+                    # to string
+                    if not isinstance(df[name].dropna().iloc[0], list | np.ndarray):
+                        df[name] = df[name].astype("str")
                 elif inferred_dtype == "datetime":
-                    df[name] = df[name].astype("string")
+                    df[name] = df[name].astype("str")
                     datetime_cols.append(name)
 
             elif isinstance(dtype, pd.DatetimeTZDtype) and str(dtype.tz) != "UTC":
                 # A pd.datetime64 column with a time zone different than UTC can contain
                 # data with different offsets because of summer/winter time.
-                df[name] = df[name].astype("string")
+                df[name] = df[name].astype("str")
                 datetime_cols.append(name)
 
         table = pa.Table.from_pandas(df, preserve_index=False)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -813,7 +813,7 @@ def write_dataframe(
             elif isinstance(dtype, pd.DatetimeTZDtype) and str(dtype.tz) != "UTC":
                 # A pd.datetime64 column with a time zone different than UTC can contain
                 # data with different offsets because of summer/winter time.
-                df[name] = df[name].astype("str")
+                df[name] = df[name].astype("string")
                 datetime_cols.append(name)
 
         table = pa.Table.from_pandas(df, preserve_index=False)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -815,7 +815,7 @@ def write_dataframe(
             elif isinstance(dtype, pd.DatetimeTZDtype) and str(dtype.tz) != "UTC":
                 # A pd.datetime64 column with a time zone different than UTC can contain
                 # data with different offsets because of summer/winter time.
-                df[name] = df[name].astype("str")
+                df[name] = df[name].astype("string")
                 datetime_cols.append(name)
 
         table = pa.Table.from_pandas(df, preserve_index=False)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -755,6 +755,8 @@ def write_dataframe(
 
         from pyogrio.raw import write_arrow
 
+        df = df.copy(deep=False)
+
         if geometry_column is not None:
             # Convert to multi type
             if promote_to_multi:
@@ -780,7 +782,6 @@ def write_dataframe(
                     )
 
             geometry = to_wkb(geometry.values)
-            df = df.copy(deep=False)
             # convert to plain DataFrame to avoid warning from geopandas about
             # writing non-geometries to the geometry column
             df = pd.DataFrame(df, copy=False)

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -799,6 +799,7 @@ def write_dataframe(
             if dtype == "object":
                 inferred_dtype = pd.api.types.infer_dtype(df[name])
                 if inferred_dtype == "string":
+                    # The column already contains strings, so no need to convert.
                     continue
                 elif inferred_dtype == "datetime":
                     # The arrow timestamp type doesn't support mixed time zone offsets,

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -807,7 +807,7 @@ def write_dataframe(
                     if not isinstance(df[name].dropna().iloc[0], list | np.ndarray):
                         df[name] = df[name].astype("str")
                 elif inferred_dtype == "datetime":
-                    df[name] = df[name].astype("str")
+                    df[name] = df[name].astype("string")
                     datetime_cols.append(name)
 
             elif isinstance(dtype, pd.DatetimeTZDtype) and str(dtype.tz) != "UTC":

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -793,9 +793,15 @@ def write_dataframe(
         # datetime columns when writing the dataset.
         datetime_cols = []
         for name, dtype in df.dtypes.items():
+            if geometry_column is not None and name == geometry_column:
+                continue
             if dtype == "object":
                 # An object column with datetimes can contain multiple offsets.
-                if pd.api.types.infer_dtype(df[name]) == "datetime":
+                inferred_dtype = pd.api.types.infer_dtype(df[name])
+                if inferred_dtype == "mixed":
+                    # mixed is an unknown object column, convert to string
+                    df[name] = df[name].astype("string")
+                elif inferred_dtype == "datetime":
                     df[name] = df[name].astype("string")
                     datetime_cols.append(name)
 

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -800,7 +800,7 @@ def write_dataframe(
                 inferred_dtype = pd.api.types.infer_dtype(df[name])
                 if inferred_dtype == "string":
                     continue
-                if inferred_dtype == "datetime":
+                elif inferred_dtype == "datetime":
                     # The arrow timestamp type doesn't support mixed time zone offsets,
                     # so convert to string to avoid data loss and pass on to GDAL
                     # that it is a datetime so GDAL can preserve the type information.

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -798,6 +798,8 @@ def write_dataframe(
                 continue
             if dtype == "object":
                 inferred_dtype = pd.api.types.infer_dtype(df[name])
+                if inferred_dtype == "string":
+                    continue
                 if inferred_dtype == "datetime":
                     # The arrow timestamp type doesn't support mixed time zone offsets,
                     # so convert to string to avoid data loss and pass on to GDAL

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -798,7 +798,7 @@ def write_dataframe(
             if dtype == "object":
                 # An object column with datetimes can contain multiple offsets.
                 inferred_dtype = pd.api.types.infer_dtype(df[name])
-                if inferred_dtype == "mixed":
+                if inferred_dtype in {"mixed", "mixed-integer", "mixed-integer-float"}:
                     # mixed is an unknown object column, convert to string
                     df[name] = df[name].astype("string")
                 elif inferred_dtype == "datetime":

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -813,7 +813,7 @@ def write_dataframe(
                     try:
                         _ = pa.Schema.from_pandas(df[[name]])
                     except pa.ArrowInvalid:
-                        df[name] = df[name].astype("str")
+                        df[name] = df[name].astype("string")
 
             elif isinstance(dtype, pd.DatetimeTZDtype) and str(dtype.tz) != "UTC":
                 # A pd.datetime64 column with a time zone different than UTC can contain

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2536,7 +2536,7 @@ def test_write_read_null(tmp_path, use_arrow):
         [date(2020, 1, 1), date(2021, 2, 2)],
         [b"foo", b"bar"],
         [[123, 321], [123, 321]],
-        ["foo", 123],
+        [123, "foo"],
         [Decimal(1), Decimal(2)],
         ["a", np.nan],
         ["a", None],
@@ -2597,9 +2597,8 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
             expected_data = object_col_data
 
     if object_col_data in (["a", np.nan], ["a", None]):
-        # With or without arrow, mix of str and nan is read back with nan as None
         expected_dtype = str_dtype
-        expected_data = ["a", None]
+        expected_data = ["a", np.nan] if PANDAS_GE_30 else ["a", None]
 
     # In other cases, the object_col is written and read back as strings
     if expected_dtype is None:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2598,7 +2598,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
 
     if object_col_data in (["a", np.nan], ["a", None]):
         expected_dtype = str_dtype
-        expected_data = ["a", np.nan] if PANDAS_GE_30 else ["a", None]
+        expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
 
     # In other cases, the object_col is written and read back as strings
     if expected_dtype is None:

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2585,6 +2585,11 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
             # Decimal objects are read back as decimal objects with arrow
             expected_dtype = "float64"
             expected_data = object_col_data
+        elif isinstance(object_col_data[0], list):
+            # lists retained with arrow
+            expected_dtype = "object"
+            expected_data = object_col_data
+
     if object_col_data in (["a", np.nan], ["a", None]):
         # With or without arrow, mix of str and nan is read back with nan as None
         expected_dtype = "object"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2572,7 +2572,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         # With arrow, some object types get a more specific treatment
         if isinstance(object_col_data[0], date):
             # datetime.date objects are read back as datetime64 with arrow
-            expected_dtype = "M8[ms]"
+            expected_dtype = "datetime64[ms]" if PANDAS_GE_20 else "datetime64[ns]"
             expected_data = [
                 pd.Timestamp(value.year, value.month, value.day)
                 for value in object_col_data
@@ -2600,7 +2600,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         expected_dtype = "object"
         expected_data = [str(value) for value in object_col_data]
 
-    assert result_gdf["object_col"].dtype == expected_dtype
+    assert result_gdf["object_col"].dtype.name == expected_dtype
     assert list(result_gdf["object_col"]) == expected_data
 
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2507,19 +2507,6 @@ def test_write_read_mixed_column_values(tmp_path):
     assert_series_equal(output_gdf["mixed"], expected)
 
 
-@requires_arrow_write_api
-def test_write_read_mixed_column_values_arrow(tmp_path):
-    # Arrow cannot represent a column of mixed types
-    mixed_values = ["test", 1.0, 1, datetime.now(), None, np.nan]
-    geoms = [shapely.Point(0, 0) for _ in mixed_values]
-    test_gdf = gp.GeoDataFrame(
-        {"geometry": geoms, "mixed": mixed_values}, crs="epsg:31370"
-    )
-    output_path = tmp_path / "test_write_mixed_column.gpkg"
-    with pytest.raises(TypeError, match=".*Conversion failed for column"):
-        write_dataframe(test_gdf, output_path, use_arrow=True)
-
-
 @pytest.mark.requires_arrow_write_api
 def test_write_read_null(tmp_path, use_arrow):
     output_path = tmp_path / "test_write_nan.gpkg"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2558,7 +2558,11 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     test_gdf = gp.GeoDataFrame(test_data, crs="epsg:31370")
 
     # Verify that object_col is actually inferred as object dtype for this test.
-    str_dtype = "str" if PANDAS_GE_30 else "object"
+    str_dtype = (
+        "str"
+        if PANDAS_GE_30 or (PANDAS_GE_23 and pd.options.future.infer_string)
+        else "object"
+    )
     input_dtype = str_dtype if isinstance(object_col_data[0], str) else "object"
     assert test_gdf["object_col"].dtype.name == input_dtype
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2560,7 +2560,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     # Verify that object_col is actually inferred as object dtype for this test.
     str_dtype = "str" if PANDAS_GE_30 else "object"
     input_dtype = str_dtype if isinstance(object_col_data[0], str) else "object"
-    assert test_gdf["object_col"].dtype == input_dtype
+    assert test_gdf["object_col"].dtype.name == input_dtype
 
     write_dataframe(test_gdf, output_path, use_arrow=use_arrow)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2558,7 +2558,9 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     test_gdf = gp.GeoDataFrame(test_data, crs="epsg:31370")
 
     # Verify that object_col is actually inferred as object dtype for this test.
-    assert test_gdf["object_col"].dtype == "object"
+    str_dtype = "str" if PANDAS_GE_30 else "object"
+    input_dtype = str_dtype if isinstance(object_col_data[0], str) else "object"
+    assert test_gdf["object_col"].dtype == input_dtype
 
     write_dataframe(test_gdf, output_path, use_arrow=use_arrow)
 
@@ -2592,12 +2594,12 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
 
     if object_col_data in (["a", np.nan], ["a", None]):
         # With or without arrow, mix of str and nan is read back with nan as None
-        expected_dtype = "object"
+        expected_dtype = str_dtype
         expected_data = ["a", None]
 
     # In other cases, the object_col is written and read back as strings
     if expected_dtype is None:
-        expected_dtype = "object"
+        expected_dtype = str_dtype
         expected_data = [str(value) for value in object_col_data]
 
     assert result_gdf["object_col"].dtype.name == expected_dtype

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2648,7 +2648,8 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         )
         expected_data = [pd.Timestamp(value) for value in object_col_data]
     elif use_arrow:
-        if isinstance(object_col_data[0], date):
+        if type(object_col_data[0]) is date:
+            # Don't use isinstance here as datetime objects are also instances of date
             # datetime.date objects are read back as datetime64 with arrow
             expected_dtype = "datetime64[ms]" if PANDAS_GE_20 else "datetime64[ns]"
             expected_data = [pd.Timestamp(value) for value in object_col_data]

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2660,8 +2660,9 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         elif isinstance(object_col_data[0], list):
             # These types are read back as object type with arrow
             expected_dtype = "object"
+            nan_value = np.nan if PANDAS_GE_30 else None
             expected_data = [
-                np.nan if value is None else value for value in object_col_data
+                nan_value if value is None else value for value in object_col_data
             ]
         elif isinstance(object_col_data[0], Decimal):
             # Decimal objects are read back as float64 objects with arrow

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2598,19 +2598,19 @@ def test_write_read_null(tmp_path, use_arrow):
 @pytest.mark.parametrize(
     "object_col_data",
     [
-        ["test1", "test2"],
-        [Path("test1"), Path("test2")],
-        [date(2020, 1, 1), date(2021, 2, 2)],
+        ["foo", "bar", np.nan],
+        ["foo", "bar", None],
+        [Path("test1"), Path("test2"), None],
+        [date(2020, 1, 1), date(2021, 2, 2), None],
         [
             datetime(2020, 1, 1, 5, tzinfo=timezone.utc),
             datetime(2021, 2, 2, 6, tzinfo=timezone.utc),
+            None,
         ],
-        [b"foo", b"bar"],
-        [[123, 321], [123, 321]],
-        [123, "foo"],
+        [b"foo", b"bar", None],
+        [[123, 321], [123, 321], None],
+        [123, "foo", None],
         [Decimal(1), Decimal(2)],
-        ["a", np.nan],
-        ["a", None],
     ],
 )
 @pytest.mark.parametrize("ext", [".gpkg"])
@@ -2641,10 +2641,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     )
 
     expected_dtype = None
-    if object_col_data in (["a", np.nan], ["a", None]):
-        expected_dtype = str_dtype
-        expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
-    elif isinstance(object_col_data[0], datetime) and (not use_arrow or GDAL_GE_311):
+    if isinstance(object_col_data[0], datetime) and (not use_arrow or GDAL_GE_311):
         # With arrow and older GDAL versions, datetimes were read back as strings.
         expected_dtype = (
             "datetime64[ms, UTC]" if PANDAS_GE_20 else "datetime64[ns, UTC]"
@@ -2655,19 +2652,29 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
             # datetime.date objects are read back as datetime64 with arrow
             expected_dtype = "datetime64[ms]" if PANDAS_GE_20 else "datetime64[ns]"
             expected_data = [pd.Timestamp(value) for value in object_col_data]
-        elif isinstance(object_col_data[0], bytes | list):
+        elif isinstance(object_col_data[0], bytes):
             # These types are read back as object type with arrow
             expected_dtype = "object"
             expected_data = object_col_data
+        elif isinstance(object_col_data[0], list):
+            # These types are read back as object type with arrow
+            expected_dtype = "object"
+            expected_data = [
+                np.nan if value is None else value for value in object_col_data
+            ]
         elif isinstance(object_col_data[0], Decimal):
-            # Decimal objects are read back as decimal objects with arrow
+            # Decimal objects are read back as float64 objects with arrow
             expected_dtype = "float64"
-            expected_data = object_col_data
+            expected_data = [float(value) for value in object_col_data]
 
     # In other cases, fallback to the values just being read back as strings
     if expected_dtype is None:
         expected_dtype = str_dtype
-        expected_data = [str(value) for value in object_col_data]
+        nan_value = np.nan if str_dtype == "str" else None
+        expected_data = [
+            nan_value if value is None or value is np.nan else str(value)
+            for value in object_col_data
+        ]
 
     assert result_gdf["object_col"].dtype.name == expected_dtype
     assert list(result_gdf["object_col"]) == expected_data

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2644,7 +2644,8 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     if object_col_data in (["a", np.nan], ["a", None]):
         expected_dtype = str_dtype
         expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
-    elif isinstance(object_col_data[0], datetime):
+    elif isinstance(object_col_data[0], datetime) and (not use_arrow or GDAL_GE_311):
+        # With arrow and older GDAL versions, datetimes were read back as strings.
         expected_dtype = (
             "datetime64[ms, UTC]" if PANDAS_GE_20 else "datetime64[ns, UTC]"
         )

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2547,7 +2547,7 @@ def test_write_read_null(tmp_path, use_arrow):
 @pytest.mark.parametrize("ext", [".gpkg"])
 @pytest.mark.requires_arrow_write_api
 def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
-    """Test writing and reading pandas object dtype columns.
+    """Test writing and reading a pandas object dtype column with different value types.
 
     Remark: how some types are handled depends a bit on the file format being used.
     """
@@ -2558,9 +2558,6 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         "object_col": object_col_data,
     }
     test_gdf = gp.GeoDataFrame(test_data, crs=31370, dtype=object)
-
-    # Verify that object_col is actually inferred as object dtype for this test.
-    assert test_gdf["object_col"].dtype.name == "object"
 
     write_dataframe(test_gdf, output_path, use_arrow=use_arrow)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -3,7 +3,7 @@ import locale
 import os
 import re
 import warnings
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
@@ -2601,6 +2601,10 @@ def test_write_read_null(tmp_path, use_arrow):
         ["test1", "test2"],
         [Path("test1"), Path("test2")],
         [date(2020, 1, 1), date(2021, 2, 2)],
+        [
+            datetime(2020, 1, 1, 5, tzinfo=timezone.utc),
+            datetime(2021, 2, 2, 6, tzinfo=timezone.utc),
+        ],
         [b"foo", b"bar"],
         [[123, 321], [123, 321]],
         [123, "foo"],
@@ -2640,14 +2644,16 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     if object_col_data in (["a", np.nan], ["a", None]):
         expected_dtype = str_dtype
         expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
+    elif isinstance(object_col_data[0], datetime):
+        expected_dtype = (
+            "datetime64[ms, UTC]" if PANDAS_GE_20 else "datetime64[ns, UTC]"
+        )
+        expected_data = [pd.Timestamp(value) for value in object_col_data]
     elif use_arrow:
         if isinstance(object_col_data[0], date):
             # datetime.date objects are read back as datetime64 with arrow
             expected_dtype = "datetime64[ms]" if PANDAS_GE_20 else "datetime64[ns]"
-            expected_data = [
-                pd.Timestamp(value.year, value.month, value.day)
-                for value in object_col_data
-            ]
+            expected_data = [pd.Timestamp(value) for value in object_col_data]
         elif isinstance(object_col_data[0], bytes | list):
             # These types are read back as object type with arrow
             expected_dtype = "object"

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2557,16 +2557,10 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
         "geometry": [geom] * len(object_col_data),
         "object_col": object_col_data,
     }
-    test_gdf = gp.GeoDataFrame(test_data, crs="epsg:31370")
+    test_gdf = gp.GeoDataFrame(test_data, crs=31370, dtype=object)
 
     # Verify that object_col is actually inferred as object dtype for this test.
-    str_dtype = (
-        "str"
-        if PANDAS_GE_30 or (PANDAS_GE_23 and pd.options.future.infer_string)
-        else "object"
-    )
-    input_dtype = str_dtype if isinstance(object_col_data[0], str) else "object"
-    assert test_gdf["object_col"].dtype.name == input_dtype
+    assert test_gdf["object_col"].dtype.name == "object"
 
     write_dataframe(test_gdf, output_path, use_arrow=use_arrow)
 
@@ -2575,9 +2569,10 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
 
     # Prepare expected dtype and data after round-tripping
     expected_dtype = None
-
-    if use_arrow:
-        # With arrow, some object types get a more specific treatment
+    if object_col_data in (["a", np.nan], ["a", None]):
+        expected_dtype = "str"
+        expected_data = ["a", np.nan]
+    elif use_arrow:
         if isinstance(object_col_data[0], date):
             # datetime.date objects are read back as datetime64 with arrow
             expected_dtype = "datetime64[ms]" if PANDAS_GE_20 else "datetime64[ns]"
@@ -2585,26 +2580,18 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
                 pd.Timestamp(value.year, value.month, value.day)
                 for value in object_col_data
             ]
-        elif isinstance(object_col_data[0], bytes):
-            # byte objects are read back as byte objects with arrow
+        elif isinstance(object_col_data[0], bytes | list):
+            # These types are read back as object type with arrow
             expected_dtype = "object"
             expected_data = object_col_data
         elif isinstance(object_col_data[0], Decimal):
             # Decimal objects are read back as decimal objects with arrow
             expected_dtype = "float64"
             expected_data = object_col_data
-        elif isinstance(object_col_data[0], list):
-            # lists retained with arrow
-            expected_dtype = "object"
-            expected_data = object_col_data
 
-    if object_col_data in (["a", np.nan], ["a", None]):
-        expected_dtype = str_dtype
-        expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
-
-    # In other cases, the object_col is written and read back as strings
+    # In other cases, fallback to the values just being read back as strings
     if expected_dtype is None:
-        expected_dtype = str_dtype
+        expected_dtype = "str"
         expected_data = [str(value) for value in object_col_data]
 
     assert result_gdf["object_col"].dtype.name == expected_dtype

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2565,9 +2565,15 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     assert len(test_gdf) == len(result_gdf)
 
     # Prepare expected dtype and data after round-tripping
+    str_dtype = (
+        "str"
+        if PANDAS_GE_30 or (PANDAS_GE_23 and pd.options.future.infer_string)
+        else "object"
+    )
+
     expected_dtype = None
     if object_col_data in (["a", np.nan], ["a", None]):
-        expected_dtype = "str"
+        expected_dtype = str_dtype
         expected_data = ["a", np.nan]
     elif use_arrow:
         if isinstance(object_col_data[0], date):
@@ -2588,7 +2594,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
 
     # In other cases, fallback to the values just being read back as strings
     if expected_dtype is None:
-        expected_dtype = "str"
+        expected_dtype = str_dtype
         expected_data = [str(value) for value in object_col_data]
 
     assert result_gdf["object_col"].dtype.name == expected_dtype

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -2574,7 +2574,7 @@ def test_write_read_object_column(tmp_path, object_col_data, ext, use_arrow):
     expected_dtype = None
     if object_col_data in (["a", np.nan], ["a", None]):
         expected_dtype = str_dtype
-        expected_data = ["a", np.nan]
+        expected_data = ["a", np.nan] if str_dtype == "str" else ["a", None]
     elif use_arrow:
         if isinstance(object_col_data[0], date):
             # datetime.date objects are read back as datetime64 with arrow


### PR DESCRIPTION
In `write_dataframe` with `use_arrow=False`, object dtype columns are implicitly serialised to string to be able to write them to the output file.

With `use_arrow=True`, the pyarrow `to_table` function supports treatment of some datatypes (e.g. lists,...), but for other cases such columns rather given an error. For datatypes that are not supported by pyarrow a good default behaviour would be to just convert them to string as is done without arrow.

This PR explicitly converts object columns to string for columns that aren't supported to be interpreted by pyarrow.

resolves #631 