### PR TITLE
TST: fixes to tests for pandas 3.0

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -39,7 +39,6 @@ jobs:
           - os: "ubuntu-latest"
             python: "3.11"
             env: "nightly-deps"
-            pandas_future_infer_string: "1"
 
     steps:
       - name: Checkout repo
@@ -64,7 +63,5 @@ jobs:
         run: pip install -e .
 
       - name: Test
-        env:
-          PANDAS_FUTURE_INFER_STRING: ${{ matrix.pandas_future_infer_string || '0' }}
         run: |
           pytest -v --color=yes -r s pyogrio/tests

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -975,6 +975,8 @@ def test_write_read_datetime_tz_mixed_offsets(
             # string type columns, so no proper roundtrip possible.
             df_exp = df.copy()
             df_exp.dates = df_exp.dates.astype("str")
+            if not PANDAS_GE_30:
+                df_exp.loc[2, "dates"] = None
             assert_geodataframe_equal(result, df_exp)
             # XFAIL: mixed tz datetimes converted to UTC with GDAL < 3.11 + arrow
             return

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -974,7 +974,7 @@ def test_write_read_datetime_tz_mixed_offsets(
             # With arrow and GDAL < 3.11, mixed time zone datetimes are written as
             # string type columns, so no proper roundtrip possible.
             df_exp = df.copy()
-            df_exp.dates = df_exp.dates.astype("string").astype("O")
+            df_exp.dates = df_exp.dates.astype("str")
             assert_geodataframe_equal(result, df_exp)
             # XFAIL: mixed tz datetimes converted to UTC with GDAL < 3.11 + arrow
             return


### PR DESCRIPTION
In this PR:
- remove `pandas_future_infer_string=0` environment variable used when running conda tests now pandas 3 is released
    - remark: this lead to some fails when `use_arrow=True` results are compared with `use_arrow=False`, as arrow seems to ignore the environment variable?
- some fixes in tests where combinations of old gdal versions with newer pandas versions gave some issues