### PR TITLE
BUG: fix error writing a column with mix of datetimes with and without timezone without arrow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,9 @@
 
 ### Bug fixes
 
--   Fix error in `write_dataframe` with `use_arrow=False` when writing a column with a
-    mix of datetimes with and without time zones (#).
+-   Fix error in `write_dataframe` with `use_arrow=False` when writing a column with
+    datetimes without any time zone offsets or with a mix of offsets and no offsets
+    (#634).
 
 ## 0.12.1 (2025-11-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,19 @@
 # CHANGELOG
 
+## 0.12.2 (????-??-??)
+
+### Bug fixes
+
+-   Fix error in `write_dataframe` with `use_arrow=False` when writing a column with a
+    mix of datetimes with and without time zones (#).
+
 ## 0.12.1 (2025-11-28)
 
 ### Bug fixes
 
--   Fix regression in reading date columns (#616)
+-   Fix regression in reading date columns (#616).
 -   Fix regression in `read_dataframe` when `use_arrow=True` and `columns` is used to filter
-    out columns of some specific types (#611)
+    out columns of some specific types (#611).
 
 ## 0.12.0 (2025-11-26)
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -2786,6 +2786,8 @@ def ogr_write(
                         tz_array = gdal_tz_offsets.get(fields[field_idx], None)
                         if tz_array is None:
                             gdal_tz = 0
+                        elif np.isnan(tz_array[i]):
+                            gdal_tz = 0
                         else:
                             gdal_tz = tz_array[i]
                         OGR_F_SetFieldDateTimeEx(

--- a/pyogrio/geopandas.py
+++ b/pyogrio/geopandas.py
@@ -921,14 +921,10 @@ def write_dataframe(
         elif col.dtype == "object":
             # Column of Timestamp/datetime objects, split in naive datetime and tz.
             if pd.api.types.infer_dtype(df[name]) == "datetime":
-                tz_offset = col.map(lambda x: x.utcoffset(), na_action="ignore")
-                gdal_offset_repr = tz_offset.map(
-                    lambda x: x // pd.Timedelta("15m") + 100, na_action="ignore"
+                tz_offset = col.map(lambda x: x.utcoffset(), na_action="ignore").astype(
+                    "timedelta64[us]" if PANDAS_GE_30 else "timedelta64[ns]"
                 )
-                # Replace pd.NA with np.nan because the cython code expects numpy arrays
-                gdal_offset_repr = gdal_offset_repr.where(
-                    ~pd.isna(gdal_offset_repr), np.nan
-                )
+                gdal_offset_repr = tz_offset // pd.Timedelta("15m") + 100
                 gdal_tz_offsets[name] = gdal_offset_repr.values
                 naive = col.map(lambda x: x.replace(tzinfo=None), na_action="ignore")
                 values = naive.values

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1017,6 +1017,10 @@ def test_write_read_datetime_tz_mixed_offsets(
     ],
 )
 @pytest.mark.requires_arrow_write_api
+@pytest.skipif(
+    not GDAL_GE_311,
+    reason="before GDAL 3.11, datetimes weren't handled as well",
+)
 def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
     """Test writing a column with datetimes with and without time zone offsets.
 
@@ -1045,10 +1049,6 @@ def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
         exp_df.dates = pd.to_datetime(exp_df.dates, utc=False)
         if PANDAS_GE_20:
             exp_df.dates = exp_df.dates.dt.as_unit("ms")
-        if not GDAL_GE_311 and use_arrow:
-            # Older versions of GDAL with arrow didn't handle datetimes properly
-            exp_df.dates = exp_df.dates.astype("str")
-            result.dates = result.dates.str.slice(0, -3)
 
     if not PANDAS_GE_30:
         exp_df.loc[2, "dates"] = None

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1045,12 +1045,13 @@ def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
         exp_df.dates = pd.to_datetime(exp_df.dates, utc=False)
         if PANDAS_GE_20:
             exp_df.dates = exp_df.dates.dt.as_unit("ms")
-        if not PANDAS_GE_30:
-            exp_df.loc[2, "dates"] = None
+        if not GDAL_GE_311 and use_arrow:
+            # Older versions of GDAL with arrow didn't handle datetimes properly
+            exp_df.dates = exp_df.dates.astype("str")
+            result.dates = result.dates.str.slice(0, -3)
 
-    if not GDAL_GE_311 and use_arrow:
-        # Older versions of GDAL with arrow didn't handle datetimes properly
-        exp_df.dates = exp_df.dates.astype("str")
+    if not PANDAS_GE_30:
+        exp_df.loc[2, "dates"] = None
 
     assert_geodataframe_equal(result, exp_df)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1045,6 +1045,12 @@ def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
         exp_df.dates = pd.to_datetime(exp_df.dates, utc=False)
         if PANDAS_GE_20:
             exp_df.dates = exp_df.dates.dt.as_unit("ms")
+        if not PANDAS_GE_30:
+            exp_df.loc[2, "dates"] = None
+
+    if not GDAL_GE_311 and use_arrow:
+        # Older versions of GDAL with arrow didn't handle datetimes properly
+        exp_df.dates = exp_df.dates.astype("str")
 
     assert_geodataframe_equal(result, exp_df)
 

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1017,7 +1017,7 @@ def test_write_read_datetime_tz_mixed_offsets(
     ],
 )
 @pytest.mark.requires_arrow_write_api
-@pytest.skipif(
+@pytest.mark.skipif(
     not GDAL_GE_311,
     reason="before GDAL 3.11, datetimes weren't handled as well",
 )

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -3,7 +3,7 @@ import locale
 import os
 import re
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -1001,25 +1001,35 @@ def test_write_read_datetime_tz_mixed_offsets(
         assert_geodataframe_equal(result, df)
 
 
+@pytest.mark.parametrize(
+    "dates",
+    [
+        [
+            datetime(2023, 1, 1, 11, 0, 1, 111000),
+            datetime(2023, 6, 1, 10, 0, 1, 111000),
+            np.nan,
+        ],
+        [
+            datetime(2023, 1, 1, 11, 0, 1, 111000, tzinfo=timezone(timedelta(hours=1))),
+            datetime(2023, 6, 1, 10, 0, 1, 111000),
+            np.nan,
+        ],
+    ],
+)
 @pytest.mark.requires_arrow_write_api
-def test_write_read_datetime_tz_mixed_offsets_None(tmp_path, use_arrow):
-    """Test with dates with mixed time zone offsets where some offsets are None.
+def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
+    """Test writing a column with datetimes with and without time zone offsets.
 
-    When datetimes with a mix of having a time zone offsets and some without an offset
-    were written without arrow, this gave the following error:
-        `ValueError: cannot convert float NaN to integer`
+    Two types of errors occured:
+      - For datetimes without any offset, when written without arrow:
+        `TypeError: Invalid dtype float64 for __floordiv__`
+      - For datetimes with a mix of having a time zone offset and without, when written
+        without arrow: `ValueError: cannot convert float NaN to integer`
     """
-    # Pandas datetime64 column types doesn't support mixed time zone offsets, so
-    # it needs to be a list of pandas.Timestamp objects instead.
-    dates = [
-        pd.Timestamp("2023-01-01 11:00:01.111+01:00"),
-        pd.Timestamp("2023-06-01 10:00:01.111+05:00"),
-        pd.Timestamp("2023-06-01 10:00:01.111"),
-        np.nan,
-    ]
-
     df = gp.GeoDataFrame(
-        {"dates": dates, "geometry": [Point(1, 1)] * len(dates)}, crs="EPSG:4326"
+        {"dates": dates, "geometry": [Point(1, 1)] * len(dates)},
+        crs="EPSG:4326",
+        dtype=object,
     )
     fpath = tmp_path / "test.gpkg"
     write_dataframe(df, fpath, use_arrow=use_arrow)
@@ -1030,7 +1040,13 @@ def test_write_read_datetime_tz_mixed_offsets_None(tmp_path, use_arrow):
         mixed_offsets_as_utc=False,
     )
 
-    assert_geodataframe_equal(result, df)
+    exp_df = df.copy()
+    if dates[0].tzinfo is None:
+        exp_df.dates = pd.to_datetime(exp_df.dates, utc=False)
+        if PANDAS_GE_20:
+            exp_df.dates = exp_df.dates.dt.as_unit("ms")
+
+    assert_geodataframe_equal(result, exp_df)
 
 
 @pytest.mark.parametrize("ext", [ext for ext in ALL_EXTS if ext != ".shp"])

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1026,14 +1026,7 @@ def test_write_read_datetime_tz_mixed_offsets(
     reason="before GDAL 3.11, datetimes weren't handled as well",
 )
 def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
-    """Test writing a column with datetimes with and without time zone offsets.
-
-    Two types of errors occured:
-      - For datetimes without any offset, when written without arrow:
-        `TypeError: Invalid dtype float64 for __floordiv__`
-      - For datetimes with a mix of having a time zone offset and without, when written
-        without arrow: `ValueError: cannot convert float NaN to integer`
-    """
+    """Test writing a column with datetimes with and without time zone offsets."""
     df = gp.GeoDataFrame(
         {"dates": dates, "geometry": [Point(1, 1)] * len(dates)},
         crs="EPSG:4326",


### PR DESCRIPTION
Fixes following errors:
- Error occured in `write_dataframe` (with `use_arrow=False`) when writing a dataframe with a datetime column where  all datetimes have no time zone offset: ``TypeError: Invalid dtype float64 for __floordiv__```
- Error occured in `write_dataframe` (with `use_arrow=False`) when writing a dataframe with a datetime column where  some datetimes have a time zone offset and some don't have an offset: ```ValueError: cannot convert float NaN to integer```

Issue noticed in https://github.com/geofileops/geofileops/issues/802