### PR TITLE
BLD: fix const discarding (c build warning)

### DIFF
--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -1030,9 +1030,9 @@ cdef process_fields(
     cdef int success
     cdef int field_index
     cdef int ret_length
-    cdef int *ints_c
-    cdef GIntBig *int64s_c
-    cdef double *doubles_c
+    cdef const int *ints_c
+    cdef const GIntBig *int64s_c
+    cdef const double *doubles_c
     cdef char **strings_c
     cdef GByte *bin_value
     cdef int year = 0


### PR DESCRIPTION
Avoiding:

```
pyogrio/_io.c: In function '__pyx_f_7pyogrio_3_io_process_fields':
pyogrio/_io.c:26292:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
26292 |       __pyx_v_ints_c = OGR_F_GetFieldAsIntegerList(__pyx_v_ogr_feature, __pyx_v_field_index, (&__pyx_v_ret_length));
      |                      ^
pyogrio/_io.c:26415:24: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
26415 |       __pyx_v_int64s_c = OGR_F_GetFieldAsInteger64List(__pyx_v_ogr_feature, __pyx_v_field_index, (&__pyx_v_ret_length));
      |                        ^
pyogrio/_io.c:26538:25: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
26538 |       __pyx_v_doubles_c = OGR_F_GetFieldAsDoubleList(__pyx_v_ogr_feature, __pyx_v_field_index, (&__pyx_v_ret_length));
```