### PR TITLE
CI: update GDAL docker images

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -20,7 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.12.3
+          - "ghcr.io/osgeo/gdal:ubuntu-small-latest" # >= python 3.14.4
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.13.0" # python 3.14.4
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.12.4" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.11.5" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.3" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.3" # python 3.12.3


### PR DESCRIPTION
There are some new GDAL versions we are not testing yet in the GDAL docker-based workflow