### PR TITLE
TST: correctly skip geopandas tests that require pyarrow for writing

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -35,6 +35,10 @@ jobs:
           - os: "ubuntu-latest"
             python: "3.10"
             env: "minimal"
+          # environment without pyarrow
+          - os: "ubuntu-latest"
+            python: "3.13"
+            env: "no-pyarrow"
           # environment with nightly wheels
           - os: "ubuntu-latest"
             python: "3.11"

--- a/ci/envs/no-pyarrow.yml
+++ b/ci/envs/no-pyarrow.yml
@@ -1,0 +1,11 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - libgdal-core
+  - libgdal-arrow-parquet
+  - pytest
+  - shapely>=2
+  - geopandas-base
+  - pyarrow-core

--- a/ci/envs/no-pyarrow.yml
+++ b/ci/envs/no-pyarrow.yml
@@ -8,4 +8,3 @@ dependencies:
   - pytest
   - shapely>=2
   - geopandas-base
-  - pyarrow-core

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -24,6 +24,7 @@ from pyogrio._compat import (
     GDAL_GE_37,
     GDAL_GE_311,
     HAS_ARROW_WRITE_API,
+    HAS_PYARROW,
     HAS_PYPROJ,
     PANDAS_GE_15,
     PANDAS_GE_23,
@@ -100,10 +101,10 @@ def skip_if_no_arrow_write_api(request):
     )
     if (
         use_arrow
-        and not HAS_ARROW_WRITE_API
+        and not (HAS_ARROW_WRITE_API and HAS_PYARROW)
         and request.node.get_closest_marker("requires_arrow_write_api")
     ):
-        pytest.skip("GDAL>=3.8 required for Arrow write API")
+        pytest.skip("GDAL>=3.8 and pyarrow required for Arrow write API")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
@theroggy follow-up on https://github.com/geopandas/pyogrio/pull/650, fixing the failing CI on main (https://github.com/geopandas/pyogrio/actions/runs/26754130592/job/78849462574)

It is a strange error (because the mark itself should be a pytest skipif that also checks for pyarrow being installed, so not entirely sure why it is not yet skipped because of that), but it seems to be solved by checking for pyarrow in the custom `skip_if_no_arrow_write_api` auto-fixture