### PR TITLE
MAINT: bump minimum Python version from 3.10 to 3.11

### DIFF
--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
           apt-get update && apt-get install -y software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
+          # set timezone to avoid tzdata interactive prompt
+          export DEBIAN_FRONTEND=noninteractive
+          export TZ=UTC
           apt-get update && apt-get install -y python3.11-dev
 
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -24,9 +24,9 @@ jobs:
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.11.5" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.10.3" # python 3.12.3
           - "ghcr.io/osgeo/gdal:ubuntu-small-3.9.3" # python 3.12.3
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5" # python 3.10.12
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.3" # python 3.10.12
-          - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.10.6
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.8.5" # python 3.11 (installed manually)
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.7.3" # python 3.11 (installed manually)
+          - "ghcr.io/osgeo/gdal:ubuntu-small-3.6.4" # python 3.11 (installed manually)
 
     container:
       image: ${{ matrix.container }}
@@ -36,14 +36,14 @@ jobs:
         run: |
           apt-get update && apt-get install -y build-essential git python3-dev
 
-      # - name: Install Python
-      #   # the GDAL 3.4 and 3.5 images do have Python 3.8 installed, so have to
-      #   # install a more recent Python version manually
-      #   if: matrix.container == 'osgeo/gdal:ubuntu-small-3.5.3' || matrix.container == 'osgeo/gdal:ubuntu-small-3.4.3'
-      #   run: |
-      #     apt-get update && apt-get install -y software-properties-common
-      #     add-apt-repository -y ppa:deadsnakes/ppa
-      #     apt-get update && apt-get install -y python3.9-dev
+      - name: Install Python
+        # the GDAL 3.6 - 3.8 images do have Python 3.10 installed, so have to
+        # install a more recent Python version manually
+        if: matrix.container == 'osgeo/gdal:ubuntu-small-3.6.4' || matrix.container == 'osgeo/gdal:ubuntu-small-3.7.3' || matrix.container == 'osgeo/gdal:ubuntu-small-3.8.5'
+        run: |
+          apt-get update && apt-get install -y software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get update && apt-get install -y python3.11-dev
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docker-gdal.yml
+++ b/.github/workflows/docker-gdal.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Python
         # the GDAL 3.6 - 3.8 images do have Python 3.10 installed, so have to
         # install a more recent Python version manually
-        if: matrix.container == 'osgeo/gdal:ubuntu-small-3.6.4' || matrix.container == 'osgeo/gdal:ubuntu-small-3.7.3' || matrix.container == 'osgeo/gdal:ubuntu-small-3.8.5'
+        if: matrix.container == 'ghcr.io/osgeo/gdal:ubuntu-small-3.6.4' || matrix.container == 'ghcr.io/osgeo/gdal:ubuntu-small-3.7.3' || matrix.container == 'ghcr.io/osgeo/gdal:ubuntu-small-3.8.5'
         run: |
           apt-get update && apt-get install -y software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
             "macos-15-intel",
             "macos-latest",
           ]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           - os: "ubuntu-latest"
             artifact: pyogrio-wheel-linux-manylinux2014_x86_64

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -23,21 +23,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
         env: ["latest"]
         include:
           # environment with lower versions of optional dependencies
-          - python: "3.10"
+          - python: "3.11"
             extra: >-
               pandas=1.5
               geopandas=0.12
           # minimal environment without optional dependencies
           - os: "ubuntu-latest"
-            python: "3.10"
+            python: "3.11"
             env: "minimal"
           # environment with nightly wheels
           - os: "ubuntu-latest"
-            python: "3.11"
+            python: "3.14"
             env: "nightly-deps"
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
 -   Fix overwriting a corrupt fileGDB directory (#600).
 -   Fix attribute data being incorrectly written with KML driver (#650).
 
+### Packaging
+
+-   Minimum required Python version is now 3.11 (#xxx).
+
 ## 0.12.1 (2025-11-28)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read the documentation for more information:
 
 ## Requirements
 
-- Python >= 3.10
+- Python >= 3.11
 - GDAL >= 3.6
 - Reading to GeoDataFrames requires `geopandas>=0.12` and `shapely>=2`. Additionally,
   installing `pyarrow` enables a further speed-up when specifying `use_arrow=True`.

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python >= 3.10
+- Python >= 3.11
 - GDAL >= 3.6
 - Reading to GeoDataFrames requires `geopandas>=0.12` and `shapely>=2`. Additionally,
   installing `pyarrow` enables a further speed-up when specifying `use_arrow=True`.

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -3,7 +3,7 @@ import locale
 import os
 import re
 import warnings
-from datetime import date, datetime, time, timezone
+from datetime import UTC, date, datetime, time
 from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
@@ -2659,8 +2659,8 @@ def test_write_read_null(tmp_path, use_arrow):
         [Path("test1"), Path("test2"), None],
         [date(2020, 1, 1), date(2021, 2, 2), None],
         [
-            datetime(2020, 1, 1, 5, tzinfo=timezone.utc),
-            datetime(2021, 2, 2, 6, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, 5, tzinfo=UTC),
+            datetime(2021, 2, 2, 6, tzinfo=UTC),
             None,
         ],
         [b"foo", b"bar", None],

--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -1001,7 +1001,11 @@ def test_write_read_datetime_tz_mixed_offsets(
             exp_dates = exp_dates.dt.as_unit("ms")
         assert_series_equal(result.dates, exp_dates)
     else:
-        assert is_object_dtype(result.dates.dtype)
+        if __gdal_version__ < (3, 7, 0):
+            assert is_string_dtype(result.dates.dtype)
+            result["dates"] = result["dates"].astype(object)
+        else:
+            assert is_object_dtype(result.dates.dtype)
         assert_geodataframe_equal(result, df)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
     "Programming Language :: Python :: Free Threading :: 2 - Beta",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["certifi", "numpy", "packaging"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = [
     "setuptools",
     "Cython>=3.1",
     "versioneer[toml]==0.28",
-    # tomli is used by versioneer
-    "tomli; python_version < '3.11'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-MIN_PYTHON_VERSION = (3, 10, 0)
+MIN_PYTHON_VERSION = (3, 11, 0)
 MIN_GDAL_VERSION = (2, 4, 0)
 
 
 if sys.version_info < MIN_PYTHON_VERSION:
-    raise RuntimeError("Python >= 3.10 is required")
+    raise RuntimeError("Python >= 3.11 is required")
 
 
 def copy_data_tree(datadir, destdir):


### PR DESCRIPTION
Increasing the required Python version to 3.11, and then we support the last 4 Python versions 3.11 - 3.14.

