### PR TITLE
BLD/RLS: update wheels to include GDAL 3.12.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GDAL_VERSION: "3.11.4"
-  VCPKG_GDAL_COMMIT: da096fdc67db437bee863ae73c4c12e289f82789
+  GDAL_VERSION: "3.12.4"
+  VCPKG_GDAL_COMMIT: 89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c
 
 jobs:
   build-sdist:
@@ -58,7 +58,7 @@ jobs:
     needs: [build-sdist]
     runs-on: ubuntu-latest
     container:
-      image: "ghcr.io/osgeo/gdal:ubuntu-small-3.11.4"
+      image: "ghcr.io/osgeo/gdal:ubuntu-small-3.12.4"
 
     steps:
       - name: Install packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,12 +200,12 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.arch }}-vcpkg-gdal${{ env.GDAL_VERSION }}-cache1
 
       # MacOS build requires aclocal, which is part of automake, but appears
-      # to be missing in default image
-      - name: Reinstall automake
+      # to be missing in default image. In addition, building libspatialite also
+      # requires full autotools
+      - name: Install autotools prerequisites
         if: runner.os == 'macOS'
         run: |
-          brew reinstall automake
-          brew install libtool
+          brew install autoconf autoconf-archive automake libtool
           echo $(which aclocal)
 
       - name: Checkout specific version of vcpkg

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 ### Packaging
 
--   The GDAL library included in the wheels is upgraded from 3.11.4 to 3.12.4.
+-   The GDAL library included in the wheels is upgraded from 3.11.4 to 3.12.4 (#658).
 
 ## 0.12.1 (2025-11-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 -   Fix overwriting a corrupt fileGDB directory (#600).
 -   Fix attribute data being incorrectly written with KML driver (#650).
 
+### Packaging
+
+-   The GDAL library included in the wheels is upgraded from 3.11.4 to 3.12.4.
+
 ## 0.12.1 (2025-11-28)
 
 ### Bug fixes

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,10 @@
 FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN yum install -y curl unzip zip tar perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
+# Additional system dependencies:
+# - vcpkg needs: curl zip unzip tar ninja
+# - openssl needs IPC-Cmd and perl-core (https://github.com/microsoft/vcpkg/issues/24988, https://github.com/openssl/openssl/issues/28579)
+# - libspatialite needs full autotools suite to build (autoconf autoconf-archive automake libtool)
+RUN yum install -y curl unzip zip tar perl-core perl-IPC-Cmd autoconf autoconf-archive automake libtool
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -6,6 +6,16 @@ RUN yum install -y curl unzip zip tar perl-IPC-Cmd
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp38-cp38/bin/python3 /usr/bin/python3
 
+# vcpkg currently requires ninja >= 1.13.2; build it from source so the binary
+# is compatible with the older manylinux2014 runtime libraries.
+# (vcpkg otherwise downloads a pre-built binary of ninja, which fails to run due to missing symbols in the older runtime)
+RUN curl -L -o /tmp/ninja-1.13.2.tar.gz https://github.com/ninja-build/ninja/archive/refs/tags/v1.13.2.tar.gz && \
+    tar -xzf /tmp/ninja-1.13.2.tar.gz -C /tmp && \
+    /usr/bin/python3 /tmp/ninja-1.13.2/configure.py --bootstrap && \
+    install -m 0755 /tmp/ninja-1.13.2/ninja /usr/local/bin/ninja && \
+    /usr/local/bin/ninja --version && \
+    rm -rf /tmp/ninja-1.13.2 /tmp/ninja-1.13.2.tar.gz
+
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \
     git -C /opt/vcpkg checkout ${VCPKG_GDAL_COMMIT}

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN yum install -y curl unzip zip tar perl-IPC-Cmd glibc-devel
+RUN yum install -y curl unzip zip tar perl-core perl-IPC-Cmd glibc-devel
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
@@ -11,8 +11,9 @@ RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
 # (vcpkg otherwise downloads a pre-built binary of ninja, which fails to run due to missing symbols in the older runtime)
 RUN curl -L -o /tmp/ninja-1.13.2.tar.gz https://github.com/ninja-build/ninja/archive/refs/tags/v1.13.2.tar.gz && \
     tar -xzf /tmp/ninja-1.13.2.tar.gz -C /tmp && \
-    python3 /tmp/ninja-1.13.2/configure.py --bootstrap && \
-    install -m 0755 /tmp/ninja-1.13.2/ninja /usr/local/bin/ninja && \
+    cd /tmp/ninja-1.13.2 && \
+    python3 configure.py --bootstrap && \
+    install -m 0755 ninja /usr/local/bin/ninja && \
     /usr/local/bin/ninja --version && \
     rm -rf /tmp/ninja-1.13.2 /tmp/ninja-1.13.2.tar.gz
 

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64:2025.09.19-1
+FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN yum install -y curl unzip zip tar perl-IPC-Cmd

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
-RUN yum install -y curl unzip zip tar perl-IPC-Cmd
+# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
+RUN yum install -y curl unzip zip tar perl-IPC-Cmd kernel-headers
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp38-cp38/bin/python3 /usr/bin/python3

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN yum install -y curl unzip zip tar perl-IPC-Cmd kernel-headers
+RUN yum install -y curl unzip zip tar perl-IPC-Cmd glibc-devel
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp38-cp38/bin/python3 /usr/bin/python3

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -4,14 +4,14 @@ FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 RUN yum install -y curl unzip zip tar perl-IPC-Cmd glibc-devel
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
-RUN ln -s /opt/python/cp38-cp38/bin/python3 /usr/bin/python3
+RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3
 
 # vcpkg currently requires ninja >= 1.13.2; build it from source so the binary
 # is compatible with the older manylinux2014 runtime libraries.
 # (vcpkg otherwise downloads a pre-built binary of ninja, which fails to run due to missing symbols in the older runtime)
 RUN curl -L -o /tmp/ninja-1.13.2.tar.gz https://github.com/ninja-build/ninja/archive/refs/tags/v1.13.2.tar.gz && \
     tar -xzf /tmp/ninja-1.13.2.tar.gz -C /tmp && \
-    /usr/bin/python3 /tmp/ninja-1.13.2/configure.py --bootstrap && \
+    python3 /tmp/ninja-1.13.2/configure.py --bootstrap && \
     install -m 0755 /tmp/ninja-1.13.2/ninja /usr/local/bin/ninja && \
     /usr/local/bin/ninja --version && \
     rm -rf /tmp/ninja-1.13.2 /tmp/ninja-1.13.2.tar.gz

--- a/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux2014_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN yum install -y curl unzip zip tar perl-core perl-IPC-Cmd glibc-devel
+RUN yum install -y curl unzip zip tar perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
 
 # require python >= 3.7 (python 3.6 is default on base image) for meson
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/bin/python3

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,10 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
+# Additional system dependencies:
+# - vcpkg needs: curl zip unzip tar ninja
+# - openssl needs IPC-Cmd and perl-core (https://github.com/microsoft/vcpkg/issues/24988, https://github.com/openssl/openssl/issues/28579)
+# - libspatialite needs full autotools suite to build (autoconf autoconf-archive automake libtool)
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd autoconf autoconf-archive automake libtool
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd
+# building openssl needs IPC-Cmd and linux kernel headers
+RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd kernel-headers
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd glibc-devel
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
-# building openssl needs IPC-Cmd and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd kernel-headers
+# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
+RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd glibc-devel
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_aarch64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_aarch64:2025.09.19-1
+FROM quay.io/pypa/manylinux_2_28_aarch64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd
+# building openssl needs IPC-Cmd and linux kernel headers
+RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd kernel-headers
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_x86_64:2025.09.19-1
+FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988)
 RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,10 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
-# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel autoconf autoconf-archive automake libtool
+# Additional system dependencies:
+# - vcpkg needs: curl zip unzip tar ninja
+# - openssl needs IPC-Cmd and perl-core (https://github.com/microsoft/vcpkg/issues/24988, https://github.com/openssl/openssl/issues/28579)
+# - libspatialite needs full autotools suite to build (autoconf autoconf-archive automake libtool)
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd autoconf autoconf-archive automake libtool
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
-# building openssl needs IPC-Cmd and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd kernel-headers
+# building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
+RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd glibc-devel
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
+++ b/ci/manylinux_2_28_x86_64-vcpkg-gdal.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64:2026.06.03-1
 
 # building openssl needs IPC-Cmd (https://github.com/microsoft/vcpkg/issues/24988) and linux kernel headers
-RUN dnf -y install curl zip unzip tar ninja-build perl-IPC-Cmd glibc-devel
+RUN dnf -y install curl zip unzip tar ninja-build perl-core perl-IPC-Cmd glibc-devel
 
 ARG VCPKG_GDAL_COMMIT
 RUN git clone https://github.com/Microsoft/vcpkg.git /opt/vcpkg && \

--- a/ci/vcpkg-manylinux2014.json
+++ b/ci/vcpkg-manylinux2014.json
@@ -12,5 +12,5 @@
             "features": ["recommended-features", "curl", "geos", "iconv", "libspatialite", "openssl"]
         }
     ],
-    "builtin-baseline": "da096fdc67db437bee863ae73c4c12e289f82789"
+    "builtin-baseline": "89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c"
 }

--- a/ci/vcpkg.json
+++ b/ci/vcpkg.json
@@ -14,5 +14,11 @@
             ]
         }
     ],
-    "builtin-baseline": "89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c"
+    "builtin-baseline": "89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c",
+    "overrides": [
+        {
+            "name": "uriparser",
+            "version": "1.0.0"
+        }
+    ]
 }

--- a/ci/vcpkg.json
+++ b/ci/vcpkg.json
@@ -14,5 +14,5 @@
             ]
         }
     ],
-    "builtin-baseline": "da096fdc67db437bee863ae73c4c12e289f82789"
+    "builtin-baseline": "89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c"
 }


### PR DESCRIPTION
Updating to GDAL 3.12.4 (https://github.com/microsoft/vcpkg/commit/89dac9685f8d0ebd0a07d8b93ed51215c3a2fb2c). 

The vpkg PR to update to GDAL 3.13.0 is not yet merged, so for now we can only update to GDAL 3.12

---

Summarizing the issues I ran into:

- building the newer libspatialite now requires the full autotools to be available (as system dependency, not through vcpkg)
- building openssl now also requires perl-core (perl-IPC-Cmd doesn't come with that; this might also have been a change on the images)
- for manylinux2014, the system ninja is now too old for vcpkg, so installing a newer version manually from source
- [most relevant] the newer `uriparser` 1.0.2 assumes a minimum glibc 2.29, giving a build error on the manylinux_2_28 images (see https://github.com/uriparser/uriparser/issues/315). For now as a quick workaround, I pinned uriparser to 1.0.0, but longer term I think ideally we use an overlay port so we can include a small patch to make it work again (I _think_ it should just be two lines to define `_GNU_SOURCE`, cfr https://github.com/uriparser/uriparser/commit/5519b963b8e7a7842c8295361d96f0458a549f11).
  UPDATE: there will be a 1.0.3 that relaxes this again (just have to wait a bit on vcpkg to include it)