### PR TITLE
Igore pixi config and envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ wheels/
 *.egg
 
 .ruff_cache
+
+# pixi environments
+.pixi/*
+pixi.toml
+pixi.lock


### PR DESCRIPTION
I am using pixi (https://pixi.prefix.dev/latest/) more and more, lately, locally for development, and when the project has no pixi config itself, you can add some locally for yourself. But in that case, it would be nice to have the config file and the generated files/dirs to be automatically ignored.