### PR TITLE
PERF: mark check_pointer as nogil and release gil outside the loop in get_feature_count

### DIFF
--- a/pyogrio/_err.pxd
+++ b/pyogrio/_err.pxd
@@ -1,6 +1,6 @@
 cdef object check_last_error()
 cdef int check_int(int retval) except -1
-cdef void *check_pointer(void *ptr) except NULL
+cdef void *check_pointer(void *ptr) except NULL nogil
 
 cdef class ErrorHandler:
     cdef object error_stack

--- a/pyogrio/_err.pyx
+++ b/pyogrio/_err.pyx
@@ -198,7 +198,7 @@ cdef clean_error_message(const char* err_msg):
     return msg
 
 
-cdef void *check_pointer(void *ptr) except NULL:
+cdef void *check_pointer(void *ptr) except NULL nogil:
     """Check the pointer returned by a GDAL/OGR function.
 
     If `ptr` is `NULL`, an exception inheriting from CPLE_BaseError is raised.
@@ -222,12 +222,13 @@ cdef void *check_pointer(void *ptr) except NULL:
 
     """
     if ptr == NULL:
-        exc = check_last_error()
-        if exc:
-            raise exc
-        else:
-            # null pointer was passed, but no error message from GDAL
-            raise NullPointerError(-1, -1, "NULL pointer error")
+        with gil:
+            exc = check_last_error()
+            if exc:
+                raise exc
+            else:
+                # null pointer was passed, but no error message from GDAL
+                raise NullPointerError(-1, -1, "NULL pointer error")
 
     return ptr
 

--- a/pyogrio/_io.pyx
+++ b/pyogrio/_io.pyx
@@ -548,37 +548,36 @@ cdef get_feature_count(OGRLayerH ogr_layer, int force):
             OGR_L_ResetReading(ogr_layer)
 
         feature_count = 0
-        while True:
-            try:
-                # Don't use `with nogil` inside this loop, as if there are many
-                # features, the overhead of acquiring and releasing the GIL becomes
-                # significant on linux.
-                ogr_feature = OGR_L_GetNextFeature(ogr_layer)
-                ogr_feature = check_pointer(ogr_feature)
-                feature_count +=1
 
-            except NullPointerError:
-                # No more rows available, so stop reading
-                break
+        try:
+            with nogil:
+                while True:
+                    ogr_feature = OGR_L_GetNextFeature(ogr_layer)
+                    ogr_feature = check_pointer(ogr_feature)
+                    feature_count +=1
 
-            # driver may raise other errors, e.g., for OSM if node ids are not
-            # increasing, the default config option OSM_USE_CUSTOM_INDEXING=YES
-            # causes errors iterating over features
-            except CPLE_BaseError as exc:
-                # if an invalid where clause is used for a GPKG file, it is not
-                # caught as an error until attempting to iterate over features;
-                # catch it here
-                if "failed to prepare SQL" in str(exc):
-                    raise ValueError(f"Invalid SQL query: {str(exc)}") from None
+        except NullPointerError:
+            # No more rows available, so stop reading
+            pass
 
-                raise DataLayerError(
-                    f"Could not iterate over features: {str(exc)}"
-                ) from None
+        # driver may raise other errors, e.g., for OSM if node ids are not
+        # increasing, the default config option OSM_USE_CUSTOM_INDEXING=YES
+        # causes errors iterating over features
+        except CPLE_BaseError as exc:
+            # if an invalid where clause is used for a GPKG file, it is not
+            # caught as an error until attempting to iterate over features;
+            # catch it here
+            if "failed to prepare SQL" in str(exc):
+                raise ValueError(f"Invalid SQL query: {str(exc)}") from None
 
-            finally:
-                if ogr_feature != NULL:
-                    OGR_F_Destroy(ogr_feature)
-                    ogr_feature = NULL
+            raise DataLayerError(
+                f"Could not iterate over features: {str(exc)}"
+            ) from None
+
+        finally:
+            if ogr_feature != NULL:
+                OGR_F_Destroy(ogr_feature)
+                ogr_feature = NULL
 
     return feature_count
 


### PR DESCRIPTION
@theroggy small follow-up on https://github.com/geopandas/pyogrio/pull/572#discussion_r2479297778

Moved the try/except to be around the while loop instead of inside it, which should be fine since the while loop is either meant to complete, or to break if one of those exceptions happen (i.e. the while loop never needs to continue when an error happens)