### PR TITLE
CI: force to use latest GDAL in nightly CI

### DIFF
--- a/ci/envs/nightly-deps.yml
+++ b/ci/envs/nightly-deps.yml
@@ -3,7 +3,7 @@ channels:
   - gdal-master
   - conda-forge
 dependencies:
-  - libgdal-core
+  - libgdal-core >= 3.13
   - pandas
   - pip
   - pytest


### PR DESCRIPTION
Attempt to fix the failing CI for the nightly-deps conda build. 
For some reason, since yesterday, it is installing an older nightly GDAL, which did not yet have the changes related to the Shapefile geometry type, and so the updated tests are failing