### PR TITLE
TST: adjust test_write_read_datetime_tz_offsets_None for pandas bug

### DIFF
--- a/pyogrio/tests/test_geopandas_io.py
+++ b/pyogrio/tests/test_geopandas_io.py
@@ -29,6 +29,7 @@ from pyogrio._compat import (
     HAS_PYARROW,
     HAS_PYPROJ,
     PANDAS_GE_15,
+    PANDAS_GE_22,
     PANDAS_GE_23,
     PANDAS_GE_30,
     SHAPELY_GE_21,
@@ -1054,7 +1055,18 @@ def test_write_read_datetime_tz_offsets_None(tmp_path, dates, use_arrow):
     if dates[0].tzinfo is None:
         exp_df.dates = pd.to_datetime(exp_df.dates, utc=False)
         if PANDAS_GE_20:
-            exp_df.dates = exp_df.dates.dt.as_unit("ms")
+            exp_df["dates"] = exp_df.dates.dt.as_unit("ms")
+    else:
+        # pandas < 2.2 returns this as objects, and pandas >= 3.0 raises an error
+        # but apparently in between (with ISO format) it actually incorrectly "works"
+        # by applying the tz also to the naive strings
+        if PANDAS_GE_22 and not PANDAS_GE_30:
+            exp_df.loc[1, "dates"] = exp_df.loc[1, "dates"].replace(
+                tzinfo=timezone(timedelta(hours=1))
+            )
+            exp_df["dates"] = pd.to_datetime(exp_df.dates)
+            if PANDAS_GE_20:
+                exp_df["dates"] = exp_df.dates.dt.as_unit("ms")
 
     if not PANDAS_GE_30:
         exp_df.loc[2, "dates"] = None


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/pyogrio/pull/634, which seems to have uncovered a bug in pandas 2.2.x and 2.3.x. On normal CI we don't run into this as we are testing with lowest pandas version, and not 2.3. But the wheels with Python 3.10 install pandas 3.10 and where failing.


Our code assumes that the following either returns Timestamp objects (pandas 2.x, potentially with warning about it raising in the future) or raises (pandas 3.0):

```
# pandas 2.1
>>> pd.to_datetime(['2023-01-01T11:00:01.111+01:00', '2023-06-01T10:00:01.111', None], format="ISO8601")
FutureWarning: In a future version of pandas, parsing datetimes with mixed time zones will raise an error unless `utc=True`. ...
Index([2023-01-01 11:00:01.111000+01:00, 2023-06-01 10:00:01.111000, NaT], dtype='object')

# pandas 3.0
>>> pd.to_datetime(['2023-01-01T11:00:01.111+01:00', '2023-06-01T10:00:01.111', None], format="ISO8601")
...
ValueError: Mixed timezones detected. Pass utc=True in to_datetime or tz='UTC' in DatetimeIndex to convert to a common timezone.
```

but with pandas 2.2 / 2.3 we get:

```
>>> pd.to_datetime(['2023-01-01T11:00:01.111+01:00', '2023-06-01T10:00:01.111', None], format="ISO8601")
DatetimeIndex(['2023-01-01 11:00:01.111000+01:00',
               '2023-06-01 10:00:01.111000+01:00', 'NaT'],
              dtype='datetime64[ns, UTC+01:00]', freq=None)
```


@theroggy currently just patching up the test, so the wheels builds pass. In theory we might be able to actually have this behave consistently (although it might be a bit costly to detect)